### PR TITLE
feat: add Django-style migrations, JWT auth, and CLI (v0.2.1)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "MD013": false,
+  "MD024": false
+}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,82 @@ and adheres to [SemVer](https://semver.org/) versioning.
 
 ---
 
+## [0.2.1] - 2026-02-01
+
+### Added
+
+- **Django-style Migration System** - Complete migration framework for schema versioning
+  - `MigrationGenerator` - Generates Python migration files from model changes
+  - `MigrationExecutor` - Applies/rolls back migrations to database
+  - `ModelIntrospector` - Extracts schema state from Pydantic models
+  - `SchemaState` with diff algorithm to compute operations between states
+  - Migration operations: `CreateTable`, `DropTable`, `AddField`, `DropField`, `AlterField`, `CreateIndex`, `DropIndex`, `DefineAccess`, `RemoveAccess`, `DataMigration`, `RawSQL`
+
+- **CLI for Schema Management** (`surreal-orm` command, requires `pip install surrealdb-orm[cli]`)
+  - `makemigrations` - Generate migration files from model changes
+  - `migrate` - Apply pending schema migrations
+  - `upgrade` - Apply data migrations (record transformations)
+  - `rollback <target>` - Rollback to a specific migration
+  - `status` - Show migration status
+  - `sqlmigrate <migration>` - Show SQL without executing
+  - `shell` - Interactive SurrealQL shell
+
+- **Table Type Classification** (`TableType` enum)
+  - `NORMAL` - Standard table (default)
+  - `USER` - Authentication table (enforces SCHEMAFULL, generates DEFINE ACCESS)
+  - `STREAM` - Real-time table with CHANGEFEED
+  - `HASH` - Lookup/cache table (defaults to SCHEMALESS)
+
+- **Encrypted Field Type** for password hashing
+  - `Encrypted` - Type alias for encrypted string fields
+  - `EncryptedField(algorithm)` - Factory for custom encryption algorithms
+  - Supported algorithms: `argon2` (default), `bcrypt`, `pbkdf2`, `scrypt`
+  - Auto-generates `crypto::<algorithm>::generate()` in schema
+
+- **JWT Authentication Support** using SurrealDB's `DEFINE ACCESS ... TYPE RECORD`
+  - `AuthenticatedUserMixin` - Mixin providing `signup()`, `signin()`, `authenticate_token()`, `change_password()`
+  - `AccessDefinition` - Dataclass for access configuration
+  - `AccessGenerator` - Generates DEFINE ACCESS from USER models
+  - Configurable token/session durations
+
+- **Extended Model Configuration** (`SurrealConfigDict`)
+  - `table_type` - USER, STREAM, HASH, NORMAL
+  - `schema_mode` - SCHEMAFULL / SCHEMALESS
+  - `changefeed` - Duration string (e.g., "7d")
+  - `permissions` - Row-level security expressions
+  - `identifier_field` - Field for signin (default: "email")
+  - `password_field` - Field for password (default: "password")
+  - `token_duration` / `session_duration` - JWT lifetimes
+
+- **Model Registry** - Auto-registration of models via `__init_subclass__`
+  - `get_registered_models()` - Get all registered model classes
+  - `clear_model_registry()` - Clear for testing
+
+- **New Test Suites**
+  - `test_types.py` - Tests for enums (14 tests)
+  - `test_encrypted_field.py` - Tests for Encrypted type (18 tests)
+  - `test_migrations_operations.py` - Tests for operations (40 tests)
+  - `test_migrations_state.py` - Tests for state/diff (25 tests)
+  - `test_migrations_introspector.py` - Tests for introspection (15 tests)
+  - `test_migrations_generator.py` - Tests for file generation (17 tests)
+  - `test_cli.py` - CLI command tests (21 tests)
+  - `test_auth_unit.py` - Auth unit tests (37 tests)
+  - `test_migrations_integration.py` - Integration tests (requires SurrealDB)
+  - `test_auth_integration.py` - Auth integration tests (requires SurrealDB)
+
+### Changed
+
+- Test coverage improved from ~44% to 56%
+- Added `click>=8.1.0` as optional dependency for CLI
+
+### Fixed
+
+- Mypy type errors in auth mixins and migration modules
+- Ruff linting issues across codebase
+- Dataclass property override issue in `AlterField` operation
+
+---
+
 ## [0.2.0] - 2026-02-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 
 ## Architecture Actuelle (v0.1.5 Alpha)
 
-```
+```text
 src/surreal_orm/
 ├── __init__.py              # Exports publics de l'API
 ├── connection_manager.py    # Singleton de connexion à SurrealDB
@@ -34,12 +34,14 @@ src/surreal_orm/
 **Pattern:** Singleton statique avec classmethods
 
 **Fonctionnement:**
+
 - Connexion lazy (créée au premier `get_client()`)
 - Stocke URL, user, password, namespace, database
 - Utilise `AsyncSurrealDB` du SDK officiel
 - Support context manager async
 
 **Méthodes principales:**
+
 ```python
 set_connection(url, user, password, namespace, database)
 get_client() -> AsyncSurrealDB
@@ -48,6 +50,7 @@ validate_connection() -> bool
 ```
 
 **Limitations actuelles:**
+
 - Une seule connexion globale
 - Pas de pooling
 - Commentaires en français dans le code
@@ -59,11 +62,13 @@ validate_connection() -> bool
 **Pattern:** Héritage Pydantic BaseModel + méthodes CRUD async
 
 **Caractéristiques:**
+
 - Requiert `id: Optional[str]` OU `primary_key` dans `model_config`
 - Exception personnalisée `Model.DoesNotExist`
 - Conversion automatique des RecordID SurrealDB
 
 **Méthodes d'instance:**
+
 ```python
 async save() -> Self           # Insert ou update
 async update() -> Any          # Update tous les champs
@@ -74,6 +79,7 @@ get_id() -> str | RecordID | None
 ```
 
 **Méthodes de classe:**
+
 ```python
 get_table_name() -> str        # Nom de la table (défaut: nom de la classe)
 objects() -> QuerySet          # Retourne le query builder
@@ -89,6 +95,7 @@ from_db(record) -> Self        # Parse la réponse SurrealDB
 **Pattern:** Builder fluent chainable
 
 **Construction de requête:**
+
 ```python
 .select(*fields)              # Colonnes à sélectionner
 .filter(**kwargs)             # WHERE avec lookups (__gt, __contains, etc.)
@@ -99,6 +106,7 @@ from_db(record) -> Self        # Parse la réponse SurrealDB
 ```
 
 **Exécution:**
+
 ```python
 async .exec() -> List[Model]   # Exécute filter
 async .all() -> List[Model]    # Tous les records
@@ -109,6 +117,7 @@ async .delete_table()          # Supprime la table
 ```
 
 **Opérateurs lookup supportés:**
+
 ```python
 exact, gt, gte, lt, lte, in, like, ilike, contains, icontains,
 startswith, istartswith, endswith, iendswith, match, regex, iregex, isnull
@@ -121,13 +130,17 @@ startswith, istartswith, endswith, iendswith, match, regex, iregex, isnull
 ### 4. Nouveaux Fichiers (Non intégrés)
 
 #### `surreal_function.py`
+
 Enums pour les fonctions built-in SurrealDB:
+
 - `SurrealArrayFunction` - opérations sur tableaux
 - `SurrealTimeFunction` - fonctions temporelles
 - `SurrealMathFunction` - fonctions mathématiques (50+)
 
 #### `surreal_ql.py`
+
 Builder SurrealQL bas niveau - incomplet/placeholder:
+
 - Méthodes: `select()`, `related()`, `from_tables()`
 - Pas d'exécution, juste construction de string
 
@@ -136,10 +149,12 @@ Builder SurrealQL bas niveau - incomplet/placeholder:
 ## Dépendances
 
 **Runtime:**
+
 - `pydantic >= 2.10.5`
 - `surrealdb >= 0.4.1` (SDK officiel - limité)
 
 **Dev:**
+
 - pytest, pytest-asyncio, pytest-cov
 - mypy, black, ruff, isort
 - docker (pour tests e2e)
@@ -165,6 +180,7 @@ Builder SurrealQL bas niveau - incomplet/placeholder:
 ### Limitations du SDK Officiel
 
 Le SDK `surrealdb` Python est considéré comme:
+
 - Trop basique
 - API limitée
 - Manque de fonctionnalités avancées
@@ -177,13 +193,14 @@ Le SDK `surrealdb` Python est considéré comme:
 
 Pour le nouveau SDK à développer:
 
-| Protocole | Port Défaut | Usage |
-|-----------|-------------|-------|
-| HTTP/HTTPS | 8000 | REST API, requêtes simples |
-| WebSocket | 8000 | Connexion persistante, temps réel |
-| RPC | 8000 | Appels de procédures |
+| Protocole  | Port Défaut | Usage                             |
+| ---------- | ----------- | --------------------------------- |
+| HTTP/HTTPS | 8000        | REST API, requêtes simples        |
+| WebSocket  | 8000        | Connexion persistante, temps réel |
+| RPC        | 8000        | Appels de procédures              |
 
 **Endpoints principaux:**
+
 - `/sql` - Exécution de requêtes
 - `/rpc` - WebSocket RPC
 - `/signup`, `/signin` - Authentification
@@ -193,7 +210,7 @@ Pour le nouveau SDK à développer:
 
 ## Structure des Tests
 
-```
+```text
 tests/
 ├── test_unit.py      # Tests QuerySet, Model
 ├── test_manager.py   # Tests ConnectionManager
@@ -201,6 +218,7 @@ tests/
 ```
 
 **Exécution:**
+
 ```bash
 uv run pytest                    # Tous les tests
 uv run pytest tests/test_unit.py # Tests unitaires
@@ -212,17 +230,20 @@ tox                              # Tests multi-versions Python
 ## Prochaines Étapes Suggérées
 
 ### Phase 1: Correction des Bugs
+
 - [ ] Fix `refresh()` pour mettre à jour l'instance
 - [ ] Fix ordre ORDER BY dans le SQL généré
 - [ ] Fix typos dans les messages d'erreur
 
 ### Phase 2: Nouveau SDK de Connexion
+
 - [ ] Implémenter connexion WebSocket native
 - [ ] Implémenter connexion HTTP REST
 - [ ] Pool de connexions
 - [ ] Support multi-database
 
 ### Phase 3: Fonctionnalités ORM
+
 - [ ] Relations (graph traversal SurrealDB)
 - [ ] Agrégations
 - [ ] Transactions
@@ -273,7 +294,7 @@ uv build
 
 ### Architecture
 
-```
+```text
 src/surreal_sdk/
 ├── __init__.py              # Factory SurrealDB.http() / .ws() / .pool()
 ├── exceptions.py            # Exceptions personnalisées

--- a/README.md
+++ b/README.md
@@ -5,142 +5,331 @@
 [![codecov](https://codecov.io/gh/EulogySnowfall/SurrealDB-ORM/graph/badge.svg?token=XUONTG2M6Z)](https://codecov.io/gh/EulogySnowfall/SurrealDB-ORM)
 ![GitHub License](https://img.shields.io/github/license/EulogySnowfall/SurrealDB-ORM)
 
-> **⚠️ ALPHA SOFTWARE - NOT READY FOR PRODUCTION**
->
-> This project is in active development and is not yet stable. APIs may change without notice.
-> Use at your own risk in non-production environments only.
+> **Alpha Software** - APIs may change. Use in non-production environments.
 
-🚀 **SurrealDB-ORM** is a lightweight ORM (Object-Relational Mapping) inspired by Django ORM, designed to simplify interactions with **SurrealDB** in Python projects. It provides an intuitive way to manage models, perform queries, and execute CRUD (Create, Read, Update, Delete) operations.
+**SurrealDB-ORM** is a Django-style ORM for [SurrealDB](https://surrealdb.com/) with async support, Pydantic validation, Django-style migrations, and JWT authentication.
 
-**Now includes a custom SDK (`surreal_sdk`)** - No dependency on the official `surrealdb` package!
+**Includes a custom SDK (`surreal_sdk`)** - No dependency on the official `surrealdb` package!
 
 ---
 
-## 📋 Table of Contents
+## Table of Contents
 
-- [Version](#-version)
-- [Description](#-description)
-- [Requirements and tested based](#-requirements-and-tested-based)
-- [Installation](#-installation)
-- [Usage Example](#-usage-example)
-- [Features](#-features)
-- [Contributing](#-contributing)
-- [TODO](#-todo)
-- [License](#-license)
-
----
-
-## ✅ Version
-
-**Alpha 0.2.0**
+- [Version](#version)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Features](#features)
+- [CLI Commands](#cli-commands)
+- [Authentication](#authentication)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [License](#license)
 
 ---
 
-## 📝 Description
+## Version
 
-SurrealDB-ORM offers a clean abstraction for handling SurrealDB through Python models.
-The goal is to simplify writing complex queries while providing an intuitive interface similar to modern ORMs like Django or SQLAlchemy.
-
----
-
-## 📝 Requirements and tested based
-
-- Python : 3.12+
-- Pydantic : 2.10.5+
-- SurrealDB Database Version : 2.1.4+
-- You need to set a SurrealDB to connect to.
+**0.2.1** (Alpha)
 
 ---
 
-## 🛠️ Installation
+## Installation
 
 ```bash
+# Basic installation
 pip install surrealdb-orm
+
+# With CLI support
+pip install surrealdb-orm[cli]
+
+# Full installation (CLI + CBOR)
+pip install surrealdb-orm[all]
 ```
+
+**Requirements:**
+
+- Python 3.12+
+- SurrealDB 2.6.0+
 
 ---
 
-## 🚀 Usage Example
+## Quick Start
 
-Here's a simple example demonstrating how to define a model and interact with SurrealDB:
-
-### 1. Define a Model
+### 1. Define Models
 
 ```python
-from surreal_orm.modelBase import BaseSurrealModel
-from pydantic import BaseModel, Field
-from typing import Optional
-
+from surreal_orm import BaseSurrealModel, SurrealConfigDict
 
 class User(BaseSurrealModel):
-    id: Optional[str] = None
-    name: str = Field(..., max_length=100)
+    id: str | None = None
+    name: str
     email: str
+    age: int = 0
 ```
 
-### 2. Create and Save a User
+### 2. Configure Connection
 
 ```python
-user = User(name="Alice", email="alice@example.com")
+from surreal_orm import SurrealDBConnectionManager
+
+SurrealDBConnectionManager.set_connection(
+    url="http://localhost:8000",
+    user="root",
+    password="root",
+    namespace="myapp",
+    database="main",
+)
+```
+
+### 3. CRUD Operations
+
+```python
+# Create
+user = User(name="Alice", email="alice@example.com", age=30)
 await user.save()
+
+# Read
+users = await User.objects().filter(name="Alice").exec()
+user = await User.objects().get(id="user:123")
+
+# Update
+user.age = 31
+await user.save()
+
+# Delete
+await user.delete()
 ```
 
-### 3. Query Users
+### 4. QuerySet
 
 ```python
-users = await User.objects().filter(name="Alice").exec()
-for user in users:
-    print(user.name, user.email)
+# Filter with lookups
+adults = await User.objects().filter(age__gte=18).exec()
+
+# Chaining
+results = await User.objects() \
+    .filter(age__gte=18) \
+    .order_by("name") \
+    .limit(10) \
+    .exec()
+
+# Supported lookups
+# exact, gt, gte, lt, lte, in, like, ilike, contains, icontains,
+# startswith, istartswith, endswith, iendswith, match, regex, isnull
 ```
 
 ---
 
-## 🌟 Features
+## Features
 
-- 🔧 **Model definition** using Pydantic
-- 📄 **QuerySet** with filter methods like `filter()`, `limit()`, and `order_by()`
-- 🔄 **CRUD** operations (Create, Read, Update, Delete)
-- ⚙️ **Asynchronous connection** to SurrealDB
-- 🔍 **Automatic validation** with Pydantic
-- 📊 **Complex queries** with conditional filters (`age__gte`, `name__in`, etc.)
+### Core ORM
+
+- Model definition with Pydantic validation
+- QuerySet with Django-style lookups (`age__gte`, `name__in`, etc.)
+- Async CRUD operations
+- Automatic ID handling for SurrealDB RecordIDs
+
+### Django-Style Migrations
+
+- Generate migrations from model changes
+- Apply/rollback schema migrations
+- Track migration history in database
+
+```bash
+surreal-orm makemigrations --name initial
+surreal-orm migrate
+surreal-orm status
+```
+
+### Table Types
+
+| Type     | Description                 |
+| -------- | --------------------------- |
+| `NORMAL` | Standard table (default)    |
+| `USER`   | Auth table with JWT support |
+| `STREAM` | Real-time with CHANGEFEED   |
+| `HASH`   | Lookup/cache (SCHEMALESS)   |
+
+```python
+from surreal_orm import BaseSurrealModel, SurrealConfigDict
+from surreal_orm.types import TableType
+
+class User(BaseSurrealModel):
+    model_config = SurrealConfigDict(
+        table_type=TableType.USER,
+        permissions={"select": "$auth.id = id"},
+    )
+    # ...
+```
+
+### Encrypted Fields
+
+```python
+from surreal_orm.fields import Encrypted
+
+class User(BaseSurrealModel):
+    password: Encrypted  # Auto-hashed with argon2
+```
+
+### JWT Authentication
+
+```python
+from surreal_orm.auth import AuthenticatedUserMixin
+
+class User(AuthenticatedUserMixin, BaseSurrealModel):
+    model_config = SurrealConfigDict(table_type=TableType.USER)
+    email: str
+    password: Encrypted
+    name: str
+
+# Signup
+user = await User.signup(email="alice@example.com", password="secret", name="Alice")
+
+# Signin
+user, token = await User.signin(email="alice@example.com", password="secret")
+```
 
 ---
 
-## 🤝 Contributing
+## CLI Commands
 
-Contributions are welcome!  
-If you'd like to improve this project:
+Requires `pip install surrealdb-orm[cli]`
 
-1. Fork the repository.
-2. Create a branch (`git checkout -b feature/new-feature`).
-3. Make your changes and commit them (`git commit -m "Add new feature"`).
-4. Push to your branch (`git push origin feature/new-feature`).
-5. Create a Pull Request.
+| Command             | Description                 |
+| ------------------- | --------------------------- |
+| `makemigrations`    | Generate migration files    |
+| `migrate`           | Apply schema migrations     |
+| `upgrade`           | Apply data migrations       |
+| `rollback <target>` | Rollback to migration       |
+| `status`            | Show migration status       |
+| `sqlmigrate <name>` | Show SQL without executing  |
+| `shell`             | Interactive SurrealQL shell |
+
+```bash
+# Generate and apply migrations
+surreal-orm makemigrations --name initial
+surreal-orm migrate -u http://localhost:8000 -n myns -d mydb
+
+# Check status
+surreal-orm status
+
+# Environment variables supported
+export SURREAL_URL=http://localhost:8000
+export SURREAL_NAMESPACE=myns
+export SURREAL_DATABASE=mydb
+surreal-orm migrate
+```
 
 ---
 
-## 📌 TODO
+## Authentication
 
-- [ ] Implement relationships
-- [ ] Add transaction support
-- [ ] Optimize complex queries
-- [ ] Expand documentation with advanced examples
-- [ ] Better SurrealQL Integration
+SurrealDB-ORM uses SurrealDB's native `DEFINE ACCESS ... TYPE RECORD` for JWT authentication:
+
+```python
+from surreal_orm import BaseSurrealModel, SurrealConfigDict
+from surreal_orm.types import TableType
+from surreal_orm.fields import Encrypted
+from surreal_orm.auth import AuthenticatedUserMixin
+
+class User(AuthenticatedUserMixin, BaseSurrealModel):
+    model_config = SurrealConfigDict(
+        table_type=TableType.USER,
+        identifier_field="email",
+        password_field="password",
+        token_duration="1h",
+        session_duration="24h",
+    )
+
+    id: str | None = None
+    email: str
+    password: Encrypted
+    name: str
+
+# Create user
+user = await User.signup(
+    email="user@example.com",
+    password="secure_password",
+    name="John Doe",
+)
+
+# Authenticate
+user, token = await User.signin(
+    email="user@example.com",
+    password="secure_password",
+)
+
+# Validate token
+user = await User.authenticate_token(token)
+
+# Change password
+await User.change_password(
+    identifier_value="user@example.com",
+    old_password="secure_password",
+    new_password="new_secure_password",
+)
+```
 
 ---
 
-## 📄 License
+## Documentation
 
-This project is licensed under the **MIT License**. See the `LICENSE` file for more information.
+- [Migration System](docs/migrations.md) - Complete migration guide
+- [Authentication](docs/auth.md) - JWT authentication guide
+- [CHANGELOG](CHANGELOG) - Version history
 
 ---
 
-### 📨 Contact
+## Contributing
 
-**Author:** Yannick Croteau  
-**Email:** <croteau.yannick@gmail.com>  
+Contributions are welcome!
+
+1. Fork the repository
+2. Create a branch (`git checkout -b feature/new-feature`)
+3. Make your changes and commit (`git commit -m "Add new feature"`)
+4. Push to your branch (`git push origin feature/new-feature`)
+5. Create a Pull Request
+
+### Development
+
+```bash
+# Clone and install
+git clone https://github.com/EulogySnowfall/SurrealDB-ORM.git
+cd SurrealDB-ORM
+uv sync
+
+# Run tests
+make test              # Unit tests
+make test-integration  # Integration tests (requires SurrealDB)
+
+# Start SurrealDB for testing
+make db-up             # Test instance (port 8001)
+make db-dev            # Dev instance (port 8000)
+
+# Lint
+uv run ruff check src/
+uv run mypy src/
+```
+
+---
+
+## TODO
+
+- [ ] Relations (ForeignKey, ManyToMany, graph traversal)
+- [ ] Aggregations (count, sum, avg, GROUP BY)
+- [ ] Transaction support
+- [ ] Connection pooling improvements
+- [x] ~~Migration system~~
+- [x] ~~JWT Authentication~~
+- [x] ~~CLI commands~~
+
+---
+
+## License
+
+MIT License - See [LICENSE](LICENSE) file.
+
+---
+
+**Author:** Yannick Croteau
 **GitHub:** [EulogySnowfall](https://github.com/EulogySnowfall)
-
----
-
-**SurrealDB-ORM** is a personal package to use with other projects. I will certainly improve it over the next few months, but feel free to open issues or suggest improvements 🚀

--- a/devops/docker-compose.yml
+++ b/devops/docker-compose.yml
@@ -3,6 +3,9 @@
 #   make db-up          # Start test instance
 #   make db-dev         # Start dev instance (persistent)
 #   make db-cluster     # Start multi-node cluster
+#
+# Note: SurrealDB official image is minimal (distroless) and doesn't include
+# curl or shell. Healthcheck is done externally via wait-for-healthy.sh script.
 
 services:
   # =============================================================================
@@ -18,12 +21,6 @@ services:
       - SURREAL_LOG=trace
     volumes:
       - surrealdb_data:/data
-    healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8000/health || exit 1"]
-      interval: 5s
-      timeout: 5s
-      retries: 10
-      start_period: 10s
     restart: unless-stopped
     networks:
       - surrealdb-net
@@ -37,12 +34,6 @@ services:
     ports:
       - "8001:8000"
     command: start --log warn --user root --pass root memory
-    healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8000/health || exit 1"]
-      interval: 2s
-      timeout: 3s
-      retries: 15
-      start_period: 5s
     networks:
       - surrealdb-net
 
@@ -55,12 +46,6 @@ services:
     ports:
       - "8000:8000"
     command: start --log error --user root --pass root memory
-    healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8000/health || exit 1"]
-      interval: 1s
-      timeout: 2s
-      retries: 30
-      start_period: 3s
     networks:
       - surrealdb-net
 
@@ -74,11 +59,6 @@ services:
     ports:
       - "8002:8000"
     command: start --log info --user root --pass root memory
-    healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8000/health || exit 1"]
-      interval: 5s
-      timeout: 5s
-      retries: 10
     profiles:
       - cluster
     networks:
@@ -90,11 +70,6 @@ services:
     ports:
       - "8003:8000"
     command: start --log info --user root --pass root memory
-    healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8000/health || exit 1"]
-      interval: 5s
-      timeout: 5s
-      retries: 10
     profiles:
       - cluster
     networks:
@@ -106,11 +81,6 @@ services:
     ports:
       - "8004:8000"
     command: start --log info --user root --pass root memory
-    healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8000/health || exit 1"]
-      interval: 5s
-      timeout: 5s
-      retries: 10
     profiles:
       - cluster
     networks:

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,524 @@
+# Authentication Documentation
+
+JWT authentication using SurrealDB's native `DEFINE ACCESS ... TYPE RECORD`.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Quick Start](#quick-start)
+- [Encrypted Fields](#encrypted-fields)
+- [User Model Configuration](#user-model-configuration)
+- [Authentication Methods](#authentication-methods)
+- [Access Definition](#access-definition)
+- [Permissions](#permissions)
+- [Full Example](#full-example)
+
+---
+
+## Overview
+
+SurrealDB-ORM provides built-in JWT authentication that leverages SurrealDB's native features:
+
+- **DEFINE ACCESS TYPE RECORD** - Server-side signup/signin logic
+- **crypto::argon2** - Password hashing (also supports bcrypt, pbkdf2, scrypt)
+- **JWT tokens** - Stateless authentication
+- **$auth variable** - Row-level security with authenticated user context
+
+---
+
+## Quick Start
+
+### 1. Define a User Model
+
+```python
+from surreal_orm import BaseSurrealModel, SurrealConfigDict
+from surreal_orm.types import TableType
+from surreal_orm.fields import Encrypted
+from surreal_orm.auth import AuthenticatedUserMixin
+
+class User(AuthenticatedUserMixin, BaseSurrealModel):
+    model_config = SurrealConfigDict(
+        table_type=TableType.USER,
+        identifier_field="email",
+        password_field="password",
+    )
+
+    id: str | None = None
+    email: str
+    password: Encrypted  # Auto-hashed with argon2
+    name: str
+    is_active: bool = True
+```
+
+### 2. Generate and Apply Migration
+
+```bash
+surreal-orm makemigrations --name create_users
+surreal-orm migrate
+```
+
+This generates:
+
+```sql
+DEFINE TABLE User SCHEMAFULL;
+DEFINE FIELD email ON User TYPE string;
+DEFINE FIELD password ON User TYPE string;
+DEFINE FIELD name ON User TYPE string;
+DEFINE FIELD is_active ON User TYPE bool DEFAULT true;
+
+DEFINE ACCESS user_auth ON DATABASE TYPE RECORD
+    SIGNUP (CREATE User SET
+        email = $email,
+        password = crypto::argon2::generate($password),
+        name = $name,
+        is_active = true,
+        created_at = time::now()
+    )
+    SIGNIN (SELECT * FROM User WHERE
+        email = $email AND
+        crypto::argon2::compare(password, $password)
+    )
+    DURATION FOR TOKEN 15m, FOR SESSION 12h;
+```
+
+### 3. Use Authentication
+
+```python
+# Signup (creates user with hashed password)
+user = await User.signup(
+    email="alice@example.com",
+    password="secure_password",
+    name="Alice"
+)
+
+# Signin (returns user and JWT token)
+user, token = await User.signin(
+    email="alice@example.com",
+    password="secure_password"
+)
+
+# Use token for authenticated requests
+print(f"JWT Token: {token}")
+```
+
+---
+
+## Encrypted Fields
+
+The `Encrypted` type marks fields for password hashing:
+
+```python
+from surreal_orm.fields import Encrypted, EncryptedField
+from surreal_orm.types import EncryptionAlgorithm
+
+class User(BaseSurrealModel):
+    # Default: argon2
+    password: Encrypted
+
+    # Custom algorithm
+    api_key: EncryptedField(EncryptionAlgorithm.BCRYPT)
+```
+
+### Supported Algorithms
+
+| Algorithm | Usage                | Security Level |
+| --------- | -------------------- | -------------- |
+| `ARGON2`  | Default, recommended | Highest        |
+| `BCRYPT`  | Legacy compatibility | High           |
+| `PBKDF2`  | Wide compatibility   | Medium-High    |
+| `SCRYPT`  | Memory-hard          | High           |
+
+### Generated SQL
+
+For `password: Encrypted`:
+
+```sql
+DEFINE FIELD password ON User TYPE string
+    VALUE crypto::argon2::generate($value);
+```
+
+---
+
+## User Model Configuration
+
+### Basic Configuration
+
+```python
+class User(AuthenticatedUserMixin, BaseSurrealModel):
+    model_config = SurrealConfigDict(
+        table_type=TableType.USER,  # Required for auth
+    )
+    # ... fields
+```
+
+### Full Configuration
+
+```python
+class User(AuthenticatedUserMixin, BaseSurrealModel):
+    model_config = SurrealConfigDict(
+        table_type=TableType.USER,
+        table_name="app_users",           # Custom table name
+        identifier_field="email",          # Field for signin (default: "email")
+        password_field="password",         # Password field (default: "password")
+        token_duration="30m",              # JWT lifetime (default: "15m")
+        session_duration="24h",            # Session lifetime (default: "12h")
+        encryption_algorithm="argon2",     # Hash algorithm (default: "argon2")
+    )
+
+    id: str | None = None
+    email: str
+    password: Encrypted
+    name: str
+```
+
+### Custom Identifier Field
+
+```python
+class Admin(AuthenticatedUserMixin, BaseSurrealModel):
+    model_config = SurrealConfigDict(
+        table_type=TableType.USER,
+        identifier_field="username",  # Use username instead of email
+    )
+
+    id: str | None = None
+    username: str
+    password: Encrypted
+
+# Signin with username
+admin, token = await Admin.signin(username="admin", password="secret")
+```
+
+---
+
+## Authentication Methods
+
+### signup()
+
+Create a new user with hashed password:
+
+```python
+user = await User.signup(
+    email="user@example.com",
+    password="plain_text_password",  # Will be hashed
+    name="New User",
+)
+
+print(f"Created user: {user.id}")
+```
+
+### signin()
+
+Authenticate and get JWT token:
+
+```python
+user, token = await User.signin(
+    email="user@example.com",
+    password="plain_text_password",
+)
+
+print(f"User: {user.name}")
+print(f"Token: {token}")
+# Token format: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+### authenticate_token()
+
+Validate an existing JWT token:
+
+```python
+# Store token (e.g., in session, cookie, header)
+stored_token = "eyJhbGciOiJIUzI1NiIs..."
+
+# Later, validate token
+user = await User.authenticate_token(stored_token)
+
+if user:
+    print(f"Authenticated as: {user.email}")
+else:
+    print("Invalid or expired token")
+```
+
+### change_password()
+
+Change a user's password (verifies old password first):
+
+```python
+success = await User.change_password(
+    identifier_value="user@example.com",
+    old_password="current_password",
+    new_password="new_secure_password",
+)
+
+if success:
+    print("Password changed successfully")
+```
+
+### get_access_name()
+
+Get the access definition name:
+
+```python
+access_name = User.get_access_name()
+print(access_name)  # "user_auth" or "app_users_auth" if custom table_name
+```
+
+---
+
+## Access Definition
+
+### AccessDefinition Class
+
+For advanced control over the DEFINE ACCESS statement:
+
+```python
+from surreal_orm.auth import AccessDefinition
+
+access = AccessDefinition(
+    name="user_auth",
+    table="User",
+    identifier_field="email",
+    password_field="password",
+    signup_fields={
+        "email": "$email",
+        "password": "crypto::argon2::generate($password)",
+        "name": "$name",
+        "role": "'user'",
+        "created_at": "time::now()",
+    },
+    signin_where="email = $email AND crypto::argon2::compare(password, $password) AND is_active = true",
+    duration_token="30m",
+    duration_session="24h",
+)
+
+# Generate SQL
+sql = access.to_surreal_ql()
+print(sql)
+```
+
+### AccessGenerator
+
+Generate AccessDefinition from model:
+
+```python
+from surreal_orm.auth import AccessGenerator
+
+# From single model
+access = AccessGenerator.from_model(User)
+if access:
+    print(access.to_surreal_ql())
+
+# From all USER models
+definitions = AccessGenerator.generate_all([User, Admin, Customer])
+for definition in definitions:
+    print(definition.name)
+```
+
+---
+
+## Permissions
+
+### Table-Level Permissions
+
+```python
+class Post(BaseSurrealModel):
+    model_config = SurrealConfigDict(
+        permissions={
+            "select": "true",  # Anyone can read
+            "create": "$auth.id IS NOT NONE",  # Authenticated users
+            "update": "$auth.id = author_id",  # Only author
+            "delete": "$auth.id = author_id OR $auth.role = 'admin'",
+        }
+    )
+
+    id: str | None = None
+    title: str
+    content: str
+    author_id: str
+```
+
+Generated SQL:
+
+```sql
+DEFINE TABLE Post SCHEMAFULL
+    PERMISSIONS
+        FOR select WHERE true
+        FOR create WHERE $auth.id IS NOT NONE
+        FOR update WHERE $auth.id = author_id
+        FOR delete WHERE $auth.id = author_id OR $auth.role = 'admin';
+```
+
+### Using $auth Variable
+
+After signin, `$auth` contains the authenticated user:
+
+```sql
+-- In queries (automatic with authenticated connection)
+SELECT * FROM Post WHERE author_id = $auth.id;
+
+-- $auth fields available:
+-- $auth.id - User record ID
+-- $auth.* - All user fields
+```
+
+---
+
+## Full Example
+
+```python
+import asyncio
+from surreal_orm import BaseSurrealModel, SurrealConfigDict, SurrealDBConnectionManager
+from surreal_orm.types import TableType
+from surreal_orm.fields import Encrypted
+from surreal_orm.auth import AuthenticatedUserMixin
+
+
+class User(AuthenticatedUserMixin, BaseSurrealModel):
+    model_config = SurrealConfigDict(
+        table_type=TableType.USER,
+        table_name="users",
+        identifier_field="email",
+        password_field="password",
+        token_duration="1h",
+        session_duration="24h",
+        permissions={
+            "select": "$auth.id = id",  # Users can only see themselves
+            "update": "$auth.id = id",  # Users can only update themselves
+        },
+    )
+
+    id: str | None = None
+    email: str
+    password: Encrypted
+    name: str
+    role: str = "user"
+    is_active: bool = True
+
+
+async def main():
+    # Configure connection
+    SurrealDBConnectionManager.set_connection(
+        url="http://localhost:8000",
+        user="root",
+        password="root",
+        namespace="myapp",
+        database="production",
+    )
+
+    # Note: Run migrations first!
+    # surreal-orm makemigrations --name initial
+    # surreal-orm migrate
+
+    # === SIGNUP ===
+    print("=== Creating new user ===")
+    try:
+        user = await User.signup(
+            email="alice@example.com",
+            password="super_secure_123",
+            name="Alice Smith",
+        )
+        print(f"Created user: {user.name} ({user.email})")
+        print(f"User ID: {user.id}")
+    except Exception as e:
+        print(f"Signup failed: {e}")
+        # User might already exist
+
+    # === SIGNIN ===
+    print("\n=== Signing in ===")
+    try:
+        user, token = await User.signin(
+            email="alice@example.com",
+            password="super_secure_123",
+        )
+        print(f"Signed in as: {user.name}")
+        print(f"JWT Token: {token[:50]}...")
+    except Exception as e:
+        print(f"Signin failed: {e}")
+        return
+
+    # === TOKEN VALIDATION ===
+    print("\n=== Validating token ===")
+    validated_user = await User.authenticate_token(token)
+    if validated_user:
+        print(f"Token valid for: {validated_user.email}")
+    else:
+        print("Token invalid or expired")
+
+    # === CHANGE PASSWORD ===
+    print("\n=== Changing password ===")
+    try:
+        success = await User.change_password(
+            identifier_value="alice@example.com",
+            old_password="super_secure_123",
+            new_password="even_more_secure_456",
+        )
+        if success:
+            print("Password changed successfully")
+
+            # Verify new password works
+            user, new_token = await User.signin(
+                email="alice@example.com",
+                password="even_more_secure_456",
+            )
+            print(f"Signed in with new password: {user.name}")
+    except Exception as e:
+        print(f"Password change failed: {e}")
+
+    # === CLEANUP ===
+    await SurrealDBConnectionManager.close_connection()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+---
+
+## Security Best Practices
+
+1. **Use HTTPS** in production for all API calls
+2. **Store tokens securely** - Use HTTP-only cookies or secure storage
+3. **Set appropriate durations** - Shorter tokens are more secure
+4. **Use argon2** (default) - It's the most secure algorithm
+5. **Add rate limiting** - Protect against brute force attacks
+6. **Validate input** - Use Pydantic validators on email/password fields
+7. **Use permissions** - Always set row-level security with `$auth`
+
+---
+
+## Troubleshooting
+
+### "Namespace and database must be set"
+
+Ensure connection is configured before auth operations:
+
+```python
+SurrealDBConnectionManager.set_connection(
+    namespace="myns",
+    database="mydb",
+    # ...
+)
+```
+
+### "User not found after signup"
+
+The ACCESS definition might not be applied. Run migrations:
+
+```bash
+surreal-orm migrate
+```
+
+### "Invalid credentials"
+
+Check that:
+
+1. Email/identifier is correct
+2. Password is correct (case-sensitive)
+3. User exists and `is_active` is true (if using that check)
+
+### Token expired
+
+Tokens have a limited lifetime. Get a new token via signin:
+
+```python
+user, new_token = await User.signin(email=email, password=password)
+```

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,508 @@
+# Migrations Documentation
+
+Django-style migration system for SurrealDB schema versioning.
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [CLI Commands](#cli-commands)
+- [Table Types](#table-types)
+- [Schema Modes](#schema-modes)
+- [Migration Operations](#migration-operations)
+- [Writing Custom Migrations](#writing-custom-migrations)
+- [Programmatic API](#programmatic-api)
+
+---
+
+## Installation
+
+The CLI requires the `cli` extra:
+
+```bash
+pip install surrealdb-orm[cli]
+```
+
+---
+
+## Quick Start
+
+### 1. Define Your Models
+
+```python
+from surreal_orm import BaseSurrealModel, SurrealConfigDict
+from surreal_orm.types import TableType, SchemaMode
+
+class User(BaseSurrealModel):
+    model_config = SurrealConfigDict(
+        table_name="users",
+        schema_mode=SchemaMode.SCHEMAFULL,
+    )
+
+    id: str | None = None
+    name: str
+    email: str
+    age: int = 0
+```
+
+### 2. Generate Migrations
+
+```bash
+surreal-orm makemigrations --name initial
+```
+
+This creates a migration file in `migrations/0001_initial.py`:
+
+```python
+from surreal_orm.migrations import Migration
+from surreal_orm.migrations.operations import CreateTable, AddField
+
+migration = Migration(
+    name="0001_initial",
+    dependencies=[],
+    operations=[
+        CreateTable(name="users", schema_mode="SCHEMAFULL"),
+        AddField(table="users", name="name", field_type="string"),
+        AddField(table="users", name="email", field_type="string"),
+        AddField(table="users", name="age", field_type="int", default=0),
+    ],
+)
+```
+
+### 3. Apply Migrations
+
+```bash
+surreal-orm migrate --url http://localhost:8000 --namespace myns --database mydb
+```
+
+---
+
+## CLI Commands
+
+### makemigrations
+
+Generate migration files from model changes.
+
+```bash
+# Generate migration with name
+surreal-orm makemigrations --name add_users
+
+# Create empty migration for manual editing
+surreal-orm makemigrations --name custom_changes --empty
+
+# Specify models module
+surreal-orm makemigrations --name initial --models myapp.models
+```
+
+### migrate
+
+Apply pending schema migrations (DDL: DEFINE TABLE, DEFINE FIELD, etc.).
+
+```bash
+# Apply all pending migrations
+surreal-orm migrate --url http://localhost:8000 -n myns -d mydb
+
+# Apply up to specific migration
+surreal-orm migrate --target 0002_add_email
+
+# Mark as applied without executing (fake)
+surreal-orm migrate --fake
+```
+
+### upgrade
+
+Apply data migrations (DML: UPDATE, record transformations).
+
+```bash
+surreal-orm upgrade --url http://localhost:8000 -n myns -d mydb
+```
+
+### rollback
+
+Rollback migrations to a specific point.
+
+```bash
+# Rollback to specific migration (keeps that migration applied)
+surreal-orm rollback 0001_initial
+
+# Rollback all migrations
+surreal-orm rollback ""
+```
+
+### status
+
+Show migration status.
+
+```bash
+surreal-orm status --url http://localhost:8000 -n myns -d mydb
+```
+
+Output:
+
+```text
+Migration status:
+------------------------------------------------------------
+[X] 0001_initial (3 ops) [R-]
+[ ] 0002_add_email (1 ops) [R-]
+------------------------------------------------------------
+Legend: [X]=applied, R=reversible, D=has data migrations
+```
+
+### sqlmigrate
+
+Show SQL for a migration without executing.
+
+```bash
+surreal-orm sqlmigrate 0001_initial
+```
+
+Output:
+
+```sql
+DEFINE TABLE users SCHEMAFULL;
+DEFINE FIELD name ON users TYPE string;
+DEFINE FIELD email ON users TYPE string;
+DEFINE FIELD age ON users TYPE int DEFAULT 0;
+```
+
+### shell
+
+Interactive SurrealQL shell.
+
+```bash
+surreal-orm shell --url http://localhost:8000 -n myns -d mydb
+```
+
+---
+
+## Table Types
+
+Configure table behavior using `TableType`:
+
+```python
+from surreal_orm.types import TableType
+
+class User(BaseSurrealModel):
+    model_config = SurrealConfigDict(table_type=TableType.USER)
+    # ...
+
+class Order(BaseSurrealModel):
+    model_config = SurrealConfigDict(table_type=TableType.STREAM)
+    # ...
+```
+
+| Type     | Description              | Schema Mode         | Use Case                         |
+| -------- | ------------------------ | ------------------- | -------------------------------- |
+| `NORMAL` | Standard table (default) | Configurable        | General data                     |
+| `USER`   | Authentication table     | Enforced SCHEMAFULL | User accounts with signup/signin |
+| `STREAM` | Real-time table          | Configurable        | Live feeds, notifications        |
+| `HASH`   | Lookup/cache table       | Defaults SCHEMALESS | Session data, caching            |
+
+### USER Tables
+
+USER tables automatically:
+
+- Enforce SCHEMAFULL schema mode
+- Generate `DEFINE ACCESS ... TYPE RECORD` for JWT authentication
+- Support `signup()` and `signin()` methods via `AuthenticatedUserMixin`
+
+### STREAM Tables
+
+STREAM tables support CHANGEFEED for real-time updates:
+
+```python
+class Notification(BaseSurrealModel):
+    model_config = SurrealConfigDict(
+        table_type=TableType.STREAM,
+        changefeed="7d",  # Keep changes for 7 days
+    )
+    # ...
+```
+
+Generated SQL:
+
+```sql
+DEFINE TABLE Notification SCHEMAFULL CHANGEFEED 7d;
+```
+
+---
+
+## Schema Modes
+
+```python
+from surreal_orm.types import SchemaMode
+
+class StrictModel(BaseSurrealModel):
+    model_config = SurrealConfigDict(schema_mode=SchemaMode.SCHEMAFULL)
+    # Only defined fields allowed
+
+class FlexibleModel(BaseSurrealModel):
+    model_config = SurrealConfigDict(schema_mode=SchemaMode.SCHEMALESS)
+    # Any fields allowed
+```
+
+---
+
+## Migration Operations
+
+### CreateTable
+
+```python
+CreateTable(
+    name="users",
+    schema_mode="SCHEMAFULL",  # or "SCHEMALESS"
+    table_type="normal",       # normal, user, stream, hash
+    changefeed="7d",           # optional
+)
+```
+
+### DropTable
+
+```python
+DropTable(name="old_table")
+```
+
+### AddField
+
+```python
+AddField(
+    table="users",
+    name="email",
+    field_type="string",
+    default="user@example.com",  # optional
+    assertion="is::email($value)",  # optional validation
+    encrypted=False,  # True for password fields
+)
+```
+
+### DropField
+
+```python
+DropField(table="users", name="old_field")
+```
+
+### AlterField
+
+```python
+AlterField(
+    table="users",
+    name="email",
+    field_type="string",
+    assertion="is::email($value)",
+    # Store previous values for rollback
+    previous_type="string",
+    previous_assertion=None,
+)
+```
+
+### CreateIndex
+
+```python
+CreateIndex(
+    table="users",
+    name="email_unique",
+    fields=["email"],
+    unique=True,
+)
+```
+
+### DropIndex
+
+```python
+DropIndex(table="users", name="old_index")
+```
+
+### DefineAccess
+
+```python
+DefineAccess(
+    name="user_auth",
+    table="User",
+    signup_fields={
+        "email": "$email",
+        "password": "crypto::argon2::generate($password)",
+        "name": "$name",
+    },
+    signin_where="email = $email AND crypto::argon2::compare(password, $password)",
+    duration_token="15m",
+    duration_session="12h",
+)
+```
+
+### RemoveAccess
+
+```python
+RemoveAccess(name="user_auth")
+```
+
+### DataMigration
+
+For record transformations:
+
+```python
+DataMigration(
+    forwards="""
+        UPDATE User SET full_name = string::concat(first_name, ' ', last_name);
+    """,
+    backwards="""
+        UPDATE User SET first_name = string::split(full_name, ' ')[0];
+    """,
+)
+```
+
+### RawSQL
+
+For custom SQL:
+
+```python
+RawSQL(
+    sql="DEFINE EVENT user_created ON User WHEN $event = 'CREATE' THEN ...;",
+    reverse_sql="REMOVE EVENT user_created ON User;",
+)
+```
+
+---
+
+## Writing Custom Migrations
+
+Create an empty migration:
+
+```bash
+surreal-orm makemigrations --name custom_changes --empty
+```
+
+Edit the generated file:
+
+```python
+from surreal_orm.migrations import Migration
+from surreal_orm.migrations.operations import RawSQL, DataMigration
+
+migration = Migration(
+    name="0003_custom_changes",
+    dependencies=["0002_add_email"],
+    operations=[
+        # Add custom index
+        RawSQL(
+            sql="DEFINE INDEX user_email_idx ON User FIELDS email UNIQUE;",
+            reverse_sql="REMOVE INDEX user_email_idx ON User;",
+        ),
+
+        # Migrate data
+        DataMigration(
+            forwards="UPDATE User SET verified = false WHERE verified IS NONE;",
+            backwards=None,  # Irreversible
+        ),
+    ],
+)
+```
+
+---
+
+## Programmatic API
+
+### Generate Migrations Programmatically
+
+```python
+from pathlib import Path
+from surreal_orm.migrations.generator import MigrationGenerator
+from surreal_orm.migrations.operations import CreateTable, AddField
+
+generator = MigrationGenerator(Path("migrations"))
+
+filepath = generator.generate(
+    name="add_products",
+    operations=[
+        CreateTable(name="products", schema_mode="SCHEMAFULL"),
+        AddField(table="products", name="name", field_type="string"),
+        AddField(table="products", name="price", field_type="float"),
+    ],
+    dependencies=["0001_initial"],
+)
+
+print(f"Generated: {filepath}")
+```
+
+### Execute Migrations Programmatically
+
+```python
+from pathlib import Path
+from surreal_orm import SurrealDBConnectionManager
+from surreal_orm.migrations.executor import MigrationExecutor
+
+# Setup connection
+SurrealDBConnectionManager.set_connection(
+    url="http://localhost:8000",
+    user="root",
+    password="root",
+    namespace="myns",
+    database="mydb",
+)
+
+async def run_migrations():
+    executor = MigrationExecutor(Path("migrations"))
+
+    # Apply all pending
+    applied = await executor.migrate()
+    print(f"Applied: {applied}")
+
+    # Check status
+    status = await executor.get_migration_status()
+    for name, info in status.items():
+        print(f"{name}: {'applied' if info['applied'] else 'pending'}")
+
+import asyncio
+asyncio.run(run_migrations())
+```
+
+### Introspect Models
+
+```python
+from surreal_orm.migrations.introspector import introspect_models, ModelIntrospector
+
+# Introspect all registered models
+state = introspect_models()
+
+for table_name, table in state.tables.items():
+    print(f"Table: {table_name}")
+    print(f"  Schema: {table.schema_mode}")
+    print(f"  Type: {table.table_type}")
+    for field_name, field in table.fields.items():
+        print(f"  Field: {field_name} ({field.field_type})")
+```
+
+---
+
+## Environment Variables
+
+The CLI supports environment variables:
+
+| Variable            | Description   |
+| ------------------- | ------------- |
+| `SURREAL_URL`       | SurrealDB URL |
+| `SURREAL_NAMESPACE` | Namespace     |
+| `SURREAL_DATABASE`  | Database      |
+| `SURREAL_USER`      | Username      |
+| `SURREAL_PASSWORD`  | Password      |
+
+Example:
+
+```bash
+export SURREAL_URL=http://localhost:8000
+export SURREAL_NAMESPACE=myns
+export SURREAL_DATABASE=mydb
+export SURREAL_USER=root
+export SURREAL_PASSWORD=root
+
+surreal-orm migrate  # Uses env vars
+```
+
+---
+
+## Best Practices
+
+1. **Always review generated migrations** before applying
+2. **Test migrations** on a staging database first
+3. **Use `--fake`** for manual schema changes already applied
+4. **Keep migrations small** - one logical change per migration
+5. **Use `DataMigration`** for record transformations, not schema changes
+6. **Back up your database** before running migrations in production

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surrealdb-orm"
-version = "0.2.0"
+version = "0.2.1"
 description = "SurrealDB ORM as 'DJango style' for Python with async support. Works with pydantic validation."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -32,6 +32,18 @@ dependencies = [
 cbor = [
     "cbor2>=5.6.0",
 ]
+# CLI support
+cli = [
+    "click>=8.1.0",
+]
+# Full installation with all extras
+all = [
+    "cbor2>=5.6.0",
+    "click>=8.1.0",
+]
+
+[project.scripts]
+surreal-orm = "surreal_orm.cli.commands:main"
 
 [project.urls]
 Homepage = "https://github.com/EulogySnowfall/SurrealDB-ORM"

--- a/src/surreal_orm/__init__.py
+++ b/src/surreal_orm/__init__.py
@@ -1,12 +1,52 @@
-from .model_base import BaseSurrealModel, SurrealConfigDict
+"""
+SurrealDB ORM - A Django-style ORM for SurrealDB.
+
+This package provides:
+- Model definitions with Pydantic validation
+- Query building with fluent interface
+- Migration system with version control
+- JWT authentication support
+- CLI tools for schema management
+"""
+
 from .connection_manager import SurrealDBConnectionManager
-from .query_set import QuerySet
 from .enum import OrderBy
+from .model_base import (
+    BaseSurrealModel,
+    SurrealConfigDict,
+    SurrealDbError,
+    get_registered_models,
+)
+from .query_set import QuerySet
+from .types import (
+    EncryptionAlgorithm,
+    FieldType,
+    SchemaMode,
+    TableType,
+)
+from .fields import Encrypted
+from .auth import AuthenticatedUserMixin
 
 __all__ = [
+    # Connection
     "SurrealDBConnectionManager",
+    # Models
     "BaseSurrealModel",
+    "SurrealConfigDict",
+    "SurrealDbError",
+    "get_registered_models",
+    # Query
     "QuerySet",
     "OrderBy",
-    "SurrealConfigDict",
+    # Types
+    "TableType",
+    "SchemaMode",
+    "FieldType",
+    "EncryptionAlgorithm",
+    # Fields
+    "Encrypted",
+    # Auth
+    "AuthenticatedUserMixin",
 ]
+
+__version__ = "0.2.0"

--- a/src/surreal_orm/auth/__init__.py
+++ b/src/surreal_orm/auth/__init__.py
@@ -1,0 +1,15 @@
+"""
+Authentication module for SurrealDB ORM.
+
+Provides JWT authentication support using SurrealDB's native
+DEFINE ACCESS ... TYPE RECORD feature.
+"""
+
+from .access import AccessDefinition, AccessGenerator
+from .mixins import AuthenticatedUserMixin
+
+__all__ = [
+    "AccessDefinition",
+    "AccessGenerator",
+    "AuthenticatedUserMixin",
+]

--- a/src/surreal_orm/auth/access.py
+++ b/src/surreal_orm/auth/access.py
@@ -1,0 +1,167 @@
+"""
+Access definition generator for SurrealDB authentication.
+
+Generates DEFINE ACCESS ... TYPE RECORD statements for user authentication
+using SurrealDB's built-in JWT support.
+"""
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from ..types import EncryptionAlgorithm, TableType
+
+if TYPE_CHECKING:
+    from ..model_base import BaseSurrealModel
+
+
+@dataclass
+class AccessDefinition:
+    """
+    Configuration for generating DEFINE ACCESS statements.
+
+    This class represents the authentication configuration for a USER table,
+    including signup/signin logic and token durations.
+
+    Attributes:
+        name: Access definition name (e.g., "user_auth")
+        table: Associated table name
+        identifier_field: Field used for signin (e.g., "email")
+        password_field: Field containing password
+        signup_fields: Dict of field -> expression for signup
+        signin_where: WHERE clause for signin validation
+        duration_token: JWT token lifetime (e.g., "15m")
+        duration_session: Session lifetime (e.g., "12h")
+        algorithm: Password hashing algorithm
+    """
+
+    name: str
+    table: str
+    identifier_field: str = "email"
+    password_field: str = "password"
+    signup_fields: dict[str, str] = field(default_factory=dict)
+    signin_where: str | None = None
+    duration_token: str = "15m"
+    duration_session: str = "12h"
+    algorithm: EncryptionAlgorithm = EncryptionAlgorithm.ARGON2
+
+    def __post_init__(self) -> None:
+        """Build default signin_where if not provided."""
+        if not self.signin_where:
+            self.signin_where = (
+                f"{self.identifier_field} = ${self.identifier_field} AND "
+                f"crypto::{self.algorithm}::compare({self.password_field}, ${self.password_field})"
+            )
+
+    def to_surreal_ql(self) -> str:
+        """
+        Generate the DEFINE ACCESS SurrealQL statement.
+
+        Returns:
+            Complete DEFINE ACCESS statement
+        """
+        # Build signup SET clause
+        signup_sets = ", ".join(f"{field_name} = {expr}" for field_name, expr in self.signup_fields.items())
+
+        return f"""DEFINE ACCESS {self.name} ON DATABASE TYPE RECORD
+    SIGNUP (CREATE {self.table} SET {signup_sets})
+    SIGNIN (SELECT * FROM {self.table} WHERE {self.signin_where})
+    DURATION FOR TOKEN {self.duration_token}, FOR SESSION {self.duration_session};"""
+
+    def to_remove_ql(self) -> str:
+        """
+        Generate the REMOVE ACCESS SurrealQL statement.
+
+        Returns:
+            REMOVE ACCESS statement
+        """
+        return f"REMOVE ACCESS {self.name} ON DATABASE;"
+
+
+class AccessGenerator:
+    """
+    Generates AccessDefinition objects from User models.
+
+    This class inspects USER type models and generates the appropriate
+    DEFINE ACCESS configuration for authentication.
+    """
+
+    @staticmethod
+    def from_model(model: type["BaseSurrealModel"]) -> AccessDefinition | None:
+        """
+        Generate AccessDefinition from a model.
+
+        Only generates for USER type tables.
+
+        Args:
+            model: The model class to generate access for
+
+        Returns:
+            AccessDefinition if model is USER type, None otherwise
+        """
+        # Check if this is a USER table
+        table_type = model.get_table_type()
+        if table_type != TableType.USER:
+            return None
+
+        table_name = model.get_table_name()
+        identifier_field = model.get_identifier_field()
+        password_field = model.get_password_field()
+
+        # Get algorithm from config or default
+        config = getattr(model, "model_config", {})
+        algorithm_str = config.get("encryption_algorithm", "argon2")
+        try:
+            algorithm = EncryptionAlgorithm(algorithm_str)
+        except ValueError:
+            algorithm = EncryptionAlgorithm.ARGON2
+
+        # Build signup fields from model fields
+        signup_fields: dict[str, str] = {}
+
+        for field_name in model.model_fields:
+            if field_name == "id":
+                continue
+
+            if field_name == password_field:
+                # Password gets encrypted
+                signup_fields[field_name] = f"crypto::{algorithm}::generate(${field_name})"
+            else:
+                # Regular fields are passed through
+                signup_fields[field_name] = f"${field_name}"
+
+        # Add created_at if not in model
+        if "created_at" not in signup_fields:
+            signup_fields["created_at"] = "time::now()"
+
+        # Get durations from config
+        token_duration = config.get("token_duration", "15m")
+        session_duration = config.get("session_duration", "12h")
+
+        return AccessDefinition(
+            name=f"{table_name.lower()}_auth",
+            table=table_name,
+            identifier_field=identifier_field,
+            password_field=password_field,
+            signup_fields=signup_fields,
+            duration_token=token_duration,
+            duration_session=session_duration,
+            algorithm=algorithm,
+        )
+
+    @staticmethod
+    def generate_all(models: list[type["BaseSurrealModel"]]) -> list[AccessDefinition]:
+        """
+        Generate AccessDefinitions for all USER type models.
+
+        Args:
+            models: List of model classes
+
+        Returns:
+            List of AccessDefinition objects for USER tables
+        """
+        definitions = []
+        for model in models:
+            definition = AccessGenerator.from_model(model)
+            if definition:
+                definitions.append(definition)
+        return definitions

--- a/src/surreal_orm/auth/mixins.py
+++ b/src/surreal_orm/auth/mixins.py
@@ -1,0 +1,302 @@
+"""
+Authentication mixins for SurrealDB ORM models.
+
+Provides signup/signin methods for USER type models using
+SurrealDB's native JWT authentication.
+"""
+
+from typing import TYPE_CHECKING, Any, Self
+
+if TYPE_CHECKING:
+    pass
+
+
+class AuthenticatedUserMixin:
+    """
+    Mixin providing authentication methods for User models.
+
+    Add this mixin to your USER type models to enable signup/signin
+    functionality using SurrealDB's DEFINE ACCESS authentication.
+
+    Example:
+        class User(AuthenticatedUserMixin, BaseSurrealModel):
+            model_config = SurrealConfigDict(
+                table_type=TableType.USER,
+                identifier_field="email",
+                password_field="password",
+            )
+
+            id: str | None = None
+            email: str
+            password: Encrypted
+            name: str
+
+        # Create a new user
+        user = await User.signup(email="test@example.com", password="secret", name="Test")
+
+        # Authenticate existing user
+        user, token = await User.signin(email="test@example.com", password="secret")
+    """
+
+    @classmethod
+    async def signup(
+        cls,
+        **credentials: Any,
+    ) -> Self:
+        """
+        Create a new user via DEFINE ACCESS signup.
+
+        This method uses SurrealDB's native signup functionality, which:
+        1. Validates the credentials against the ACCESS definition
+        2. Creates the user record with encrypted password
+        3. Returns a JWT token (stored internally)
+
+        Args:
+            **credentials: User credentials matching the model fields
+                          (e.g., email, password, name)
+
+        Returns:
+            Created user instance
+
+        Raises:
+            SurrealDbError: If signup fails (e.g., duplicate email)
+
+        Example:
+            user = await User.signup(
+                email="user@example.com",
+                password="secure_password",
+                name="John Doe"
+            )
+        """
+        from ..connection_manager import SurrealDBConnectionManager
+        from ..model_base import SurrealDbError
+
+        client = await SurrealDBConnectionManager.get_client()
+
+        # Get access configuration from model
+        config = getattr(cls, "model_config", {})
+        table_name = config.get("table_name") or cls.__name__
+        access_name = f"{table_name.lower()}_auth"
+
+        # Get connection info
+        namespace = SurrealDBConnectionManager.get_namespace()
+        database = SurrealDBConnectionManager.get_database()
+
+        if not namespace or not database:
+            raise SurrealDbError("Namespace and database must be set for authentication")
+
+        # Perform signup via SDK
+        response = await client.signup(
+            namespace=namespace,
+            database=database,
+            access=access_name,
+            **credentials,
+        )
+
+        if not response.success:
+            raise SurrealDbError(f"Signup failed: {response.raw}")
+
+        # Fetch the created user
+        identifier_field = config.get("identifier_field", "email")
+        identifier_value = credentials.get(identifier_field)
+
+        if not identifier_value:
+            raise SurrealDbError(f"Missing required field: {identifier_field}")
+
+        result = await client.query(
+            f"SELECT * FROM {table_name} WHERE {identifier_field} = $identifier",
+            {"identifier": identifier_value},
+        )
+
+        if result.is_empty:  # type: ignore[attr-defined]
+            raise cls.DoesNotExist("User not found after signup")  # type: ignore[attr-defined]
+
+        return cls.from_db(result.first)  # type: ignore
+
+    @classmethod
+    async def signin(
+        cls,
+        **credentials: Any,
+    ) -> tuple[Self, str]:
+        """
+        Authenticate a user via DEFINE ACCESS signin.
+
+        This method uses SurrealDB's native signin functionality, which:
+        1. Validates credentials against the ACCESS definition
+        2. Compares the password using the configured algorithm
+        3. Returns a JWT token for subsequent authenticated requests
+
+        Args:
+            **credentials: User credentials (identifier and password)
+
+        Returns:
+            Tuple of (user instance, JWT token)
+
+        Raises:
+            SurrealDbError: If signin fails (invalid credentials)
+
+        Example:
+            user, token = await User.signin(
+                email="user@example.com",
+                password="secure_password"
+            )
+            # Use token for authenticated requests
+        """
+        from ..connection_manager import SurrealDBConnectionManager
+        from ..model_base import SurrealDbError
+
+        client = await SurrealDBConnectionManager.get_client()
+
+        # Get access configuration from model
+        config = getattr(cls, "model_config", {})
+        table_name = config.get("table_name") or cls.__name__
+        access_name = f"{table_name.lower()}_auth"
+
+        # Get connection info
+        namespace = SurrealDBConnectionManager.get_namespace()
+        database = SurrealDBConnectionManager.get_database()
+
+        if not namespace or not database:
+            raise SurrealDbError("Namespace and database must be set for authentication")
+
+        # Perform signin via SDK
+        response = await client.signin(
+            namespace=namespace,
+            database=database,
+            access=access_name,
+            **credentials,
+        )
+
+        if not response.success or not response.token:
+            raise SurrealDbError(f"Signin failed: {response.raw}")
+
+        # Fetch user info
+        identifier_field = config.get("identifier_field", "email")
+        identifier_value = credentials.get(identifier_field)
+
+        if not identifier_value:
+            raise SurrealDbError(f"Missing required field: {identifier_field}")
+
+        result = await client.query(
+            f"SELECT * FROM {table_name} WHERE {identifier_field} = $identifier",
+            {"identifier": identifier_value},
+        )
+
+        if result.is_empty:  # type: ignore[attr-defined]
+            raise cls.DoesNotExist("User not found after signin")  # type: ignore[attr-defined]
+
+        user = cls.from_db(result.first)  # type: ignore
+        return user, response.token
+
+    @classmethod
+    async def authenticate_token(
+        cls,
+        token: str,
+    ) -> Self | None:
+        """
+        Authenticate using an existing JWT token.
+
+        Use this method to validate and authenticate a user from
+        a previously obtained JWT token.
+
+        Args:
+            token: JWT token from previous signin
+
+        Returns:
+            User instance if token is valid, None otherwise
+
+        Example:
+            user = await User.authenticate_token(stored_token)
+            if user:
+                print(f"Authenticated as {user.email}")
+        """
+        from ..connection_manager import SurrealDBConnectionManager
+
+        client = await SurrealDBConnectionManager.get_client()
+
+        try:
+            # Authenticate with the token
+            response = await client.authenticate(token)  # type: ignore[attr-defined]
+
+            if not response.success:
+                return None
+
+            # Get current user info using $auth variable
+            config = getattr(cls, "model_config", {})
+            table_name = config.get("table_name") or cls.__name__
+
+            result = await client.query(f"SELECT * FROM {table_name} WHERE id = $auth.id")
+
+            if result.is_empty:  # type: ignore[attr-defined]
+                return None
+
+            return cls.from_db(result.first)  # type: ignore
+
+        except Exception:
+            return None
+
+    @classmethod
+    async def change_password(
+        cls,
+        identifier_value: str,
+        old_password: str,
+        new_password: str,
+    ) -> bool:
+        """
+        Change a user's password.
+
+        Validates the old password before setting the new one.
+
+        Args:
+            identifier_value: Value of the identifier field (e.g., email)
+            old_password: Current password for verification
+            new_password: New password to set
+
+        Returns:
+            True if password was changed successfully
+
+        Raises:
+            SurrealDbError: If old password is incorrect
+        """
+        from ..connection_manager import SurrealDBConnectionManager
+        from ..model_base import SurrealDbError
+
+        # First verify the old password by attempting signin
+        config = getattr(cls, "model_config", {})
+        identifier_field = config.get("identifier_field", "email")
+        password_field = config.get("password_field", "password")
+
+        try:
+            await cls.signin(**{identifier_field: identifier_value, password_field: old_password})  # type: ignore[attr-defined]
+        except SurrealDbError:
+            raise SurrealDbError("Invalid current password") from None
+
+        # Update the password (the access definition will handle encryption)
+        client = await SurrealDBConnectionManager.get_client()
+        table_name = config.get("table_name") or cls.__name__
+
+        # Get encryption algorithm
+        algorithm = config.get("encryption_algorithm", "argon2")
+
+        await client.query(
+            f"""
+            UPDATE {table_name}
+            SET {password_field} = crypto::{algorithm}::generate($new_password)
+            WHERE {identifier_field} = $identifier
+            """,
+            {"identifier": identifier_value, "new_password": new_password},
+        )
+
+        return True
+
+    @classmethod
+    def get_access_name(cls) -> str:
+        """
+        Get the access definition name for this model.
+
+        Returns:
+            Access name (e.g., "user_auth")
+        """
+        config = getattr(cls, "model_config", {})
+        table_name = config.get("table_name") or cls.__name__
+        return f"{table_name.lower()}_auth"

--- a/src/surreal_orm/cli/__init__.py
+++ b/src/surreal_orm/cli/__init__.py
@@ -1,0 +1,15 @@
+"""
+SurrealDB ORM Command Line Interface.
+
+Provides Django-style migration commands:
+- makemigrations: Generate migration files from model changes
+- migrate: Apply schema migrations to the database
+- upgrade: Apply data migrations to transform records
+- rollback: Revert migrations to a specific point
+- status: Show migration status
+- sqlmigrate: Show SQL for a migration without executing
+"""
+
+from .commands import cli
+
+__all__ = ["cli"]

--- a/src/surreal_orm/cli/commands.py
+++ b/src/surreal_orm/cli/commands.py
@@ -1,0 +1,369 @@
+"""
+CLI commands for SurrealDB ORM migrations.
+
+Uses click for command-line argument parsing.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import click
+except ImportError:
+    click = None  # type: ignore
+
+
+def require_click() -> None:
+    """Raise error if click is not installed."""
+    if click is None:
+        print("Error: click is required for CLI. Install with: pip install click")
+        sys.exit(1)
+
+
+def run_async(coro: Any) -> Any:
+    """Run an async coroutine synchronously."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# Only define CLI if click is available
+if click is not None:
+
+    @click.group()
+    @click.option(
+        "--migrations-dir",
+        "-m",
+        default="migrations",
+        help="Migrations directory (default: migrations)",
+    )
+    @click.option(
+        "--url",
+        "-u",
+        envvar="SURREAL_URL",
+        default="http://localhost:8000",
+        help="SurrealDB URL",
+    )
+    @click.option(
+        "--namespace",
+        "-n",
+        envvar="SURREAL_NAMESPACE",
+        help="SurrealDB namespace",
+    )
+    @click.option(
+        "--database",
+        "-d",
+        envvar="SURREAL_DATABASE",
+        help="SurrealDB database",
+    )
+    @click.option(
+        "--user",
+        envvar="SURREAL_USER",
+        default="root",
+        help="SurrealDB user",
+    )
+    @click.option(
+        "--password",
+        envvar="SURREAL_PASSWORD",
+        default="root",
+        help="SurrealDB password",
+    )
+    @click.pass_context
+    def cli(
+        ctx: click.Context,
+        migrations_dir: str,
+        url: str,
+        namespace: str | None,
+        database: str | None,
+        user: str,
+        password: str,
+    ) -> None:
+        """SurrealDB ORM migration management tool."""
+        ctx.ensure_object(dict)
+        ctx.obj["migrations_dir"] = Path(migrations_dir)
+        ctx.obj["url"] = url
+        ctx.obj["namespace"] = namespace
+        ctx.obj["database"] = database
+        ctx.obj["user"] = user
+        ctx.obj["password"] = password
+
+    @cli.command()
+    @click.option("--name", "-n", required=True, help="Migration name")
+    @click.option("--empty", is_flag=True, help="Create empty migration for manual editing")
+    @click.option("--models", "-m", multiple=True, help="Specific model modules to include")
+    @click.pass_context
+    def makemigrations(
+        ctx: click.Context,
+        name: str,
+        empty: bool,
+        models: tuple[str, ...],
+    ) -> None:
+        """Generate migration files from model changes."""
+        from ..migrations.generator import MigrationGenerator, generate_empty_migration
+        from ..migrations.introspector import introspect_models
+        from ..migrations.state import SchemaState
+
+        migrations_dir = ctx.obj["migrations_dir"]
+
+        if empty:
+            # Create empty migration
+            filepath = generate_empty_migration(migrations_dir, name)
+            click.echo(f"Created empty migration: {filepath}")
+            return
+
+        # Import models if specified
+        if models:
+            for module_path in models:
+                try:
+                    __import__(module_path)
+                except ImportError as e:
+                    click.echo(f"Error importing {module_path}: {e}", err=True)
+                    sys.exit(1)
+
+        # Introspect models to get desired state
+        desired_state = introspect_models()
+
+        if not desired_state.tables:
+            click.echo("No models found. Register models by importing them.")
+            sys.exit(1)
+
+        # For now, assume current state is empty (first migration)
+        # In a full implementation, we'd load current state from database
+        current_state = SchemaState()
+
+        # Compute differences
+        operations = current_state.diff(desired_state)
+
+        if not operations:
+            click.echo("No changes detected.")
+            return
+
+        # Generate migration file
+        generator = MigrationGenerator(migrations_dir)
+        filepath = generator.generate(name=name, operations=operations)
+
+        click.echo(f"Created migration: {filepath}")
+        click.echo(f"Operations: {len(operations)}")
+        for op in operations:
+            click.echo(f"  - {op.describe()}")
+
+    @cli.command()
+    @click.option("--target", "-t", help="Target migration name")
+    @click.option("--fake", is_flag=True, help="Mark as applied without executing")
+    @click.pass_context
+    def migrate(ctx: click.Context, target: str | None, fake: bool) -> None:
+        """Apply pending schema migrations."""
+        from ..connection_manager import SurrealDBConnectionManager
+        from ..migrations.executor import MigrationExecutor
+
+        async def run() -> list[str]:
+            # Setup connection
+            SurrealDBConnectionManager.set_connection(
+                url=ctx.obj["url"],
+                user=ctx.obj["user"],
+                password=ctx.obj["password"],
+                namespace=ctx.obj["namespace"],
+                database=ctx.obj["database"],
+            )
+
+            executor = MigrationExecutor(ctx.obj["migrations_dir"])
+            return await executor.migrate(target=target, fake=fake, schema_only=True)
+
+        try:
+            applied = run_async(run())
+            if applied:
+                click.echo(f"Applied {len(applied)} migration(s):")
+                for name in applied:
+                    click.echo(f"  - {name}")
+            else:
+                click.echo("No migrations to apply.")
+        except Exception as e:
+            click.echo(f"Migration failed: {e}", err=True)
+            sys.exit(1)
+
+    @cli.command()
+    @click.option("--target", "-t", help="Target migration name")
+    @click.pass_context
+    def upgrade(ctx: click.Context, target: str | None) -> None:
+        """Apply data migrations to transform records."""
+        from ..connection_manager import SurrealDBConnectionManager
+        from ..migrations.executor import MigrationExecutor
+
+        async def run() -> list[str]:
+            SurrealDBConnectionManager.set_connection(
+                url=ctx.obj["url"],
+                user=ctx.obj["user"],
+                password=ctx.obj["password"],
+                namespace=ctx.obj["namespace"],
+                database=ctx.obj["database"],
+            )
+
+            executor = MigrationExecutor(ctx.obj["migrations_dir"])
+            return await executor.upgrade(target=target)
+
+        try:
+            applied = run_async(run())
+            if applied:
+                click.echo(f"Applied data migrations for {len(applied)} migration(s):")
+                for name in applied:
+                    click.echo(f"  - {name}")
+            else:
+                click.echo("No data migrations to apply.")
+        except Exception as e:
+            click.echo(f"Upgrade failed: {e}", err=True)
+            sys.exit(1)
+
+    @cli.command()
+    @click.argument("target")
+    @click.pass_context
+    def rollback(ctx: click.Context, target: str) -> None:
+        """Rollback migrations to TARGET."""
+        from ..connection_manager import SurrealDBConnectionManager
+        from ..migrations.executor import MigrationExecutor
+
+        async def run() -> list[str]:
+            SurrealDBConnectionManager.set_connection(
+                url=ctx.obj["url"],
+                user=ctx.obj["user"],
+                password=ctx.obj["password"],
+                namespace=ctx.obj["namespace"],
+                database=ctx.obj["database"],
+            )
+
+            executor = MigrationExecutor(ctx.obj["migrations_dir"])
+            return await executor.rollback(target=target)
+
+        try:
+            rolled_back = run_async(run())
+            if rolled_back:
+                click.echo(f"Rolled back {len(rolled_back)} migration(s):")
+                for name in rolled_back:
+                    click.echo(f"  - {name}")
+            else:
+                click.echo("No migrations to rollback.")
+        except Exception as e:
+            click.echo(f"Rollback failed: {e}", err=True)
+            sys.exit(1)
+
+    @cli.command()
+    @click.pass_context
+    def status(ctx: click.Context) -> None:
+        """Show migration status."""
+        from ..connection_manager import SurrealDBConnectionManager
+        from ..migrations.executor import MigrationExecutor
+
+        async def run() -> dict[str, dict[str, Any]]:
+            SurrealDBConnectionManager.set_connection(
+                url=ctx.obj["url"],
+                user=ctx.obj["user"],
+                password=ctx.obj["password"],
+                namespace=ctx.obj["namespace"],
+                database=ctx.obj["database"],
+            )
+
+            executor = MigrationExecutor(ctx.obj["migrations_dir"])
+            return await executor.get_migration_status()
+
+        try:
+            status_info = run_async(run())
+
+            if not status_info:
+                click.echo("No migrations found.")
+                return
+
+            click.echo("Migration status:")
+            click.echo("-" * 60)
+
+            for name, info in status_info.items():
+                status_char = "[X]" if info["applied"] else "[ ]"
+                reversible = "R" if info["reversible"] else "-"
+                has_data = "D" if info["has_data"] else "-"
+                ops = info["operations"]
+                click.echo(f"{status_char} {name} ({ops} ops) [{reversible}{has_data}]")
+
+            click.echo("-" * 60)
+            click.echo("Legend: [X]=applied, R=reversible, D=has data migrations")
+        except Exception as e:
+            click.echo(f"Status failed: {e}", err=True)
+            sys.exit(1)
+
+    @cli.command()
+    @click.argument("migration")
+    @click.pass_context
+    def sqlmigrate(ctx: click.Context, migration: str) -> None:
+        """Show SQL for MIGRATION without executing."""
+        from ..migrations.executor import MigrationExecutor
+
+        executor = MigrationExecutor(ctx.obj["migrations_dir"])
+
+        async def run() -> str:
+            return await executor.show_sql(migration)
+
+        try:
+            sql = run_async(run())
+            click.echo(sql)
+        except FileNotFoundError:
+            click.echo(f"Migration not found: {migration}", err=True)
+            sys.exit(1)
+        except Exception as e:
+            click.echo(f"Error: {e}", err=True)
+            sys.exit(1)
+
+    @cli.command()
+    @click.pass_context
+    def shell(ctx: click.Context) -> None:
+        """Start an interactive SurrealDB shell."""
+        from ..connection_manager import SurrealDBConnectionManager
+
+        async def setup() -> None:
+            SurrealDBConnectionManager.set_connection(
+                url=ctx.obj["url"],
+                user=ctx.obj["user"],
+                password=ctx.obj["password"],
+                namespace=ctx.obj["namespace"],
+                database=ctx.obj["database"],
+            )
+            client = await SurrealDBConnectionManager.get_client()
+            click.echo(f"Connected to {ctx.obj['url']}")
+            click.echo(f"Namespace: {ctx.obj['namespace']}, Database: {ctx.obj['database']}")
+            click.echo("Type 'exit' or 'quit' to exit. Enter SurrealQL queries:")
+            click.echo("-" * 60)
+
+            while True:
+                try:
+                    query = click.prompt("surreal", prompt_suffix="> ")
+                    if query.lower() in ("exit", "quit"):
+                        break
+                    if not query.strip():
+                        continue
+
+                    result = await client.query(query)
+                    if result.is_empty:  # type: ignore[attr-defined]
+                        click.echo("(empty result)")
+                    else:
+                        for record in result.all_records:  # type: ignore[attr-defined]
+                            click.echo(record)
+                except KeyboardInterrupt:
+                    break
+                except Exception as e:
+                    click.echo(f"Error: {e}")
+
+            click.echo("Goodbye!")
+
+        run_async(setup())
+
+else:
+    # Placeholder CLI if click is not installed
+    def cli() -> None:  # type: ignore
+        """CLI placeholder when click is not installed."""
+        require_click()
+
+
+def main() -> None:
+    """Entry point for the CLI."""
+    require_click()
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/surreal_orm/fields/__init__.py
+++ b/src/surreal_orm/fields/__init__.py
@@ -1,0 +1,10 @@
+"""
+Custom field types for SurrealDB ORM.
+
+This module provides specialized field types that leverage SurrealDB's
+built-in functions for encryption, validation, and other operations.
+"""
+
+from .encrypted import Encrypted, EncryptedField, EncryptedFieldInfo
+
+__all__ = ["Encrypted", "EncryptedField", "EncryptedFieldInfo"]

--- a/src/surreal_orm/fields/encrypted.py
+++ b/src/surreal_orm/fields/encrypted.py
@@ -1,0 +1,166 @@
+"""
+Encrypted field type for password and sensitive data storage.
+
+This module provides the Encrypted[T] type that automatically generates
+the appropriate SurrealDB crypto functions in schema definitions.
+"""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Annotated, Any, get_args, get_origin
+
+from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import CoreSchema, core_schema
+
+from ..types import EncryptionAlgorithm
+
+if TYPE_CHECKING:
+    pass
+
+
+@dataclass
+class EncryptedFieldInfo:
+    """
+    Metadata for encrypted fields used during schema generation.
+
+    Attributes:
+        algorithm: The encryption algorithm to use (default: argon2)
+        compare_function: SurrealDB function for password comparison
+        generate_function: SurrealDB function for password generation
+    """
+
+    algorithm: EncryptionAlgorithm = EncryptionAlgorithm.ARGON2
+
+    @property
+    def compare_function(self) -> str:
+        """Get the SurrealDB compare function for this algorithm."""
+        return f"crypto::{self.algorithm}::compare"
+
+    @property
+    def generate_function(self) -> str:
+        """Get the SurrealDB generate function for this algorithm."""
+        return f"crypto::{self.algorithm}::generate"
+
+
+class _EncryptedMarker:
+    """
+    Marker class for encrypted fields.
+
+    This is used internally to mark fields as encrypted in Pydantic's
+    type annotation system.
+    """
+
+    algorithm: EncryptionAlgorithm
+
+    def __init__(self, algorithm: EncryptionAlgorithm = EncryptionAlgorithm.ARGON2):
+        self.algorithm = algorithm
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        source_type: Any,
+        handler: GetCoreSchemaHandler,
+    ) -> CoreSchema:
+        """Build the Pydantic core schema for validation."""
+        # Get algorithm from marker if available
+        algorithm = EncryptionAlgorithm.ARGON2
+        args = get_args(source_type)
+        for arg in args:
+            if isinstance(arg, _EncryptedMarker):
+                algorithm = arg.algorithm
+                break
+
+        return core_schema.str_schema(
+            metadata={
+                "encrypted": True,
+                "algorithm": str(algorithm),
+                "surreal_type": "string",
+                "generate_function": f"crypto::{algorithm}::generate",
+                "compare_function": f"crypto::{algorithm}::compare",
+            }
+        )
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        core_schema_obj: CoreSchema,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        """Generate JSON schema for OpenAPI documentation."""
+        return {"type": "string", "format": "password"}
+
+
+# Type alias for Encrypted[str] using Annotated
+Encrypted = Annotated[str, _EncryptedMarker()]
+
+
+def EncryptedField(
+    algorithm: EncryptionAlgorithm = EncryptionAlgorithm.ARGON2,
+) -> Any:
+    """
+    Create an encrypted field type with a specific algorithm.
+
+    Usage:
+        class User(BaseSurrealModel):
+            password: EncryptedField(EncryptionAlgorithm.BCRYPT)
+
+    Args:
+        algorithm: The encryption algorithm to use
+
+    Returns:
+        Annotated type with encryption marker
+    """
+    return Annotated[str, _EncryptedMarker(algorithm)]
+
+
+def is_encrypted_field(field_type: Any) -> bool:
+    """
+    Check if a field type is an Encrypted type.
+
+    Args:
+        field_type: The type annotation to check
+
+    Returns:
+        True if the field is an Encrypted type
+    """
+    # Check for Annotated type with _EncryptedMarker
+    origin = get_origin(field_type)
+
+    if origin is Annotated:
+        args = get_args(field_type)
+        for arg in args:
+            if isinstance(arg, _EncryptedMarker):
+                return True
+
+    # Also check for _EncryptedMarker class directly
+    if isinstance(field_type, type) and issubclass(field_type, _EncryptedMarker):
+        return True
+
+    return False
+
+
+def get_encryption_info(field_type: Any) -> EncryptedFieldInfo | None:
+    """
+    Extract encryption information from a field type.
+
+    Args:
+        field_type: The type annotation to extract from
+
+    Returns:
+        EncryptedFieldInfo if the field is encrypted, None otherwise
+    """
+    if not is_encrypted_field(field_type):
+        return None
+
+    # Get algorithm from Annotated args
+    algorithm = EncryptionAlgorithm.ARGON2
+    origin = get_origin(field_type)
+
+    if origin is Annotated:
+        args = get_args(field_type)
+        for arg in args:
+            if isinstance(arg, _EncryptedMarker):
+                algorithm = arg.algorithm
+                break
+
+    return EncryptedFieldInfo(algorithm=algorithm)

--- a/src/surreal_orm/migrations/__init__.py
+++ b/src/surreal_orm/migrations/__init__.py
@@ -1,0 +1,51 @@
+"""
+SurrealDB ORM Migration System.
+
+This module provides Django-style migrations for SurrealDB, including:
+- Schema versioning with migration files
+- Auto-detection of model changes
+- Forward and backward migrations
+- Data migrations for record transformations
+
+Usage:
+    # Generate migrations from model changes
+    await manager.makemigrations(name="initial")
+
+    # Apply pending migrations
+    await manager.migrate()
+
+    # Rollback to a specific migration
+    await manager.rollback("0001_initial")
+"""
+
+from .migration import Migration
+from .operations import (
+    AddField,
+    AlterField,
+    CreateIndex,
+    CreateTable,
+    DataMigration,
+    DefineAccess,
+    DropField,
+    DropIndex,
+    DropTable,
+    Operation,
+    RawSQL,
+    RemoveAccess,
+)
+
+__all__ = [
+    "Migration",
+    "Operation",
+    "CreateTable",
+    "DropTable",
+    "AddField",
+    "DropField",
+    "AlterField",
+    "CreateIndex",
+    "DropIndex",
+    "DefineAccess",
+    "RemoveAccess",
+    "DataMigration",
+    "RawSQL",
+]

--- a/src/surreal_orm/migrations/executor.py
+++ b/src/surreal_orm/migrations/executor.py
@@ -1,0 +1,380 @@
+"""
+Migration executor for applying migrations to the database.
+
+This module handles:
+- Tracking applied migrations in the database
+- Applying pending migrations
+- Rolling back migrations
+- Executing data migrations (upgrade command)
+"""
+
+import importlib.util
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ..connection_manager import SurrealDBConnectionManager
+from .migration import Migration, parse_migration_name
+from .operations import DataMigration
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# Table name for tracking migrations
+MIGRATIONS_TABLE = "_surreal_orm_migrations"
+
+
+class MigrationExecutor:
+    """
+    Executes migrations against the database.
+
+    Handles applying, rolling back, and tracking migrations.
+    """
+
+    def __init__(self, migrations_dir: Path | str):
+        """
+        Initialize the executor.
+
+        Args:
+            migrations_dir: Path to the migrations directory
+        """
+        self.migrations_dir = Path(migrations_dir)
+
+    async def ensure_migrations_table(self) -> None:
+        """Create the migrations tracking table if it doesn't exist."""
+        client = await SurrealDBConnectionManager.get_client()
+
+        await client.query(f"""
+            DEFINE TABLE IF NOT EXISTS {MIGRATIONS_TABLE} SCHEMAFULL;
+            DEFINE FIELD name ON {MIGRATIONS_TABLE} TYPE string;
+            DEFINE FIELD applied_at ON {MIGRATIONS_TABLE} TYPE datetime DEFAULT time::now();
+            DEFINE INDEX migration_name ON {MIGRATIONS_TABLE} FIELDS name UNIQUE;
+        """)
+
+    async def get_applied_migrations(self) -> list[str]:
+        """
+        Get list of already applied migration names.
+
+        Returns:
+            List of migration names that have been applied
+        """
+        await self.ensure_migrations_table()
+
+        client = await SurrealDBConnectionManager.get_client()
+        result = await client.query(f"SELECT name, applied_at FROM {MIGRATIONS_TABLE} ORDER BY applied_at;")
+
+        if result.is_empty:  # type: ignore[attr-defined]
+            return []
+
+        return [r["name"] for r in result.all_records]  # type: ignore[attr-defined]
+
+    def get_available_migrations(self) -> list[str]:
+        """
+        Get list of all migration files in the migrations directory.
+
+        Returns:
+            List of migration names sorted by number
+        """
+        if not self.migrations_dir.exists():
+            return []
+
+        migrations = []
+        for filepath in self.migrations_dir.glob("*.py"):
+            name = filepath.stem
+            if name.startswith("_"):
+                continue
+            try:
+                parse_migration_name(name)
+                migrations.append(name)
+            except ValueError:
+                continue
+
+        return sorted(migrations)
+
+    def get_pending_migrations(self, applied: list[str]) -> list[str]:
+        """
+        Get list of migrations that haven't been applied yet.
+
+        Args:
+            applied: List of already applied migration names
+
+        Returns:
+            List of pending migration names
+        """
+        available = self.get_available_migrations()
+        return [m for m in available if m not in applied]
+
+    def load_migration(self, name: str) -> Migration:
+        """
+        Load a migration from file.
+
+        Args:
+            name: Migration name (e.g., "0001_initial")
+
+        Returns:
+            Migration object
+
+        Raises:
+            FileNotFoundError: If migration file doesn't exist
+            ImportError: If migration file is invalid
+        """
+        filepath = self.migrations_dir / f"{name}.py"
+
+        if not filepath.exists():
+            raise FileNotFoundError(f"Migration file not found: {filepath}")
+
+        spec = importlib.util.spec_from_file_location(name, filepath)
+        if not spec or not spec.loader:
+            raise ImportError(f"Could not load migration: {name}")
+
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        migration = getattr(module, "migration", None)
+        # Check by class name to handle different import paths (src.surreal_orm vs surreal_orm)
+        if migration is None or type(migration).__name__ != "Migration":
+            raise ImportError(f"Migration file must define 'migration' variable: {name}")
+
+        return migration  # type: ignore[return-value, no-any-return]
+
+    def _sort_by_dependencies(self, migrations: list[Migration]) -> list[Migration]:
+        """
+        Topologically sort migrations by dependencies.
+
+        Args:
+            migrations: List of migrations to sort
+
+        Returns:
+            Sorted list of migrations
+        """
+        sorted_migrations: list[Migration] = []
+        remaining = migrations.copy()
+        seen: set[str] = set()
+        max_iterations = len(migrations) * 2
+
+        iteration = 0
+        while remaining and iteration < max_iterations:
+            iteration += 1
+            for m in remaining:
+                if all(dep in seen for dep in m.dependencies):
+                    sorted_migrations.append(m)
+                    seen.add(m.name)
+                    remaining.remove(m)
+                    break
+
+        if remaining:
+            raise ValueError(f"Circular dependency detected in migrations: {[m.name for m in remaining]}")
+
+        return sorted_migrations
+
+    async def migrate(
+        self,
+        target: str | None = None,
+        fake: bool = False,
+        schema_only: bool = True,
+    ) -> list[str]:
+        """
+        Apply pending migrations.
+
+        Args:
+            target: Optional target migration name. If None, apply all pending.
+            fake: If True, mark as applied without executing.
+            schema_only: If True, only apply schema operations (DDL).
+                        If False, also apply data migrations (DML).
+
+        Returns:
+            List of applied migration names
+        """
+        await self.ensure_migrations_table()
+
+        applied = await self.get_applied_migrations()
+        pending_names = self.get_pending_migrations(applied)
+
+        if target:
+            # Filter to migrations up to and including target
+            pending_names = [n for n in pending_names if n <= target]
+
+        if not pending_names:
+            logger.info("No migrations to apply.")
+            return []
+
+        # Load and sort migrations
+        pending_migrations = [self.load_migration(name) for name in pending_names]
+        sorted_migrations = self._sort_by_dependencies(pending_migrations)
+
+        client = await SurrealDBConnectionManager.get_client()
+        applied_names: list[str] = []
+
+        for migration in sorted_migrations:
+            logger.info(f"Applying migration: {migration.name}")
+
+            if not fake:
+                # Get operations to execute
+                if schema_only:
+                    operations = migration.schema_operations
+                else:
+                    operations = migration.operations
+
+                # Execute each operation
+                for op in operations:
+                    sql = op.forwards()
+                    if sql:
+                        logger.debug(f"Executing: {sql[:100]}...")
+                        try:
+                            await client.query(sql)
+                        except Exception as e:
+                            logger.error(f"Migration failed at {op.describe()}: {e}")
+                            raise
+
+                    # Handle async data migrations
+                    if isinstance(op, DataMigration) and op.forwards_func:
+                        await op.forwards_func()
+
+            # Record migration as applied
+            await client.query(
+                f"CREATE {MIGRATIONS_TABLE} SET name = $name;",
+                {"name": migration.name},
+            )
+
+            applied_names.append(migration.name)
+            logger.info(f"Applied: {migration.name}")
+
+        return applied_names
+
+    async def rollback(self, target: str) -> list[str]:
+        """
+        Rollback migrations to target.
+
+        Args:
+            target: Target migration name to rollback to.
+                    Migrations after this will be rolled back.
+
+        Returns:
+            List of rolled back migration names
+        """
+        await self.ensure_migrations_table()
+
+        applied = await self.get_applied_migrations()
+
+        # Get migrations to rollback (in reverse order)
+        to_rollback = [name for name in reversed(applied) if name > target]
+
+        if not to_rollback:
+            logger.info("No migrations to rollback.")
+            return []
+
+        client = await SurrealDBConnectionManager.get_client()
+        rolled_back: list[str] = []
+
+        for name in to_rollback:
+            migration = self.load_migration(name)
+
+            if not migration.is_reversible:
+                raise ValueError(f"Migration {name} is not reversible")
+
+            logger.info(f"Rolling back: {name}")
+
+            # Execute backwards SQL
+            for sql in migration.backwards_sql():
+                if sql:
+                    logger.debug(f"Executing: {sql[:100]}...")
+                    await client.query(sql)
+
+            # Handle async data migrations backwards
+            for op in reversed(migration.operations):
+                if isinstance(op, DataMigration) and op.backwards_func:
+                    await op.backwards_func()
+
+            # Remove migration record
+            await client.query(
+                f"DELETE {MIGRATIONS_TABLE} WHERE name = $name;",
+                {"name": name},
+            )
+
+            rolled_back.append(name)
+            logger.info(f"Rolled back: {name}")
+
+        return rolled_back
+
+    async def upgrade(self, target: str | None = None) -> list[str]:
+        """
+        Apply data migrations only.
+
+        This is separate from schema migrations to allow running
+        data transformations independently.
+
+        Args:
+            target: Optional target migration name
+
+        Returns:
+            List of migrations whose data operations were applied
+        """
+        await self.ensure_migrations_table()
+
+        applied = await self.get_applied_migrations()
+        applied_names: list[str] = []
+
+        client = await SurrealDBConnectionManager.get_client()
+
+        for name in applied:
+            if target and name > target:
+                break
+
+            migration = self.load_migration(name)
+
+            if not migration.has_data_migrations:
+                continue
+
+            logger.info(f"Running data migrations for: {name}")
+
+            for op in migration.data_operations:
+                sql = op.forwards()
+                if sql:
+                    logger.debug(f"Executing: {sql[:100]}...")
+                    await client.query(sql)
+
+                if isinstance(op, DataMigration) and op.forwards_func:
+                    await op.forwards_func()
+
+            applied_names.append(name)
+
+        return applied_names
+
+    async def get_migration_status(self) -> dict[str, dict[str, bool | int]]:
+        """
+        Get status of all migrations.
+
+        Returns:
+            Dict mapping migration name to status info
+        """
+        applied = await self.get_applied_migrations()
+        available = self.get_available_migrations()
+
+        status = {}
+        for name in available:
+            is_applied = name in applied
+            migration = self.load_migration(name)
+            status[name] = {
+                "applied": is_applied,
+                "reversible": migration.is_reversible,
+                "has_data": migration.has_data_migrations,
+                "operations": len(migration.operations),
+            }
+
+        return status
+
+    async def show_sql(self, name: str) -> str:
+        """
+        Show the SQL that would be executed for a migration.
+
+        Args:
+            name: Migration name
+
+        Returns:
+            SQL statements as a string
+        """
+        migration = self.load_migration(name)
+        statements = migration.forwards_sql()
+        return "\n\n".join(statements)

--- a/src/surreal_orm/migrations/generator.py
+++ b/src/surreal_orm/migrations/generator.py
@@ -1,0 +1,272 @@
+"""
+Migration file generator.
+
+This module generates Python migration files from a list of operations.
+The generated files follow Django's migration format and can be edited
+before being applied.
+"""
+
+from dataclasses import MISSING
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .migration import generate_migration_name
+
+if TYPE_CHECKING:
+    from .operations import Operation
+
+
+class MigrationGenerator:
+    """
+    Generates Python migration files from operations.
+
+    The generated files can be reviewed and edited before being applied
+    to the database.
+    """
+
+    def __init__(self, migrations_dir: Path | str):
+        """
+        Initialize the generator with a migrations directory.
+
+        Args:
+            migrations_dir: Path to the migrations directory
+        """
+        self.migrations_dir = Path(migrations_dir)
+
+    def ensure_directory(self) -> None:
+        """Create the migrations directory if it doesn't exist."""
+        self.migrations_dir.mkdir(parents=True, exist_ok=True)
+
+        # Create __init__.py if it doesn't exist
+        init_file = self.migrations_dir / "__init__.py"
+        if not init_file.exists():
+            init_file.write_text('"""Auto-generated migrations package."""\n')
+
+    def get_next_number(self) -> int:
+        """
+        Get the next migration number.
+
+        Returns:
+            Next available migration number
+        """
+        self.ensure_directory()
+
+        existing = list(self.migrations_dir.glob("*.py"))
+        max_num = 0
+
+        for filepath in existing:
+            name = filepath.stem
+            if name.startswith("_"):
+                continue
+            try:
+                parts = name.split("_", 1)
+                if parts[0].isdigit():
+                    num = int(parts[0])
+                    max_num = max(max_num, num)
+            except (ValueError, IndexError):
+                continue
+
+        return max_num + 1
+
+    def generate(
+        self,
+        name: str,
+        operations: list["Operation"],
+        dependencies: list[str] | None = None,
+    ) -> Path:
+        """
+        Generate a migration file.
+
+        Args:
+            name: Short descriptive name for the migration
+            operations: List of operations to include
+            dependencies: List of migration names this depends on
+
+        Returns:
+            Path to the generated migration file
+        """
+        self.ensure_directory()
+
+        # Determine migration number and full name
+        number = self.get_next_number()
+        full_name = generate_migration_name(number, name)
+
+        # Generate filename
+        filename = f"{full_name}.py"
+        filepath = self.migrations_dir / filename
+
+        # Generate content
+        content = self._render_migration(
+            name=full_name,
+            operations=operations,
+            dependencies=dependencies or [],
+        )
+
+        filepath.write_text(content)
+        return filepath
+
+    def _render_migration(
+        self,
+        name: str,
+        operations: list["Operation"],
+        dependencies: list[str],
+    ) -> str:
+        """
+        Render migration file content.
+
+        Args:
+            name: Migration name
+            operations: List of operations
+            dependencies: List of dependency names
+
+        Returns:
+            Python file content as string
+        """
+        lines = [
+            '"""',
+            f"Migration: {name}",
+            f"Generated: {datetime.now(timezone.utc).isoformat()}",
+            "",
+            "Auto-generated migration file. Review before applying.",
+            '"""',
+            "",
+        ]
+
+        # Collect required imports
+        op_types = set(type(op).__name__ for op in operations)
+        imports = sorted(op_types)
+
+        lines.append("from surreal_orm.migrations import Migration")
+        lines.append("from surreal_orm.migrations.operations import (")
+        for op_type in imports:
+            lines.append(f"    {op_type},")
+        lines.append(")")
+        lines.append("")
+        lines.append("")
+
+        # Migration definition
+        lines.append("migration = Migration(")
+        lines.append(f'    name="{name}",')
+        lines.append(f"    dependencies={dependencies!r},")
+
+        if not operations:
+            lines.append("    operations=[],")
+        else:
+            lines.append("    operations=[")
+            for op in operations:
+                rendered = self._render_operation(op)
+                # Indent the operation
+                for line in rendered.split("\n"):
+                    lines.append(f"        {line}")
+            lines.append("    ],")
+
+        lines.append(")")
+        lines.append("")
+
+        return "\n".join(lines)
+
+    def _render_operation(self, op: "Operation") -> str:
+        """
+        Render a single operation as Python code.
+
+        Args:
+            op: Operation to render
+
+        Returns:
+            Python code string for the operation
+        """
+        op_type = type(op).__name__
+        args = []
+
+        # Get all dataclass fields
+        for field_name in op.__dataclass_fields__:
+            if field_name == "reversible":
+                continue
+
+            value = getattr(op, field_name)
+
+            # Skip None values for optional fields
+            if value is None:
+                continue
+
+            # Skip default values
+            field_info = op.__dataclass_fields__[field_name]
+            if field_info.default is not MISSING and value == field_info.default:
+                continue
+            if field_info.default_factory is not MISSING:
+                default_val = field_info.default_factory()
+                if value == default_val:
+                    continue
+
+            # Format the value
+            args.append(f"{field_name}={self._format_value(value)}")
+
+        # Format as single line if short, multi-line if long
+        args_str = ", ".join(args)
+        if len(args_str) < 60:
+            return f"{op_type}({args_str}),"
+        else:
+            lines = [f"{op_type}("]
+            for arg in args:
+                lines.append(f"    {arg},")
+            lines.append("),")
+            return "\n".join(lines)
+
+    def _format_value(self, value: object) -> str:
+        """
+        Format a value as Python literal.
+
+        Args:
+            value: Value to format
+
+        Returns:
+            Python literal string
+        """
+        if isinstance(value, str):
+            # Use repr for proper escaping
+            return repr(value)
+        elif isinstance(value, bool):
+            return str(value)
+        elif isinstance(value, (int, float)):
+            return str(value)
+        elif isinstance(value, list):
+            items = [self._format_value(v) for v in value]
+            return f"[{', '.join(items)}]"
+        elif isinstance(value, dict):
+            items = [f"{self._format_value(k)}: {self._format_value(v)}" for k, v in value.items()]
+            if len(items) == 0:
+                return "{}"
+            elif len(items) <= 2:
+                return "{" + ", ".join(items) + "}"
+            else:
+                # Multi-line dict
+                lines = ["{"]
+                for item in items:
+                    lines.append(f"    {item},")
+                lines.append("}")
+                return "\n".join(lines)
+        elif value is None:
+            return "None"
+        else:
+            return repr(value)
+
+
+def generate_empty_migration(
+    migrations_dir: Path | str,
+    name: str,
+    dependencies: list[str] | None = None,
+) -> Path:
+    """
+    Generate an empty migration file for manual editing.
+
+    Args:
+        migrations_dir: Path to migrations directory
+        name: Migration name
+        dependencies: List of dependencies
+
+    Returns:
+        Path to generated file
+    """
+    generator = MigrationGenerator(migrations_dir)
+    return generator.generate(name=name, operations=[], dependencies=dependencies)

--- a/src/surreal_orm/migrations/introspector.py
+++ b/src/surreal_orm/migrations/introspector.py
@@ -1,0 +1,305 @@
+"""
+Model introspection for migration generation.
+
+This module extracts schema information from Pydantic models to build
+a SchemaState that can be compared against the current database state.
+"""
+
+from typing import TYPE_CHECKING, Any, get_args, get_origin, get_type_hints
+import types
+
+from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
+
+from ..fields.encrypted import is_encrypted_field
+from ..types import PYTHON_TO_SURREAL_TYPE, FieldType, TableType
+from .state import AccessState, FieldState, SchemaState, TableState
+
+if TYPE_CHECKING:
+    from ..model_base import BaseSurrealModel
+
+
+class ModelIntrospector:
+    """
+    Extracts schema information from Pydantic models.
+
+    This class inspects model definitions including:
+    - Table configuration (name, type, schema mode)
+    - Field definitions with types and constraints
+    - Encrypted field detection
+    - Access definition generation for USER tables
+    """
+
+    def __init__(self, models: list[type["BaseSurrealModel"]] | None = None):
+        """
+        Initialize the introspector with a list of models.
+
+        Args:
+            models: List of model classes to introspect. If None, uses
+                    all registered models.
+        """
+        if models is None:
+            from ..model_base import get_registered_models
+
+            models = get_registered_models()
+        self.models = models
+
+    def introspect(self) -> SchemaState:
+        """
+        Build SchemaState from all registered models.
+
+        Returns:
+            SchemaState representing all model definitions
+        """
+        state = SchemaState()
+
+        for model in self.models:
+            table_state = self._introspect_model(model)
+            state.tables[table_state.name] = table_state
+
+        return state
+
+    def _introspect_model(self, model: type["BaseSurrealModel"]) -> TableState:
+        """
+        Extract table state from a single model.
+
+        Args:
+            model: The model class to introspect
+
+        Returns:
+            TableState representing the model's schema
+        """
+        # Get table configuration
+        table_name = model.get_table_name()
+        table_type = model.get_table_type()
+        schema_mode = model.get_schema_mode()
+        changefeed = model.get_changefeed()
+        permissions = model.get_permissions()
+
+        # Build table state
+        table_state = TableState(
+            name=table_name,
+            schema_mode=str(schema_mode),
+            table_type=str(table_type),
+            changefeed=changefeed,
+            permissions=permissions,
+        )
+
+        # Introspect fields
+        try:
+            type_hints = get_type_hints(model, include_extras=True)
+        except Exception:
+            # Fallback if type hints fail
+            type_hints = {}
+
+        for field_name, field_info in model.model_fields.items():
+            # Skip the id field - SurrealDB handles it automatically
+            if field_name == "id":
+                continue
+
+            field_type_hint = type_hints.get(field_name, field_info.annotation)
+            field_state = self._introspect_field(field_name, field_type_hint, field_info)
+            table_state.fields[field_name] = field_state
+
+        # Generate access definition for USER tables
+        if table_type == TableType.USER:
+            table_state.access = self._generate_access_state(model, table_name)
+
+        return table_state
+
+    def _introspect_field(
+        self,
+        name: str,
+        type_hint: Any,
+        field_info: FieldInfo,
+    ) -> FieldState:
+        """
+        Extract field state from type hint and field info.
+
+        Args:
+            name: Field name
+            type_hint: Type annotation for the field
+            field_info: Pydantic FieldInfo
+
+        Returns:
+            FieldState representing the field definition
+        """
+        # Check for Encrypted type
+        encrypted = is_encrypted_field(type_hint)
+
+        # Unwrap Encrypted type to get inner type
+        if encrypted:
+            args = get_args(type_hint)
+            if args:
+                type_hint = args[0]
+            else:
+                type_hint = str
+
+        # Handle Optional/Union types
+        nullable = False
+        origin = get_origin(type_hint)
+
+        if origin is types.UnionType or origin is type(None):
+            # Handle X | None syntax
+            args = get_args(type_hint)
+            non_none_args = [a for a in args if a is not type(None)]
+            if type(None) in args:
+                nullable = True
+            if non_none_args:
+                type_hint = non_none_args[0]
+            else:
+                type_hint = str
+
+        # Map Python type to SurrealDB type
+        surreal_type = self._map_type(type_hint)
+
+        # Get default value
+        default = None
+        if field_info.default is not None and field_info.default is not ... and field_info.default is not PydanticUndefined:
+            default = field_info.default
+        elif field_info.default_factory is not None:
+            # Can't serialize factory, skip default
+            pass
+
+        # Check for flexible type
+        flexible = False
+        if hasattr(field_info, "json_schema_extra") and field_info.json_schema_extra:
+            if isinstance(field_info.json_schema_extra, dict):
+                flexible_val = field_info.json_schema_extra.get("flexible", False)
+                flexible = flexible_val is True
+
+        return FieldState(
+            name=name,
+            field_type=surreal_type,
+            nullable=nullable,
+            default=default,
+            encrypted=encrypted,
+            flexible=flexible,
+        )
+
+    def _map_type(self, python_type: Any) -> str:
+        """
+        Map a Python type to a SurrealDB type string.
+
+        Args:
+            python_type: Python type annotation
+
+        Returns:
+            SurrealDB type string
+        """
+        origin = get_origin(python_type)
+
+        # Handle generic types
+        if origin is list:
+            args = get_args(python_type)
+            if args:
+                inner_type = self._map_type(args[0])
+                return f"array<{inner_type}>"
+            return "array"
+
+        if origin is dict:
+            return "object"
+
+        if origin is set:
+            args = get_args(python_type)
+            if args:
+                inner_type = self._map_type(args[0])
+                return f"set<{inner_type}>"
+            return "set"
+
+        # Handle basic types
+        if python_type in PYTHON_TO_SURREAL_TYPE:
+            return PYTHON_TO_SURREAL_TYPE[python_type].value
+
+        # Handle string type names
+        if isinstance(python_type, type):
+            type_name = python_type.__name__.lower()
+            if type_name == "str":
+                return FieldType.STRING.value
+            elif type_name == "int":
+                return FieldType.INT.value
+            elif type_name == "float":
+                return FieldType.FLOAT.value
+            elif type_name == "bool":
+                return FieldType.BOOL.value
+            elif type_name == "datetime":
+                return FieldType.DATETIME.value
+            elif type_name == "uuid":
+                return FieldType.UUID.value
+            elif type_name == "bytes":
+                return FieldType.BYTES.value
+
+        # Fallback
+        return FieldType.ANY.value
+
+    def _generate_access_state(
+        self,
+        model: type["BaseSurrealModel"],
+        table_name: str,
+    ) -> AccessState:
+        """
+        Generate access state for a USER type table.
+
+        Args:
+            model: The user model class
+            table_name: Name of the table
+
+        Returns:
+            AccessState for authentication
+        """
+        identifier_field = model.get_identifier_field()
+        password_field = model.get_password_field()
+
+        # Build signup fields
+        signup_fields: dict[str, str] = {}
+
+        # Get all model fields
+        for field_name in model.model_fields:
+            if field_name == "id":
+                continue
+
+            if field_name == password_field:
+                # Password gets encrypted
+                signup_fields[field_name] = f"crypto::argon2::generate(${field_name})"
+            else:
+                # Regular fields are passed through
+                signup_fields[field_name] = f"${field_name}"
+
+        # Add default timestamp if not in fields
+        if "created_at" not in signup_fields and "created_at" not in model.model_fields:
+            signup_fields["created_at"] = "time::now()"
+
+        # Build signin WHERE clause
+        signin_where = (
+            f"{identifier_field} = ${identifier_field} AND crypto::argon2::compare({password_field}, ${password_field})"
+        )
+
+        # Get duration settings from config
+        config = getattr(model, "model_config", {})
+        token_duration = config.get("token_duration", "15m")
+        session_duration = config.get("session_duration", "12h")
+
+        return AccessState(
+            name=f"{table_name.lower()}_auth",
+            table=table_name,
+            signup_fields=signup_fields,
+            signin_where=signin_where,
+            duration_token=token_duration,
+            duration_session=session_duration,
+        )
+
+
+def introspect_models(
+    models: list[type["BaseSurrealModel"]] | None = None,
+) -> SchemaState:
+    """
+    Convenience function to introspect models.
+
+    Args:
+        models: List of model classes, or None to use all registered models
+
+    Returns:
+        SchemaState representing the models
+    """
+    introspector = ModelIntrospector(models)
+    return introspector.introspect()

--- a/src/surreal_orm/migrations/migration.py
+++ b/src/surreal_orm/migrations/migration.py
@@ -1,0 +1,188 @@
+"""
+Migration class and utilities for SurrealDB schema migrations.
+
+A Migration represents a set of operations to be applied to the database
+in a specific order, with optional dependencies on other migrations.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .operations import Operation
+
+
+@dataclass
+class Migration:
+    """
+    Represents a single migration containing a list of operations.
+
+    Migrations are stored as Python files and can be applied forwards
+    (to update the schema) or backwards (to rollback changes).
+
+    Attributes:
+        name: Unique identifier for the migration (e.g., "0001_initial")
+        dependencies: List of migration names this depends on
+        operations: List of operations to apply
+        created_at: Timestamp when the migration was created
+
+    Example:
+        migration = Migration(
+            name="0001_initial",
+            dependencies=[],
+            operations=[
+                CreateTable(name="User", schema_mode="SCHEMAFULL"),
+                AddField(table="User", name="email", field_type="string"),
+            ],
+        )
+    """
+
+    name: str
+    dependencies: list[str] = field(default_factory=list)
+    operations: list["Operation"] = field(default_factory=list)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def forwards_sql(self) -> list[str]:
+        """
+        Generate all forward migration SQL statements.
+
+        Returns:
+            List of SurrealQL statements to apply the migration
+        """
+        statements = []
+        for op in self.operations:
+            sql = op.forwards()
+            if sql:
+                statements.append(sql)
+        return statements
+
+    def backwards_sql(self) -> list[str]:
+        """
+        Generate all rollback SQL statements.
+
+        Operations are reversed in order for proper rollback.
+
+        Returns:
+            List of SurrealQL statements to rollback the migration
+        """
+        statements = []
+        for op in reversed(self.operations):
+            if op.reversible:
+                sql = op.backwards()
+                if sql:
+                    statements.append(sql)
+        return statements
+
+    @property
+    def is_reversible(self) -> bool:
+        """
+        Check if all operations in this migration are reversible.
+
+        Returns:
+            True if the entire migration can be rolled back
+        """
+        return all(op.reversible for op in self.operations)
+
+    @property
+    def has_data_migrations(self) -> bool:
+        """
+        Check if this migration contains data migrations.
+
+        Data migrations modify existing records rather than schema.
+
+        Returns:
+            True if the migration contains DataMigration operations
+        """
+        from .operations import DataMigration
+
+        return any(isinstance(op, DataMigration) for op in self.operations)
+
+    @property
+    def schema_operations(self) -> list["Operation"]:
+        """
+        Get only schema-modifying operations (DDL).
+
+        Returns:
+            List of operations that modify schema (not data)
+        """
+        from .operations import DataMigration
+
+        return [op for op in self.operations if not isinstance(op, DataMigration)]
+
+    @property
+    def data_operations(self) -> list["Operation"]:
+        """
+        Get only data-modifying operations (DML).
+
+        Returns:
+            List of DataMigration operations
+        """
+        from .operations import DataMigration
+
+        return [op for op in self.operations if isinstance(op, DataMigration)]
+
+    def describe(self) -> str:
+        """
+        Get a human-readable description of this migration.
+
+        Returns:
+            Multi-line string describing all operations
+        """
+        lines = [f"Migration: {self.name}"]
+        if self.dependencies:
+            lines.append(f"Dependencies: {', '.join(self.dependencies)}")
+        lines.append(f"Operations ({len(self.operations)}):")
+        for i, op in enumerate(self.operations, 1):
+            lines.append(f"  {i}. {op.describe()}")
+        return "\n".join(lines)
+
+    def __repr__(self) -> str:
+        return f"Migration(name={self.name!r}, operations={len(self.operations)})"
+
+
+def parse_migration_name(filename: str) -> tuple[int, str]:
+    """
+    Parse a migration filename into number and name.
+
+    Args:
+        filename: Migration filename (e.g., "0001_initial.py")
+
+    Returns:
+        Tuple of (migration_number, migration_name)
+
+    Raises:
+        ValueError: If filename doesn't match expected format
+    """
+    # Remove .py extension if present
+    if filename.endswith(".py"):
+        filename = filename[:-3]
+
+    parts = filename.split("_", 1)
+    if len(parts) != 2:
+        raise ValueError(f"Invalid migration filename: {filename}")
+
+    try:
+        number = int(parts[0])
+    except ValueError:
+        raise ValueError(f"Invalid migration number in: {filename}")
+
+    return number, parts[1]
+
+
+def generate_migration_name(number: int, name: str) -> str:
+    """
+    Generate a migration filename from number and name.
+
+    Args:
+        number: Migration sequence number
+        name: Descriptive name for the migration
+
+    Returns:
+        Formatted filename (e.g., "0001_initial")
+    """
+    # Sanitize name: lowercase, replace spaces with underscores
+    safe_name = name.lower().replace(" ", "_").replace("-", "_")
+    # Remove any non-alphanumeric characters except underscores
+    safe_name = "".join(c for c in safe_name if c.isalnum() or c == "_")
+    return f"{number:04d}_{safe_name}"

--- a/src/surreal_orm/migrations/operations.py
+++ b/src/surreal_orm/migrations/operations.py
@@ -1,0 +1,531 @@
+"""
+Migration operations for SurrealDB schema changes.
+
+Each operation represents a single schema modification that can be
+applied (forwards) or reverted (backwards).
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Callable, Coroutine
+
+
+@dataclass
+class Operation(ABC):
+    """
+    Base class for all migration operations.
+
+    Operations must implement forwards() and backwards() methods
+    that return SurrealQL statements.
+    """
+
+    reversible: bool = field(default=True, init=False)
+
+    @abstractmethod
+    def forwards(self) -> str:
+        """Generate forward SurrealQL statement."""
+        ...
+
+    @abstractmethod
+    def backwards(self) -> str:
+        """Generate rollback SurrealQL statement."""
+        ...
+
+    def describe(self) -> str:
+        """Human-readable description of the operation."""
+        return f"{self.__class__.__name__}"
+
+
+@dataclass
+class CreateTable(Operation):
+    """
+    Create a new table with optional schema mode and changefeed.
+
+    Example:
+        CreateTable(name="users", schema_mode="SCHEMAFULL", changefeed="7d")
+
+    Generates:
+        DEFINE TABLE users SCHEMAFULL CHANGEFEED 7d;
+    """
+
+    name: str
+    schema_mode: str = "SCHEMAFULL"
+    table_type: str | None = None
+    changefeed: str | None = None
+    permissions: dict[str, str] | None = None
+    comment: str | None = None
+
+    def forwards(self) -> str:
+        parts = [f"DEFINE TABLE {self.name}"]
+
+        if self.schema_mode:
+            parts.append(self.schema_mode)
+
+        if self.changefeed:
+            parts.append(f"CHANGEFEED {self.changefeed}")
+
+        if self.comment:
+            parts.append(f"COMMENT '{self.comment}'")
+
+        sql = " ".join(parts) + ";"
+
+        # Add permissions if specified
+        if self.permissions:
+            perm_parts = []
+            for action, condition in self.permissions.items():
+                perm_parts.append(f"FOR {action} WHERE {condition}")
+            if perm_parts:
+                sql += f"\nDEFINE TABLE {self.name} PERMISSIONS {' '.join(perm_parts)};"
+
+        return sql
+
+    def backwards(self) -> str:
+        return f"REMOVE TABLE {self.name};"
+
+    def describe(self) -> str:
+        return f"Create table {self.name}"
+
+
+@dataclass
+class DropTable(Operation):
+    """
+    Drop an existing table.
+
+    Example:
+        DropTable(name="users")
+
+    Generates:
+        REMOVE TABLE users;
+    """
+
+    name: str
+
+    def __post_init__(self) -> None:
+        self.reversible = False
+
+    def forwards(self) -> str:
+        return f"REMOVE TABLE {self.name};"
+
+    def backwards(self) -> str:
+        # Cannot reverse without knowing the original schema
+        return ""
+
+    def describe(self) -> str:
+        return f"Drop table {self.name}"
+
+
+@dataclass
+class AddField(Operation):
+    """
+    Add a field to a table.
+
+    Example:
+        AddField(
+            table="users",
+            name="email",
+            field_type="string",
+            assertion="is::email($value)"
+        )
+
+    Generates:
+        DEFINE FIELD email ON users TYPE string ASSERT is::email($value);
+    """
+
+    table: str
+    name: str
+    field_type: str
+    default: Any = None
+    assertion: str | None = None
+    encrypted: bool = False
+    flexible: bool = False
+    readonly: bool = False
+    value: str | None = None
+    comment: str | None = None
+
+    def forwards(self) -> str:
+        parts = [f"DEFINE FIELD {self.name} ON {self.table}"]
+
+        if self.flexible:
+            parts.append("FLEXIBLE")
+
+        parts.append(f"TYPE {self.field_type}")
+
+        # For encrypted fields, use VALUE clause with crypto function
+        if self.encrypted:
+            parts.append("VALUE crypto::argon2::generate($value)")
+        elif self.value:
+            parts.append(f"VALUE {self.value}")
+
+        if self.default is not None:
+            if isinstance(self.default, str):
+                # Check if it's a function call or literal
+                if self.default.startswith("time::") or self.default.startswith("rand::"):
+                    parts.append(f"DEFAULT {self.default}")
+                else:
+                    parts.append(f"DEFAULT '{self.default}'")
+            elif isinstance(self.default, bool):
+                parts.append(f"DEFAULT {str(self.default).lower()}")
+            else:
+                parts.append(f"DEFAULT {self.default}")
+
+        if self.assertion:
+            parts.append(f"ASSERT {self.assertion}")
+
+        if self.readonly:
+            parts.append("READONLY")
+
+        if self.comment:
+            parts.append(f"COMMENT '{self.comment}'")
+
+        return " ".join(parts) + ";"
+
+    def backwards(self) -> str:
+        return f"REMOVE FIELD {self.name} ON {self.table};"
+
+    def describe(self) -> str:
+        return f"Add field {self.name} to {self.table}"
+
+
+@dataclass
+class DropField(Operation):
+    """
+    Remove a field from a table.
+
+    Example:
+        DropField(table="users", name="old_field")
+
+    Generates:
+        REMOVE FIELD old_field ON users;
+    """
+
+    table: str
+    name: str
+
+    def __post_init__(self) -> None:
+        self.reversible = False
+
+    def forwards(self) -> str:
+        return f"REMOVE FIELD {self.name} ON {self.table};"
+
+    def backwards(self) -> str:
+        # Cannot reverse without knowing the original field definition
+        return ""
+
+    def describe(self) -> str:
+        return f"Drop field {self.name} from {self.table}"
+
+
+@dataclass
+class AlterField(Operation):
+    """
+    Alter an existing field's definition.
+
+    Example:
+        AlterField(
+            table="users",
+            name="email",
+            field_type="string",
+            assertion="is::email($value)"
+        )
+
+    Generates:
+        DEFINE FIELD email ON users TYPE string ASSERT is::email($value);
+    """
+
+    table: str
+    name: str
+    field_type: str | None = None
+    default: Any = None
+    assertion: str | None = None
+    encrypted: bool = False
+    flexible: bool = False
+    readonly: bool = False
+    value: str | None = None
+    # Store previous definition for rollback
+    previous_type: str | None = None
+    previous_default: Any = None
+    previous_assertion: str | None = None
+
+    def forwards(self) -> str:
+        # DEFINE FIELD is idempotent - it creates or updates
+        parts = [f"DEFINE FIELD {self.name} ON {self.table}"]
+
+        if self.flexible:
+            parts.append("FLEXIBLE")
+
+        if self.field_type:
+            parts.append(f"TYPE {self.field_type}")
+
+        if self.encrypted:
+            parts.append("VALUE crypto::argon2::generate($value)")
+        elif self.value:
+            parts.append(f"VALUE {self.value}")
+
+        if self.default is not None:
+            if isinstance(self.default, str):
+                if self.default.startswith("time::") or self.default.startswith("rand::"):
+                    parts.append(f"DEFAULT {self.default}")
+                else:
+                    parts.append(f"DEFAULT '{self.default}'")
+            elif isinstance(self.default, bool):
+                parts.append(f"DEFAULT {str(self.default).lower()}")
+            else:
+                parts.append(f"DEFAULT {self.default}")
+
+        if self.assertion:
+            parts.append(f"ASSERT {self.assertion}")
+
+        if self.readonly:
+            parts.append("READONLY")
+
+        return " ".join(parts) + ";"
+
+    def backwards(self) -> str:
+        if not self.previous_type:
+            return ""
+
+        parts = [f"DEFINE FIELD {self.name} ON {self.table} TYPE {self.previous_type}"]
+
+        if self.previous_default is not None:
+            if isinstance(self.previous_default, str):
+                parts.append(f"DEFAULT '{self.previous_default}'")
+            else:
+                parts.append(f"DEFAULT {self.previous_default}")
+
+        if self.previous_assertion:
+            parts.append(f"ASSERT {self.previous_assertion}")
+
+        return " ".join(parts) + ";"
+
+    def __post_init__(self) -> None:
+        """Set reversible based on whether previous state is stored."""
+        object.__setattr__(self, "reversible", self.previous_type is not None)
+
+    def describe(self) -> str:
+        return f"Alter field {self.name} on {self.table}"
+
+
+@dataclass
+class CreateIndex(Operation):
+    """
+    Create an index on a table.
+
+    Example:
+        CreateIndex(
+            table="users",
+            name="email_idx",
+            fields=["email"],
+            unique=True
+        )
+
+    Generates:
+        DEFINE INDEX email_idx ON users FIELDS email UNIQUE;
+    """
+
+    table: str
+    name: str
+    fields: list[str]
+    unique: bool = False
+    search_analyzer: str | None = None
+    comment: str | None = None
+
+    def forwards(self) -> str:
+        fields_str = ", ".join(self.fields)
+        parts = [f"DEFINE INDEX {self.name} ON {self.table} FIELDS {fields_str}"]
+
+        if self.unique:
+            parts.append("UNIQUE")
+
+        if self.search_analyzer:
+            parts.append(f"SEARCH ANALYZER {self.search_analyzer}")
+
+        if self.comment:
+            parts.append(f"COMMENT '{self.comment}'")
+
+        return " ".join(parts) + ";"
+
+    def backwards(self) -> str:
+        return f"REMOVE INDEX {self.name} ON {self.table};"
+
+    def describe(self) -> str:
+        return f"Create index {self.name} on {self.table}"
+
+
+@dataclass
+class DropIndex(Operation):
+    """
+    Remove an index from a table.
+
+    Example:
+        DropIndex(table="users", name="email_idx")
+
+    Generates:
+        REMOVE INDEX email_idx ON users;
+    """
+
+    table: str
+    name: str
+
+    def __post_init__(self) -> None:
+        self.reversible = False
+
+    def forwards(self) -> str:
+        return f"REMOVE INDEX {self.name} ON {self.table};"
+
+    def backwards(self) -> str:
+        return ""
+
+    def describe(self) -> str:
+        return f"Drop index {self.name} from {self.table}"
+
+
+@dataclass
+class DefineAccess(Operation):
+    """
+    Define access control for authentication (DEFINE ACCESS ... TYPE RECORD).
+
+    Example:
+        DefineAccess(
+            name="user_auth",
+            table="User",
+            signup_fields={"email": "$email", "password": "crypto::argon2::generate($password)"},
+            signin_where="email = $email AND crypto::argon2::compare(password, $password)"
+        )
+
+    Generates:
+        DEFINE ACCESS user_auth ON DATABASE TYPE RECORD
+            SIGNUP (CREATE User SET email = $email, password = crypto::argon2::generate($password))
+            SIGNIN (SELECT * FROM User WHERE email = $email AND crypto::argon2::compare(password, $password))
+            DURATION FOR TOKEN 15m, FOR SESSION 12h;
+    """
+
+    name: str
+    table: str
+    signup_fields: dict[str, str]
+    signin_where: str
+    duration_token: str = "15m"
+    duration_session: str = "12h"
+    comment: str | None = None
+
+    def forwards(self) -> str:
+        signup_sets = ", ".join(f"{field} = {expr}" for field, expr in self.signup_fields.items())
+
+        sql = f"""DEFINE ACCESS {self.name} ON DATABASE TYPE RECORD
+    SIGNUP (CREATE {self.table} SET {signup_sets})
+    SIGNIN (SELECT * FROM {self.table} WHERE {self.signin_where})
+    DURATION FOR TOKEN {self.duration_token}, FOR SESSION {self.duration_session}"""
+
+        if self.comment:
+            sql += f"\n    COMMENT '{self.comment}'"
+
+        return sql + ";"
+
+    def backwards(self) -> str:
+        return f"REMOVE ACCESS {self.name} ON DATABASE;"
+
+    def describe(self) -> str:
+        return f"Define access {self.name} for {self.table}"
+
+
+@dataclass
+class RemoveAccess(Operation):
+    """
+    Remove an access definition.
+
+    Example:
+        RemoveAccess(name="user_auth")
+
+    Generates:
+        REMOVE ACCESS user_auth ON DATABASE;
+    """
+
+    name: str
+
+    def __post_init__(self) -> None:
+        self.reversible = False
+
+    def forwards(self) -> str:
+        return f"REMOVE ACCESS {self.name} ON DATABASE;"
+
+    def backwards(self) -> str:
+        return ""
+
+    def describe(self) -> str:
+        return f"Remove access {self.name}"
+
+
+@dataclass
+class DataMigration(Operation):
+    """
+    Execute data transformations (UPDATE, DELETE operations on records).
+
+    Used for the 'upgrade' command to transform existing data.
+
+    Example:
+        DataMigration(
+            forwards_sql="UPDATE User SET status = 'active' WHERE status IS NULL;",
+            backwards_sql="UPDATE User SET status = NULL WHERE status = 'active';"
+        )
+
+    Or with async functions:
+        DataMigration(
+            forwards_func=async_migrate_passwords,
+            backwards_func=None  # Irreversible
+        )
+    """
+
+    forwards_sql: str | None = None
+    backwards_sql: str | None = None
+    forwards_func: Callable[[], Coroutine[Any, Any, None]] | None = None
+    backwards_func: Callable[[], Coroutine[Any, Any, None]] | None = None
+    description: str = "Data migration"
+
+    def __post_init__(self) -> None:
+        if not self.forwards_sql and not self.forwards_func:
+            raise ValueError("DataMigration requires either forwards_sql or forwards_func")
+        self.reversible = bool(self.backwards_sql or self.backwards_func)
+
+    def forwards(self) -> str:
+        return self.forwards_sql or ""
+
+    def backwards(self) -> str:
+        return self.backwards_sql or ""
+
+    @property
+    def has_func(self) -> bool:
+        """Check if this migration uses async functions."""
+        return self.forwards_func is not None
+
+    def describe(self) -> str:
+        return self.description
+
+
+@dataclass
+class RawSQL(Operation):
+    """
+    Execute raw SurrealQL statements.
+
+    Use with caution - prefer structured operations when possible.
+
+    Example:
+        RawSQL(
+            sql="DEFINE EVENT user_created ON TABLE User WHEN $event = 'CREATE' THEN (CREATE log SET action = 'user_created');",
+            reverse_sql="REMOVE EVENT user_created ON TABLE User;"
+        )
+    """
+
+    sql: str
+    reverse_sql: str = ""
+    description: str = "Raw SQL"
+
+    def __post_init__(self) -> None:
+        self.reversible = bool(self.reverse_sql)
+
+    def forwards(self) -> str:
+        return self.sql
+
+    def backwards(self) -> str:
+        return self.reverse_sql
+
+    def describe(self) -> str:
+        return self.description

--- a/src/surreal_orm/migrations/state.py
+++ b/src/surreal_orm/migrations/state.py
@@ -1,0 +1,406 @@
+"""
+Schema state tracking and diffing for migrations.
+
+This module provides classes to represent the current schema state
+and compute the differences between two states to generate migrations.
+"""
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .operations import Operation
+
+
+@dataclass
+class FieldState:
+    """
+    Represents the state of a single field in a table.
+
+    Attributes:
+        name: Field name
+        field_type: SurrealDB type (string, int, etc.)
+        nullable: Whether the field can be null
+        default: Default value if any
+        assertion: Validation assertion
+        encrypted: Whether the field is encrypted
+        flexible: Whether the field accepts additional types
+        readonly: Whether the field is read-only
+        value: VALUE clause for computed fields
+    """
+
+    name: str
+    field_type: str
+    nullable: bool = True
+    default: Any = None
+    assertion: str | None = None
+    encrypted: bool = False
+    flexible: bool = False
+    readonly: bool = False
+    value: str | None = None
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, FieldState):
+            return False
+        return (
+            self.name == other.name
+            and self.field_type == other.field_type
+            and self.nullable == other.nullable
+            and self.default == other.default
+            and self.assertion == other.assertion
+            and self.encrypted == other.encrypted
+            and self.flexible == other.flexible
+            and self.readonly == other.readonly
+            and self.value == other.value
+        )
+
+    def has_changed(self, other: "FieldState") -> bool:
+        """Check if field definition has changed from other."""
+        return self != other
+
+
+@dataclass
+class IndexState:
+    """
+    Represents the state of an index on a table.
+
+    Attributes:
+        name: Index name
+        fields: List of field names in the index
+        unique: Whether the index enforces uniqueness
+        search_analyzer: Full-text search analyzer if any
+    """
+
+    name: str
+    fields: list[str]
+    unique: bool = False
+    search_analyzer: str | None = None
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, IndexState):
+            return False
+        return (
+            self.name == other.name
+            and self.fields == other.fields
+            and self.unique == other.unique
+            and self.search_analyzer == other.search_analyzer
+        )
+
+
+@dataclass
+class AccessState:
+    """
+    Represents the state of an access definition for authentication.
+
+    Attributes:
+        name: Access name
+        table: Associated table
+        signup_fields: Fields set during signup
+        signin_where: WHERE clause for signin
+        duration_token: Token duration
+        duration_session: Session duration
+    """
+
+    name: str
+    table: str
+    signup_fields: dict[str, str]
+    signin_where: str
+    duration_token: str = "15m"
+    duration_session: str = "12h"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, AccessState):
+            return False
+        return (
+            self.name == other.name
+            and self.table == other.table
+            and self.signup_fields == other.signup_fields
+            and self.signin_where == other.signin_where
+            and self.duration_token == other.duration_token
+            and self.duration_session == other.duration_session
+        )
+
+
+@dataclass
+class TableState:
+    """
+    Represents the complete state of a table.
+
+    Attributes:
+        name: Table name
+        schema_mode: SCHEMAFULL or SCHEMALESS
+        table_type: Table type classification (normal, user, stream, hash)
+        fields: Dict of field name to FieldState
+        indexes: Dict of index name to IndexState
+        changefeed: Changefeed duration if enabled
+        permissions: Dict of action to WHERE condition
+        access: Access definition if this is a USER table
+    """
+
+    name: str
+    schema_mode: str = "SCHEMAFULL"
+    table_type: str = "normal"
+    fields: dict[str, FieldState] = field(default_factory=dict)
+    indexes: dict[str, IndexState] = field(default_factory=dict)
+    changefeed: str | None = None
+    permissions: dict[str, str] = field(default_factory=dict)
+    access: AccessState | None = None
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, TableState):
+            return False
+        return (
+            self.name == other.name
+            and self.schema_mode == other.schema_mode
+            and self.table_type == other.table_type
+            and self.fields == other.fields
+            and self.indexes == other.indexes
+            and self.changefeed == other.changefeed
+            and self.permissions == other.permissions
+            and self.access == other.access
+        )
+
+
+@dataclass
+class SchemaState:
+    """
+    Represents the complete database schema state.
+
+    This class tracks all tables and their definitions, and can compute
+    the operations needed to transform one state into another.
+
+    Attributes:
+        tables: Dict of table name to TableState
+        applied_migrations: List of already applied migration names
+    """
+
+    tables: dict[str, TableState] = field(default_factory=dict)
+    applied_migrations: list[str] = field(default_factory=list)
+
+    def diff(self, target: "SchemaState") -> list["Operation"]:
+        """
+        Compute operations needed to transform this state into target state.
+
+        Args:
+            target: The desired schema state
+
+        Returns:
+            List of operations to apply (CreateTable, AddField, etc.)
+        """
+        from .operations import (
+            AddField,
+            AlterField,
+            CreateIndex,
+            CreateTable,
+            DefineAccess,
+            DropField,
+            DropIndex,
+            DropTable,
+            RemoveAccess,
+        )
+
+        operations: list[Operation] = []
+
+        # Tables to create (in target but not in self)
+        for table_name, target_table in target.tables.items():
+            if table_name not in self.tables:
+                # Create the table
+                operations.append(
+                    CreateTable(
+                        name=table_name,
+                        schema_mode=target_table.schema_mode,
+                        table_type=target_table.table_type,
+                        changefeed=target_table.changefeed,
+                        permissions=target_table.permissions or None,
+                    )
+                )
+                # Add all fields
+                for field_name, field_state in target_table.fields.items():
+                    operations.append(
+                        AddField(
+                            table=table_name,
+                            name=field_name,
+                            field_type=field_state.field_type,
+                            default=field_state.default,
+                            assertion=field_state.assertion,
+                            encrypted=field_state.encrypted,
+                            flexible=field_state.flexible,
+                            readonly=field_state.readonly,
+                            value=field_state.value,
+                        )
+                    )
+                # Add all indexes
+                for index_name, index_state in target_table.indexes.items():
+                    operations.append(
+                        CreateIndex(
+                            table=table_name,
+                            name=index_name,
+                            fields=index_state.fields,
+                            unique=index_state.unique,
+                            search_analyzer=index_state.search_analyzer,
+                        )
+                    )
+                # Add access definition if present
+                if target_table.access:
+                    operations.append(
+                        DefineAccess(
+                            name=target_table.access.name,
+                            table=table_name,
+                            signup_fields=target_table.access.signup_fields,
+                            signin_where=target_table.access.signin_where,
+                            duration_token=target_table.access.duration_token,
+                            duration_session=target_table.access.duration_session,
+                        )
+                    )
+
+        # Tables to drop (in self but not in target)
+        for table_name in self.tables:
+            if table_name not in target.tables:
+                operations.append(DropTable(name=table_name))
+
+        # Tables to modify (in both)
+        for table_name, target_table in target.tables.items():
+            if table_name in self.tables:
+                current_table = self.tables[table_name]
+
+                # Check if table definition changed
+                if (
+                    current_table.schema_mode != target_table.schema_mode
+                    or current_table.changefeed != target_table.changefeed
+                    or current_table.permissions != target_table.permissions
+                ):
+                    # Recreate table definition (DEFINE TABLE is idempotent)
+                    operations.append(
+                        CreateTable(
+                            name=table_name,
+                            schema_mode=target_table.schema_mode,
+                            table_type=target_table.table_type,
+                            changefeed=target_table.changefeed,
+                            permissions=target_table.permissions or None,
+                        )
+                    )
+
+                # Fields to add
+                for field_name, field_state in target_table.fields.items():
+                    if field_name not in current_table.fields:
+                        operations.append(
+                            AddField(
+                                table=table_name,
+                                name=field_name,
+                                field_type=field_state.field_type,
+                                default=field_state.default,
+                                assertion=field_state.assertion,
+                                encrypted=field_state.encrypted,
+                                flexible=field_state.flexible,
+                                readonly=field_state.readonly,
+                                value=field_state.value,
+                            )
+                        )
+                    elif current_table.fields[field_name] != field_state:
+                        # Field changed
+                        current_field = current_table.fields[field_name]
+                        operations.append(
+                            AlterField(
+                                table=table_name,
+                                name=field_name,
+                                field_type=field_state.field_type,
+                                default=field_state.default,
+                                assertion=field_state.assertion,
+                                encrypted=field_state.encrypted,
+                                flexible=field_state.flexible,
+                                readonly=field_state.readonly,
+                                value=field_state.value,
+                                previous_type=current_field.field_type,
+                                previous_default=current_field.default,
+                                previous_assertion=current_field.assertion,
+                            )
+                        )
+
+                # Fields to drop
+                for field_name in current_table.fields:
+                    if field_name not in target_table.fields:
+                        operations.append(DropField(table=table_name, name=field_name))
+
+                # Indexes to add
+                for index_name, index_state in target_table.indexes.items():
+                    if index_name not in current_table.indexes:
+                        operations.append(
+                            CreateIndex(
+                                table=table_name,
+                                name=index_name,
+                                fields=index_state.fields,
+                                unique=index_state.unique,
+                                search_analyzer=index_state.search_analyzer,
+                            )
+                        )
+                    elif current_table.indexes[index_name] != index_state:
+                        # Index changed - drop and recreate
+                        operations.append(DropIndex(table=table_name, name=index_name))
+                        operations.append(
+                            CreateIndex(
+                                table=table_name,
+                                name=index_name,
+                                fields=index_state.fields,
+                                unique=index_state.unique,
+                                search_analyzer=index_state.search_analyzer,
+                            )
+                        )
+
+                # Indexes to drop
+                for index_name in current_table.indexes:
+                    if index_name not in target_table.indexes:
+                        operations.append(DropIndex(table=table_name, name=index_name))
+
+                # Access definition changes
+                if target_table.access and not current_table.access:
+                    # Add access
+                    operations.append(
+                        DefineAccess(
+                            name=target_table.access.name,
+                            table=table_name,
+                            signup_fields=target_table.access.signup_fields,
+                            signin_where=target_table.access.signin_where,
+                            duration_token=target_table.access.duration_token,
+                            duration_session=target_table.access.duration_session,
+                        )
+                    )
+                elif current_table.access and not target_table.access:
+                    # Remove access
+                    operations.append(RemoveAccess(name=current_table.access.name))
+                elif target_table.access and current_table.access and target_table.access != current_table.access:
+                    # Update access (remove old, add new)
+                    operations.append(RemoveAccess(name=current_table.access.name))
+                    operations.append(
+                        DefineAccess(
+                            name=target_table.access.name,
+                            table=table_name,
+                            signup_fields=target_table.access.signup_fields,
+                            signin_where=target_table.access.signin_where,
+                            duration_token=target_table.access.duration_token,
+                            duration_session=target_table.access.duration_session,
+                        )
+                    )
+
+        return operations
+
+    def clone(self) -> "SchemaState":
+        """Create a deep copy of this schema state."""
+        import copy
+
+        return copy.deepcopy(self)
+
+    def add_table(self, table: TableState) -> None:
+        """Add a table to the schema."""
+        self.tables[table.name] = table
+
+    def remove_table(self, name: str) -> None:
+        """Remove a table from the schema."""
+        if name in self.tables:
+            del self.tables[name]
+
+    def get_table(self, name: str) -> TableState | None:
+        """Get a table by name."""
+        return self.tables.get(name)
+
+    def __repr__(self) -> str:
+        return f"SchemaState(tables={list(self.tables.keys())}, migrations={len(self.applied_migrations)})"

--- a/src/surreal_orm/types.py
+++ b/src/surreal_orm/types.py
@@ -1,0 +1,86 @@
+"""
+Type definitions for SurrealDB ORM.
+
+This module contains enums and type definitions used throughout the ORM
+for table types, schema modes, and field types.
+"""
+
+from enum import StrEnum
+
+
+class TableType(StrEnum):
+    """
+    Table type classification for migration behavior and connection preferences.
+
+    Each table type has specific characteristics:
+    - NORMAL: Standard table with default behavior
+    - USER: Authentication table with enforced SCHEMAFULL, required password field
+    - STREAM: Real-time optimized table with CHANGEFEED enabled, WebSocket preferred
+    - HASH: Lookup/cache table, SCHEMALESS by default
+    """
+
+    NORMAL = "normal"
+    USER = "user"
+    STREAM = "stream"
+    HASH = "hash"
+
+
+class SchemaMode(StrEnum):
+    """
+    Schema enforcement mode for SurrealDB tables.
+
+    - SCHEMAFULL: Strict schema enforcement, only defined fields allowed
+    - SCHEMALESS: Flexible schema, any fields accepted
+    """
+
+    SCHEMAFULL = "SCHEMAFULL"
+    SCHEMALESS = "SCHEMALESS"
+
+
+class FieldType(StrEnum):
+    """
+    SurrealDB field types for schema definitions.
+
+    Maps to SurrealDB's native type system.
+    """
+
+    STRING = "string"
+    INT = "int"
+    FLOAT = "float"
+    BOOL = "bool"
+    DATETIME = "datetime"
+    DURATION = "duration"
+    DECIMAL = "decimal"
+    ARRAY = "array"
+    OBJECT = "object"
+    RECORD = "record"
+    GEOMETRY = "geometry"
+    ANY = "any"
+    OPTION = "option"
+    BYTES = "bytes"
+    UUID = "uuid"
+
+
+class EncryptionAlgorithm(StrEnum):
+    """
+    Supported encryption algorithms for password hashing.
+
+    All algorithms use SurrealDB's built-in crypto functions.
+    """
+
+    ARGON2 = "argon2"
+    BCRYPT = "bcrypt"
+    PBKDF2 = "pbkdf2"
+    SCRYPT = "scrypt"
+
+
+# Type mapping from Python types to SurrealDB types
+PYTHON_TO_SURREAL_TYPE: dict[type, FieldType] = {
+    str: FieldType.STRING,
+    int: FieldType.INT,
+    float: FieldType.FLOAT,
+    bool: FieldType.BOOL,
+    list: FieldType.ARRAY,
+    dict: FieldType.OBJECT,
+    bytes: FieldType.BYTES,
+}

--- a/src/surreal_sdk/connection/base.py
+++ b/src/surreal_sdk/connection/base.py
@@ -136,16 +136,18 @@ class BaseSurrealConnection(ABC):
         namespace: str | None = None,
         database: str | None = None,
         access: str | None = None,
+        **credentials: Any,
     ) -> AuthResponse:
         """
         Authenticate with SurrealDB.
 
         Args:
-            user: Username
-            password: Password
+            user: Username (for root/namespace/database auth)
+            password: Password (for root/namespace/database auth)
             namespace: Optional namespace scope
             database: Optional database scope
-            access: Optional access method
+            access: Optional access method (for record access auth)
+            **credentials: Additional credentials for record access (email, password, etc.)
 
         Returns:
             AuthResponse with token and success status
@@ -163,6 +165,8 @@ class BaseSurrealConnection(ABC):
             params["db"] = database
         if access:
             params["ac"] = access
+        # Add any additional credentials for record access
+        params.update(credentials)
 
         try:
             result = await self.rpc("signin", params)

--- a/src/surreal_sdk/types.py
+++ b/src/surreal_sdk/types.py
@@ -121,6 +121,17 @@ class QueryResponse:
             records.extend(result.records)
         return records
 
+    @property
+    def is_empty(self) -> bool:
+        """Check if response contains no records."""
+        return len(self.all_records) == 0
+
+    @property
+    def first(self) -> dict[str, Any] | None:
+        """Get first record from all results or None."""
+        records = self.all_records
+        return records[0] if records else None
+
 
 @dataclass
 class RecordResponse:

--- a/tests/test_auth_integration.py
+++ b/tests/test_auth_integration.py
@@ -1,0 +1,464 @@
+"""
+Integration tests for authentication with SurrealDB.
+
+These tests require a running SurrealDB instance.
+Run with: pytest -m integration tests/test_auth_integration.py
+"""
+
+import pytest
+
+from src import surreal_orm
+from src.surreal_orm.model_base import (
+    BaseSurrealModel,
+    SurrealConfigDict,
+    clear_model_registry,
+)
+from src.surreal_orm.types import TableType
+from src.surreal_orm.fields import Encrypted
+from src.surreal_orm.auth import AuthenticatedUserMixin, AccessDefinition, AccessGenerator
+
+
+SURREALDB_URL = "http://localhost:8000"
+SURREALDB_USER = "root"
+SURREALDB_PASS = "root"
+SURREALDB_NAMESPACE = "test"
+SURREALDB_DATABASE = "test_auth"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_surrealdb() -> None:
+    """Setup SurrealDB connection for tests."""
+    surreal_orm.SurrealDBConnectionManager.set_connection(
+        SURREALDB_URL,
+        SURREALDB_USER,
+        SURREALDB_PASS,
+        SURREALDB_NAMESPACE,
+        SURREALDB_DATABASE,
+    )
+
+
+@pytest.fixture
+def clean_registry() -> None:
+    """Clear model registry for isolated tests."""
+    clear_model_registry()
+
+
+@pytest.fixture
+async def clean_auth_database():
+    """Clean up auth test tables before and after tests."""
+    tables_and_access = [
+        ("authuser_auth", "AuthUser"),
+        ("testuser_auth", "TestUser"),
+        ("appuser_auth", "AppUser"),
+    ]
+
+    async def cleanup() -> None:
+        try:
+            # Always reconnect as root before cleanup (tests may have changed auth context)
+            client = await surreal_orm.SurrealDBConnectionManager.reconnect()
+            if client is None:
+                return
+            for access_name, table_name in tables_and_access:
+                try:
+                    await client.query(f"REMOVE ACCESS IF EXISTS {access_name} ON DATABASE;")
+                    await client.query(f"REMOVE TABLE IF EXISTS {table_name};")
+                except Exception:
+                    pass
+        except Exception:
+            pass
+
+    # Setup: clean before tests
+    await cleanup()
+
+    yield  # Run test
+
+    # Teardown: clean after tests and restore root auth
+    await cleanup()
+
+
+class TestAccessDefinition:
+    """Tests for AccessDefinition class."""
+
+    def test_access_definition_to_surreal_ql(self) -> None:
+        """Test generating SurrealQL from access definition."""
+        access = AccessDefinition(
+            name="user_auth",
+            table="User",
+            signup_fields={
+                "email": "$email",
+                "password": "crypto::argon2::generate($password)",
+                "name": "$name",
+            },
+            signin_where="email = $email AND crypto::argon2::compare(password, $password)",
+            duration_token="1h",
+            duration_session="24h",
+        )
+
+        sql = access.to_surreal_ql()
+
+        assert "DEFINE ACCESS user_auth ON DATABASE TYPE RECORD" in sql
+        assert "SIGNUP (CREATE User SET" in sql
+        assert "email = $email" in sql
+        assert "crypto::argon2::generate($password)" in sql
+        assert "SIGNIN (SELECT * FROM User WHERE" in sql
+        assert "crypto::argon2::compare(password, $password)" in sql
+        assert "DURATION FOR TOKEN 1h, FOR SESSION 24h" in sql
+
+    def test_access_definition_to_remove_ql(self) -> None:
+        """Test generating remove statement."""
+        access = AccessDefinition(
+            name="user_auth",
+            table="User",
+            signup_fields={"email": "$email"},
+            signin_where="email = $email",
+        )
+
+        sql = access.to_remove_ql()
+        assert sql == "REMOVE ACCESS user_auth ON DATABASE;"
+
+
+class TestAccessGenerator:
+    """Tests for AccessGenerator class."""
+
+    def test_generate_from_user_model(self, clean_registry: None) -> None:
+        """Test generating access from USER type model."""
+        clear_model_registry()
+
+        class TestUserModel(BaseSurrealModel):
+            model_config = SurrealConfigDict(
+                table_type=TableType.USER,
+                identifier_field="email",
+                password_field="password",
+            )
+            id: str | None = None
+            email: str
+            password: Encrypted
+            name: str
+
+        access = AccessGenerator.from_model(TestUserModel)
+
+        assert access is not None
+        assert access.name == "testusermodel_auth"
+        assert access.table == "TestUserModel"
+        assert access.signup_fields["email"] == "$email"
+        assert "crypto::argon2::generate($password)" in access.signup_fields["password"]
+
+    def test_returns_none_for_non_user_model(self, clean_registry: None) -> None:
+        """Test that None is returned for non-USER type models."""
+        clear_model_registry()
+
+        class RegularModel(BaseSurrealModel):
+            id: str | None = None
+            name: str
+
+        access = AccessGenerator.from_model(RegularModel)
+        assert access is None
+
+    def test_generate_all_user_models(self, clean_registry: None) -> None:
+        """Test generating access for all USER models."""
+        clear_model_registry()
+
+        class UserA(BaseSurrealModel):
+            model_config = SurrealConfigDict(table_type=TableType.USER)
+            id: str | None = None
+            email: str
+            password: Encrypted
+
+        class UserB(BaseSurrealModel):
+            model_config = SurrealConfigDict(table_type=TableType.USER)
+            id: str | None = None
+            username: str
+            password: Encrypted
+
+        class RegularModel(BaseSurrealModel):
+            id: str | None = None
+            data: str
+
+        definitions = AccessGenerator.generate_all([UserA, UserB, RegularModel])
+
+        assert len(definitions) == 2
+        names = [d.name for d in definitions]
+        assert "usera_auth" in names
+        assert "userb_auth" in names
+
+
+@pytest.mark.integration
+class TestAuthenticatedUserMixinIntegration:
+    """Integration tests for AuthenticatedUserMixin."""
+
+    async def test_create_auth_schema(self, clean_auth_database: None) -> None:
+        """Test creating authentication schema in database."""
+        client = await surreal_orm.SurrealDBConnectionManager.get_client()
+
+        # Create the table and access definition manually for testing
+        await client.query("""
+            DEFINE TABLE AuthUser SCHEMAFULL;
+            DEFINE FIELD email ON AuthUser TYPE string;
+            DEFINE FIELD password ON AuthUser TYPE string;
+            DEFINE FIELD name ON AuthUser TYPE string;
+            DEFINE INDEX email_unique ON AuthUser FIELDS email UNIQUE;
+        """)
+
+        access = AccessDefinition(
+            name="authuser_auth",
+            table="AuthUser",
+            signup_fields={
+                "email": "$email",
+                "password": "crypto::argon2::generate($password)",
+                "name": "$name",
+            },
+            signin_where="email = $email AND crypto::argon2::compare(password, $password)",
+        )
+
+        await client.query(access.to_surreal_ql())
+
+        # Verify access is defined
+        result = await client.query("INFO FOR DATABASE;")
+        assert result is not None
+
+    async def test_signup_creates_user_with_hashed_password(self, clean_auth_database: None) -> None:
+        """Test that signup creates user with properly hashed password."""
+        client = await surreal_orm.SurrealDBConnectionManager.get_client()
+
+        # Setup schema
+        await client.query("""
+            DEFINE TABLE TestUser SCHEMAFULL;
+            DEFINE FIELD email ON TestUser TYPE string;
+            DEFINE FIELD password ON TestUser TYPE string;
+            DEFINE FIELD name ON TestUser TYPE string;
+            DEFINE INDEX email_unique ON TestUser FIELDS email UNIQUE;
+
+            DEFINE ACCESS testuser_auth ON DATABASE TYPE RECORD
+                SIGNUP (CREATE TestUser SET
+                    email = $email,
+                    password = crypto::argon2::generate($password),
+                    name = $name
+                )
+                SIGNIN (SELECT * FROM TestUser WHERE
+                    email = $email AND
+                    crypto::argon2::compare(password, $password)
+                )
+                DURATION FOR TOKEN 15m, FOR SESSION 12h;
+        """)
+
+        # Create user via direct signup (simulating what AuthenticatedUserMixin.signup does)
+        response = await client.signup(
+            namespace=SURREALDB_NAMESPACE,
+            database=SURREALDB_DATABASE,
+            access="testuser_auth",
+            email="test@example.com",
+            password="secret123",
+            name="Test User",
+        )
+
+        assert response.success
+
+        # Reconnect as root to verify user was created (signup changes auth context to new user)
+        client = await surreal_orm.SurrealDBConnectionManager.reconnect()
+        assert client is not None
+
+        # Verify user was created with hashed password
+        result = await client.query("SELECT * FROM TestUser WHERE email = 'test@example.com';")
+        assert not result.is_empty
+
+        user = result.first
+        assert user["email"] == "test@example.com"
+        assert user["name"] == "Test User"
+        # Password should be hashed (starts with $argon2)
+        assert user["password"].startswith("$argon2")
+
+    async def test_signin_returns_token(self, clean_auth_database: None) -> None:
+        """Test that signin returns JWT token."""
+        client = await surreal_orm.SurrealDBConnectionManager.get_client()
+
+        # Setup schema and create user
+        await client.query("""
+            DEFINE TABLE TestUser SCHEMAFULL;
+            DEFINE FIELD email ON TestUser TYPE string;
+            DEFINE FIELD password ON TestUser TYPE string;
+            DEFINE FIELD name ON TestUser TYPE string;
+
+            DEFINE ACCESS testuser_auth ON DATABASE TYPE RECORD
+                SIGNUP (CREATE TestUser SET
+                    email = $email,
+                    password = crypto::argon2::generate($password),
+                    name = $name
+                )
+                SIGNIN (SELECT * FROM TestUser WHERE
+                    email = $email AND
+                    crypto::argon2::compare(password, $password)
+                )
+                DURATION FOR TOKEN 15m, FOR SESSION 12h;
+        """)
+
+        # Signup first
+        await client.signup(
+            namespace=SURREALDB_NAMESPACE,
+            database=SURREALDB_DATABASE,
+            access="testuser_auth",
+            email="signin_test@example.com",
+            password="mypassword",
+            name="Signin Test",
+        )
+
+        # Reconnect as root before signin (signup changes auth context)
+        client = await surreal_orm.SurrealDBConnectionManager.reconnect()
+        assert client is not None
+
+        # Now signin as the user (for record access, password goes in credentials, not as 'pass')
+        response = await client.signin(
+            namespace=SURREALDB_NAMESPACE,
+            database=SURREALDB_DATABASE,
+            access="testuser_auth",
+            email="signin_test@example.com",
+            password="mypassword",  # This goes into credentials as 'password'
+        )
+
+        assert response.success
+        assert response.token is not None
+        # JWT tokens have 3 parts separated by dots
+        assert len(response.token.split(".")) == 3
+
+    async def test_signin_fails_with_wrong_password(self, clean_auth_database: None) -> None:
+        """Test that signin fails with incorrect password."""
+        client = await surreal_orm.SurrealDBConnectionManager.get_client()
+
+        # Setup schema and create user
+        await client.query("""
+            DEFINE TABLE TestUser SCHEMAFULL;
+            DEFINE FIELD email ON TestUser TYPE string;
+            DEFINE FIELD password ON TestUser TYPE string;
+
+            DEFINE ACCESS testuser_auth ON DATABASE TYPE RECORD
+                SIGNUP (CREATE TestUser SET
+                    email = $email,
+                    password = crypto::argon2::generate($password)
+                )
+                SIGNIN (SELECT * FROM TestUser WHERE
+                    email = $email AND
+                    crypto::argon2::compare(password, $password)
+                )
+                DURATION FOR TOKEN 15m, FOR SESSION 12h;
+        """)
+
+        # Signup
+        await client.signup(
+            namespace=SURREALDB_NAMESPACE,
+            database=SURREALDB_DATABASE,
+            access="testuser_auth",
+            email="wrong_pass@example.com",
+            password="correct_password",
+        )
+
+        # Reconnect as root before signin (signup changes auth context)
+        client = await surreal_orm.SurrealDBConnectionManager.reconnect()
+        assert client is not None
+
+        # Try signin with wrong password - should fail
+        from surreal_sdk.exceptions import AuthenticationError
+
+        try:
+            response = await client.signin(
+                namespace=SURREALDB_NAMESPACE,
+                database=SURREALDB_DATABASE,
+                access="testuser_auth",
+                email="wrong_pass@example.com",
+                password="wrong_password",
+            )
+            # If no exception, check that it failed
+            assert response.success is False or response.token is None
+        except AuthenticationError:
+            # Expected - wrong password should cause auth failure
+            pass
+
+
+@pytest.mark.integration
+class TestAuthWithModel:
+    """Integration tests combining auth with ORM models."""
+
+    async def test_full_auth_workflow(self, clean_auth_database: None) -> None:
+        """Test complete authentication workflow with model."""
+        client = await surreal_orm.SurrealDBConnectionManager.get_client()
+
+        # Define model (simulating what would be in user's code)
+        clear_model_registry()
+
+        class AppUser(AuthenticatedUserMixin, BaseSurrealModel):
+            model_config = SurrealConfigDict(
+                table_type=TableType.USER,
+                table_name="AppUser",
+                identifier_field="email",
+                password_field="password",
+            )
+            id: str | None = None
+            email: str
+            password: Encrypted
+            name: str
+            is_active: bool = True
+
+        # Setup schema manually (in real usage, this would be done via migrations)
+        await client.query("""
+            DEFINE TABLE AppUser SCHEMAFULL;
+            DEFINE FIELD email ON AppUser TYPE string;
+            DEFINE FIELD password ON AppUser TYPE string;
+            DEFINE FIELD name ON AppUser TYPE string;
+            DEFINE FIELD is_active ON AppUser TYPE bool DEFAULT true;
+            DEFINE INDEX email_unique ON AppUser FIELDS email UNIQUE;
+
+            DEFINE ACCESS appuser_auth ON DATABASE TYPE RECORD
+                SIGNUP (CREATE AppUser SET
+                    email = $email,
+                    password = crypto::argon2::generate($password),
+                    name = $name,
+                    is_active = true
+                )
+                SIGNIN (SELECT * FROM AppUser WHERE
+                    email = $email AND
+                    crypto::argon2::compare(password, $password)
+                )
+                DURATION FOR TOKEN 1h, FOR SESSION 24h;
+        """)
+
+        # Test signup via SDK (simulating AuthenticatedUserMixin.signup)
+        signup_response = await client.signup(
+            namespace=SURREALDB_NAMESPACE,
+            database=SURREALDB_DATABASE,
+            access="appuser_auth",
+            email="fulltest@example.com",
+            password="secure123",
+            name="Full Test User",
+        )
+
+        assert signup_response.success
+
+        # Reconnect as root before signin (signup changes auth context)
+        client = await surreal_orm.SurrealDBConnectionManager.reconnect()
+        assert client is not None
+
+        # Test signin via SDK (simulating AuthenticatedUserMixin.signin)
+        signin_response = await client.signin(
+            namespace=SURREALDB_NAMESPACE,
+            database=SURREALDB_DATABASE,
+            access="appuser_auth",
+            email="fulltest@example.com",
+            password="secure123",
+        )
+
+        assert signin_response.success
+        assert signin_response.token is not None
+
+        # Reconnect as root to query the table (signin changes auth context)
+        client = await surreal_orm.SurrealDBConnectionManager.reconnect()
+        assert client is not None
+
+        # Fetch user data
+        result = await client.query("SELECT * FROM AppUser WHERE email = 'fulltest@example.com';")
+
+        assert not result.is_empty
+        user_data = result.first
+
+        # Create model instance from DB data
+        user = AppUser.from_db(user_data)
+        assert user.email == "fulltest@example.com"
+        assert user.name == "Full Test User"
+        assert user.is_active is True

--- a/tests/test_auth_unit.py
+++ b/tests/test_auth_unit.py
@@ -1,0 +1,620 @@
+"""
+Unit tests for authentication modules.
+
+Tests AccessDefinition, AccessGenerator, and AuthenticatedUserMixin
+using mocks instead of real database connections.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+import sys
+
+from src.surreal_orm.auth.access import AccessDefinition, AccessGenerator
+from src.surreal_orm.auth.mixins import AuthenticatedUserMixin
+from src.surreal_orm.model_base import (
+    BaseSurrealModel,
+    SurrealConfigDict,
+    SurrealDbError,
+    clear_model_registry,
+)
+from src.surreal_orm.types import EncryptionAlgorithm, TableType
+from src.surreal_orm.fields import Encrypted
+
+
+@pytest.fixture(autouse=True)
+def clear_registry() -> None:
+    """Clear model registry before each test."""
+    clear_model_registry()
+
+
+class TestAccessDefinition:
+    """Tests for AccessDefinition dataclass."""
+
+    def test_basic_creation(self) -> None:
+        """Test creating a basic access definition."""
+        access = AccessDefinition(
+            name="user_auth",
+            table="User",
+            signup_fields={"email": "$email", "password": "crypto::argon2::generate($password)"},
+        )
+
+        assert access.name == "user_auth"
+        assert access.table == "User"
+        assert access.identifier_field == "email"  # Default
+        assert access.password_field == "password"  # Default
+        assert access.duration_token == "15m"  # Default
+        assert access.duration_session == "12h"  # Default
+        assert access.algorithm == EncryptionAlgorithm.ARGON2  # Default
+
+    def test_custom_fields(self) -> None:
+        """Test access definition with custom fields."""
+        access = AccessDefinition(
+            name="admin_auth",
+            table="Admin",
+            identifier_field="username",
+            password_field="secret",
+            duration_token="1h",
+            duration_session="24h",
+            algorithm=EncryptionAlgorithm.BCRYPT,
+            signup_fields={
+                "username": "$username",
+                "secret": "crypto::bcrypt::generate($secret)",
+            },
+        )
+
+        assert access.identifier_field == "username"
+        assert access.password_field == "secret"
+        assert access.duration_token == "1h"
+        assert access.duration_session == "24h"
+        assert access.algorithm == EncryptionAlgorithm.BCRYPT
+
+    def test_signin_where_auto_generated(self) -> None:
+        """Test that signin_where is auto-generated if not provided."""
+        access = AccessDefinition(
+            name="user_auth",
+            table="User",
+            identifier_field="email",
+            password_field="password",
+            signup_fields={"email": "$email"},
+        )
+
+        assert access.signin_where is not None
+        assert "email = $email" in access.signin_where
+        assert "crypto::argon2::compare(password, $password)" in access.signin_where
+
+    def test_signin_where_custom(self) -> None:
+        """Test custom signin_where is preserved."""
+        custom_where = "email = $email AND is_active = true AND crypto::argon2::compare(password, $password)"
+        access = AccessDefinition(
+            name="user_auth",
+            table="User",
+            signin_where=custom_where,
+            signup_fields={"email": "$email"},
+        )
+
+        assert access.signin_where == custom_where
+
+    def test_to_surreal_ql(self) -> None:
+        """Test generating SurrealQL from access definition."""
+        access = AccessDefinition(
+            name="user_auth",
+            table="User",
+            signup_fields={
+                "email": "$email",
+                "password": "crypto::argon2::generate($password)",
+                "name": "$name",
+            },
+            signin_where="email = $email AND crypto::argon2::compare(password, $password)",
+            duration_token="30m",
+            duration_session="8h",
+        )
+
+        sql = access.to_surreal_ql()
+
+        assert "DEFINE ACCESS user_auth ON DATABASE TYPE RECORD" in sql
+        assert "SIGNUP (CREATE User SET" in sql
+        assert "email = $email" in sql
+        assert "crypto::argon2::generate($password)" in sql
+        assert "name = $name" in sql
+        assert "SIGNIN (SELECT * FROM User WHERE" in sql
+        assert "crypto::argon2::compare(password, $password)" in sql
+        assert "DURATION FOR TOKEN 30m, FOR SESSION 8h" in sql
+
+    def test_to_remove_ql(self) -> None:
+        """Test generating REMOVE ACCESS statement."""
+        access = AccessDefinition(
+            name="user_auth",
+            table="User",
+            signup_fields={"email": "$email"},
+        )
+
+        sql = access.to_remove_ql()
+        assert sql == "REMOVE ACCESS user_auth ON DATABASE;"
+
+    def test_different_algorithms(self) -> None:
+        """Test access definition with different algorithms."""
+        for algo in EncryptionAlgorithm:
+            access = AccessDefinition(
+                name="test_auth",
+                table="Test",
+                algorithm=algo,
+                signup_fields={"password": f"crypto::{algo}::generate($password)"},
+            )
+            sql = access.to_surreal_ql()
+            assert f"crypto::{algo}" in sql
+
+
+class TestAccessGenerator:
+    """Tests for AccessGenerator class."""
+
+    def test_from_user_model(self) -> None:
+        """Test generating access from USER type model."""
+
+        class TestUser(BaseSurrealModel):
+            model_config = SurrealConfigDict(
+                table_type=TableType.USER,
+                identifier_field="email",
+                password_field="password",
+            )
+            id: str | None = None
+            email: str
+            password: Encrypted
+            name: str
+
+        access = AccessGenerator.from_model(TestUser)
+
+        assert access is not None
+        assert access.name == "testuser_auth"
+        assert access.table == "TestUser"
+        assert access.identifier_field == "email"
+        assert access.password_field == "password"
+        assert "email" in access.signup_fields
+        assert "password" in access.signup_fields
+        assert "name" in access.signup_fields
+        assert "crypto::argon2::generate($password)" in access.signup_fields["password"]
+
+    def test_from_non_user_model(self) -> None:
+        """Test that non-USER models return None."""
+
+        class RegularModel(BaseSurrealModel):
+            id: str | None = None
+            name: str
+
+        access = AccessGenerator.from_model(RegularModel)
+        assert access is None
+
+    def test_from_stream_model(self) -> None:
+        """Test that STREAM models return None."""
+
+        class StreamModel(BaseSurrealModel):
+            model_config = SurrealConfigDict(table_type=TableType.STREAM)
+            id: str | None = None
+            data: str
+
+        access = AccessGenerator.from_model(StreamModel)
+        assert access is None
+
+    def test_custom_table_name(self) -> None:
+        """Test access generation with custom table name."""
+
+        class MyUser(BaseSurrealModel):
+            model_config = SurrealConfigDict(
+                table_type=TableType.USER,
+                table_name="app_users",
+            )
+            id: str | None = None
+            email: str
+            password: Encrypted
+
+        access = AccessGenerator.from_model(MyUser)
+
+        assert access is not None
+        assert access.name == "app_users_auth"
+        assert access.table == "app_users"
+
+    def test_custom_identifier_field(self) -> None:
+        """Test access generation with custom identifier field."""
+
+        class AdminUser(BaseSurrealModel):
+            model_config = SurrealConfigDict(
+                table_type=TableType.USER,
+                identifier_field="username",
+            )
+            id: str | None = None
+            username: str
+            password: Encrypted
+
+        access = AccessGenerator.from_model(AdminUser)
+
+        assert access is not None
+        assert access.identifier_field == "username"
+        assert "username = $username" in access.signin_where
+
+    def test_custom_durations(self) -> None:
+        """Test access generation with custom durations."""
+
+        class SecureUser(BaseSurrealModel):
+            model_config = SurrealConfigDict(
+                table_type=TableType.USER,
+                token_duration="5m",
+                session_duration="1h",
+            )
+            id: str | None = None
+            email: str
+            password: Encrypted
+
+        access = AccessGenerator.from_model(SecureUser)
+
+        assert access is not None
+        assert access.duration_token == "5m"
+        assert access.duration_session == "1h"
+
+    def test_adds_created_at(self) -> None:
+        """Test that created_at is added to signup fields."""
+
+        class SimpleUser(BaseSurrealModel):
+            model_config = SurrealConfigDict(table_type=TableType.USER)
+            id: str | None = None
+            email: str
+            password: Encrypted
+
+        access = AccessGenerator.from_model(SimpleUser)
+
+        assert access is not None
+        assert "created_at" in access.signup_fields
+        assert access.signup_fields["created_at"] == "time::now()"
+
+    def test_generate_all(self) -> None:
+        """Test generating access for all USER models."""
+
+        class UserA(BaseSurrealModel):
+            model_config = SurrealConfigDict(table_type=TableType.USER)
+            id: str | None = None
+            email: str
+            password: Encrypted
+
+        class UserB(BaseSurrealModel):
+            model_config = SurrealConfigDict(table_type=TableType.USER)
+            id: str | None = None
+            username: str
+            password: Encrypted
+
+        class RegularModel(BaseSurrealModel):
+            id: str | None = None
+            data: str
+
+        definitions = AccessGenerator.generate_all([UserA, UserB, RegularModel])
+
+        assert len(definitions) == 2
+        names = [d.name for d in definitions]
+        assert "usera_auth" in names
+        assert "userb_auth" in names
+
+    def test_generate_all_empty(self) -> None:
+        """Test generate_all with no USER models."""
+
+        class RegularModel(BaseSurrealModel):
+            id: str | None = None
+            data: str
+
+        definitions = AccessGenerator.generate_all([RegularModel])
+        assert definitions == []
+
+
+class TestAuthenticatedUserMixin:
+    """Tests for AuthenticatedUserMixin methods."""
+
+    def test_get_access_name(self) -> None:
+        """Test get_access_name method."""
+
+        class TestUser(AuthenticatedUserMixin, BaseSurrealModel):
+            model_config = SurrealConfigDict(table_type=TableType.USER)
+            id: str | None = None
+            email: str
+            password: Encrypted
+
+        assert TestUser.get_access_name() == "testuser_auth"
+
+    def test_get_access_name_custom_table(self) -> None:
+        """Test get_access_name with custom table name."""
+
+        class CustomUser(AuthenticatedUserMixin, BaseSurrealModel):
+            model_config = SurrealConfigDict(
+                table_type=TableType.USER,
+                table_name="my_users",
+            )
+            id: str | None = None
+            email: str
+            password: Encrypted
+
+        assert CustomUser.get_access_name() == "my_users_auth"
+
+
+class TestAuthenticatedUserMixinAsync:
+    """Async tests for AuthenticatedUserMixin - mocking connection manager."""
+
+    @pytest.fixture
+    def mock_connection_manager(self):
+        """Create mock for SurrealDBConnectionManager."""
+        mock_client = AsyncMock()
+
+        # Create mock manager
+        mock_manager = MagicMock()
+        mock_manager.get_client = AsyncMock(return_value=mock_client)
+        mock_manager.get_namespace = MagicMock(return_value="test_ns")
+        mock_manager.get_database = MagicMock(return_value="test_db")
+
+        return mock_manager, mock_client
+
+    @pytest.mark.asyncio
+    async def test_signup_success(self, mock_connection_manager) -> None:
+        """Test successful signup."""
+        mock_manager, mock_client = mock_connection_manager
+
+        # Mock signup response
+        mock_response = MagicMock()
+        mock_response.success = True
+        mock_response.raw = {}
+        mock_client.signup = AsyncMock(return_value=mock_response)
+
+        # Mock query response
+        mock_result = MagicMock()
+        mock_result.is_empty = False
+        mock_result.first = {
+            "id": "TestUser:123",
+            "email": "test@example.com",
+            "name": "Test User",
+        }
+        mock_client.query = AsyncMock(return_value=mock_result)
+
+        class TestUser(AuthenticatedUserMixin, BaseSurrealModel):
+            model_config = SurrealConfigDict(table_type=TableType.USER)
+            id: str | None = None
+            email: str
+            password: Encrypted
+            name: str
+
+        with patch.dict(
+            sys.modules, {"src.surreal_orm.connection_manager": MagicMock(SurrealDBConnectionManager=mock_manager)}
+        ):
+            # Patch the import inside the method
+            with patch.object(TestUser, "signup", new=AsyncMock()) as mock_signup:
+                mock_signup.return_value = TestUser(
+                    id="TestUser:123", email="test@example.com", name="Test User", password="hashed"
+                )
+
+                user = await TestUser.signup(
+                    email="test@example.com",
+                    password="secret123",
+                    name="Test User",
+                )
+
+                assert user is not None
+                assert user.email == "test@example.com"
+
+    @pytest.mark.asyncio
+    async def test_signin_success(self, mock_connection_manager) -> None:
+        """Test successful signin."""
+        mock_manager, mock_client = mock_connection_manager
+
+        class TestUser(AuthenticatedUserMixin, BaseSurrealModel):
+            model_config = SurrealConfigDict(table_type=TableType.USER)
+            id: str | None = None
+            email: str
+            password: Encrypted
+            name: str
+
+        # Mock signin method
+        with patch.object(TestUser, "signin", new=AsyncMock()) as mock_signin:
+            mock_user = TestUser(id="TestUser:123", email="test@example.com", name="Test User", password="hashed")
+            mock_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test.signature"
+            mock_signin.return_value = (mock_user, mock_token)
+
+            user, token = await TestUser.signin(
+                email="test@example.com",
+                password="secret123",
+            )
+
+            assert user is not None
+            assert user.email == "test@example.com"
+            assert token.startswith("eyJ")
+
+    @pytest.mark.asyncio
+    async def test_authenticate_token_success(self, mock_connection_manager) -> None:
+        """Test successful token authentication."""
+
+        class TestUser(AuthenticatedUserMixin, BaseSurrealModel):
+            model_config = SurrealConfigDict(table_type=TableType.USER)
+            id: str | None = None
+            email: str
+            password: Encrypted
+
+        with patch.object(TestUser, "authenticate_token", new=AsyncMock()) as mock_auth:
+            mock_auth.return_value = TestUser(id="TestUser:123", email="test@example.com", password="hashed")
+
+            user = await TestUser.authenticate_token("valid_token")
+
+            assert user is not None
+            assert user.email == "test@example.com"
+
+    @pytest.mark.asyncio
+    async def test_authenticate_token_invalid(self, mock_connection_manager) -> None:
+        """Test invalid token returns None."""
+
+        class TestUser(AuthenticatedUserMixin, BaseSurrealModel):
+            model_config = SurrealConfigDict(table_type=TableType.USER)
+            id: str | None = None
+            email: str
+            password: Encrypted
+
+        with patch.object(TestUser, "authenticate_token", new=AsyncMock()) as mock_auth:
+            mock_auth.return_value = None
+
+            user = await TestUser.authenticate_token("invalid_token")
+            assert user is None
+
+    @pytest.mark.asyncio
+    async def test_change_password_success(self, mock_connection_manager) -> None:
+        """Test successful password change."""
+
+        class TestUser(AuthenticatedUserMixin, BaseSurrealModel):
+            model_config = SurrealConfigDict(table_type=TableType.USER)
+            id: str | None = None
+            email: str
+            password: Encrypted
+
+        with patch.object(TestUser, "change_password", new=AsyncMock()) as mock_change:
+            mock_change.return_value = True
+
+            result = await TestUser.change_password(
+                identifier_value="test@example.com",
+                old_password="old_pass",
+                new_password="new_pass",
+            )
+
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_change_password_wrong_old_password(self, mock_connection_manager) -> None:
+        """Test password change fails with wrong old password."""
+
+        class TestUser(AuthenticatedUserMixin, BaseSurrealModel):
+            model_config = SurrealConfigDict(table_type=TableType.USER)
+            id: str | None = None
+            email: str
+            password: Encrypted
+
+        with patch.object(TestUser, "change_password", new=AsyncMock()) as mock_change:
+            mock_change.side_effect = SurrealDbError("Invalid current password")
+
+            with pytest.raises(SurrealDbError):
+                await TestUser.change_password(
+                    identifier_value="test@example.com",
+                    old_password="wrong_old",
+                    new_password="new_pass",
+                )
+
+
+class TestAccessDefinitionEquality:
+    """Tests for AccessDefinition comparison."""
+
+    def test_equal_definitions(self) -> None:
+        """Test two identical definitions are equal."""
+        access1 = AccessDefinition(
+            name="user_auth",
+            table="User",
+            signup_fields={"email": "$email"},
+            signin_where="email = $email",
+        )
+        access2 = AccessDefinition(
+            name="user_auth",
+            table="User",
+            signup_fields={"email": "$email"},
+            signin_where="email = $email",
+        )
+
+        assert access1 == access2
+
+    def test_different_names(self) -> None:
+        """Test definitions with different names are not equal."""
+        access1 = AccessDefinition(
+            name="user_auth",
+            table="User",
+            signup_fields={"email": "$email"},
+        )
+        access2 = AccessDefinition(
+            name="admin_auth",
+            table="User",
+            signup_fields={"email": "$email"},
+        )
+
+        assert access1 != access2
+
+    def test_different_durations(self) -> None:
+        """Test definitions with different durations are not equal."""
+        access1 = AccessDefinition(
+            name="user_auth",
+            table="User",
+            duration_token="15m",
+            signup_fields={"email": "$email"},
+        )
+        access2 = AccessDefinition(
+            name="user_auth",
+            table="User",
+            duration_token="1h",
+            signup_fields={"email": "$email"},
+        )
+
+        assert access1 != access2
+
+
+class TestAccessDefinitionSQLGeneration:
+    """Tests for SQL generation edge cases."""
+
+    def test_sql_with_special_characters_in_table(self) -> None:
+        """Test SQL generation with table name."""
+        access = AccessDefinition(
+            name="user_auth",
+            table="MyTable",
+            signup_fields={"email": "$email"},
+        )
+        sql = access.to_surreal_ql()
+        assert "CREATE MyTable SET" in sql
+
+    def test_sql_with_multiple_signup_fields(self) -> None:
+        """Test SQL with many signup fields."""
+        access = AccessDefinition(
+            name="user_auth",
+            table="User",
+            signup_fields={
+                "email": "$email",
+                "password": "crypto::argon2::generate($password)",
+                "name": "$name",
+                "role": "'user'",
+                "created_at": "time::now()",
+            },
+        )
+        sql = access.to_surreal_ql()
+
+        # All fields should be in the signup
+        assert "email = $email" in sql
+        assert "password = crypto::argon2::generate($password)" in sql
+        assert "name = $name" in sql
+        assert "role = 'user'" in sql
+        assert "created_at = time::now()" in sql
+
+    def test_sql_with_bcrypt(self) -> None:
+        """Test SQL generation with bcrypt algorithm."""
+        access = AccessDefinition(
+            name="user_auth",
+            table="User",
+            algorithm=EncryptionAlgorithm.BCRYPT,
+            signup_fields={"password": "crypto::bcrypt::generate($password)"},
+        )
+        sql = access.to_surreal_ql()
+
+        assert "crypto::bcrypt::compare(password, $password)" in sql
+
+    def test_sql_with_pbkdf2(self) -> None:
+        """Test SQL generation with pbkdf2 algorithm."""
+        access = AccessDefinition(
+            name="user_auth",
+            table="User",
+            algorithm=EncryptionAlgorithm.PBKDF2,
+            signup_fields={"password": "crypto::pbkdf2::generate($password)"},
+        )
+        sql = access.to_surreal_ql()
+
+        assert "crypto::pbkdf2::compare(password, $password)" in sql
+
+    def test_sql_with_scrypt(self) -> None:
+        """Test SQL generation with scrypt algorithm."""
+        access = AccessDefinition(
+            name="user_auth",
+            table="User",
+            algorithm=EncryptionAlgorithm.SCRYPT,
+            signup_fields={"password": "crypto::scrypt::generate($password)"},
+        )
+        sql = access.to_surreal_ql()
+
+        assert "crypto::scrypt::compare(password, $password)" in sql

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,427 @@
+"""
+Unit tests for CLI commands.
+
+Uses Click's CliRunner for testing CLI commands without database connections.
+"""
+
+import tempfile
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Check if click is available
+try:
+    from click.testing import CliRunner
+
+    click_available = True
+except ImportError:
+    click_available = False
+
+
+pytestmark = pytest.mark.skipif(not click_available, reason="click not installed")
+
+
+@pytest.fixture
+def runner() -> "CliRunner":
+    """Create a CliRunner for testing."""
+    from click.testing import CliRunner
+
+    return CliRunner()
+
+
+@pytest.fixture
+def temp_migrations_dir() -> Path:
+    """Create a temporary migrations directory."""
+    temp_dir = Path(tempfile.mkdtemp())
+    yield temp_dir
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def cli_command():
+    """Import CLI command."""
+    from src.surreal_orm.cli.commands import cli
+
+    return cli
+
+
+class TestCliBasics:
+    """Tests for basic CLI functionality."""
+
+    def test_cli_help(self, runner: "CliRunner", cli_command) -> None:
+        """Test CLI --help shows usage."""
+        result = runner.invoke(cli_command, ["--help"])
+        assert result.exit_code == 0
+        assert "SurrealDB ORM migration management tool" in result.output
+
+    def test_cli_version_options(self, runner: "CliRunner", cli_command) -> None:
+        """Test CLI accepts connection options."""
+        result = runner.invoke(
+            cli_command,
+            ["--url", "http://localhost:8000", "--namespace", "test", "--database", "test", "--help"],
+        )
+        assert result.exit_code == 0
+
+
+class TestMakeMigrationsCommand:
+    """Tests for makemigrations command."""
+
+    def test_makemigrations_help(self, runner: "CliRunner", cli_command) -> None:
+        """Test makemigrations --help."""
+        result = runner.invoke(cli_command, ["makemigrations", "--help"])
+        assert result.exit_code == 0
+        assert "Generate migration files" in result.output
+
+    def test_makemigrations_empty(self, runner: "CliRunner", cli_command, temp_migrations_dir: Path) -> None:
+        """Test creating empty migration."""
+        result = runner.invoke(
+            cli_command,
+            [
+                "--migrations-dir",
+                str(temp_migrations_dir),
+                "makemigrations",
+                "--name",
+                "test_migration",
+                "--empty",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Created empty migration" in result.output
+        # Verify file was created
+        migration_files = list(temp_migrations_dir.glob("*.py"))
+        assert len(migration_files) >= 1  # At least __init__.py and migration file
+
+    def test_makemigrations_requires_name(self, runner: "CliRunner", cli_command) -> None:
+        """Test that makemigrations requires --name."""
+        result = runner.invoke(cli_command, ["makemigrations"])
+        assert result.exit_code != 0
+        assert "Missing option" in result.output or "required" in result.output.lower()
+
+    def test_makemigrations_no_models(self, runner: "CliRunner", cli_command, temp_migrations_dir: Path) -> None:
+        """Test makemigrations with no models registered."""
+        # Clear model registry
+        from src.surreal_orm.model_base import clear_model_registry
+
+        clear_model_registry()
+
+        result = runner.invoke(
+            cli_command,
+            [
+                "--migrations-dir",
+                str(temp_migrations_dir),
+                "makemigrations",
+                "--name",
+                "initial",
+            ],
+        )
+        # Should fail or warn about no models
+        assert "No models found" in result.output or result.exit_code != 0
+
+    def test_makemigrations_with_model(self, runner: "CliRunner", cli_command, temp_migrations_dir: Path) -> None:
+        """Test makemigrations detects model changes."""
+        from src.surreal_orm.model_base import BaseSurrealModel, clear_model_registry
+
+        clear_model_registry()
+
+        # Define a model
+        class TestUser(BaseSurrealModel):
+            id: str | None = None
+            name: str
+            email: str
+
+        result = runner.invoke(
+            cli_command,
+            [
+                "--migrations-dir",
+                str(temp_migrations_dir),
+                "makemigrations",
+                "--name",
+                "create_user",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Created migration" in result.output
+        assert "Operations" in result.output
+
+        # Clean up
+        clear_model_registry()
+
+
+class TestMigrateCommand:
+    """Tests for migrate command."""
+
+    def test_migrate_help(self, runner: "CliRunner", cli_command) -> None:
+        """Test migrate --help."""
+        result = runner.invoke(cli_command, ["migrate", "--help"])
+        assert result.exit_code == 0
+        assert "Apply pending schema migrations" in result.output
+
+    @patch("src.surreal_orm.cli.commands.run_async")
+    def test_migrate_no_migrations(self, mock_run_async, runner: "CliRunner", cli_command, temp_migrations_dir: Path) -> None:
+        """Test migrate with no pending migrations."""
+        mock_run_async.return_value = []
+
+        result = runner.invoke(
+            cli_command,
+            [
+                "--migrations-dir",
+                str(temp_migrations_dir),
+                "--namespace",
+                "test",
+                "--database",
+                "test",
+                "migrate",
+            ],
+        )
+        # Should handle gracefully
+        assert "No migrations to apply" in result.output or result.exit_code == 0
+
+    @patch("src.surreal_orm.cli.commands.run_async")
+    def test_migrate_applies_migrations(
+        self, mock_run_async, runner: "CliRunner", cli_command, temp_migrations_dir: Path
+    ) -> None:
+        """Test migrate applies pending migrations."""
+        mock_run_async.return_value = ["0001_initial", "0002_add_field"]
+
+        result = runner.invoke(
+            cli_command,
+            [
+                "--migrations-dir",
+                str(temp_migrations_dir),
+                "--namespace",
+                "test",
+                "--database",
+                "test",
+                "migrate",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Applied 2 migration" in result.output
+        assert "0001_initial" in result.output
+        assert "0002_add_field" in result.output
+
+    @patch("src.surreal_orm.cli.commands.run_async")
+    def test_migrate_with_fake(self, mock_run_async, runner: "CliRunner", cli_command, temp_migrations_dir: Path) -> None:
+        """Test migrate --fake option."""
+        mock_run_async.return_value = ["0001_initial"]
+
+        result = runner.invoke(
+            cli_command,
+            [
+                "--migrations-dir",
+                str(temp_migrations_dir),
+                "--namespace",
+                "test",
+                "--database",
+                "test",
+                "migrate",
+                "--fake",
+            ],
+        )
+        assert result.exit_code == 0
+
+
+class TestUpgradeCommand:
+    """Tests for upgrade command."""
+
+    def test_upgrade_help(self, runner: "CliRunner", cli_command) -> None:
+        """Test upgrade --help."""
+        result = runner.invoke(cli_command, ["upgrade", "--help"])
+        assert result.exit_code == 0
+        assert "Apply data migrations" in result.output
+
+    @patch("src.surreal_orm.cli.commands.run_async")
+    def test_upgrade_applies_data_migrations(
+        self, mock_run_async, runner: "CliRunner", cli_command, temp_migrations_dir: Path
+    ) -> None:
+        """Test upgrade applies data migrations."""
+        mock_run_async.return_value = ["0001_initial"]
+
+        result = runner.invoke(
+            cli_command,
+            [
+                "--migrations-dir",
+                str(temp_migrations_dir),
+                "--namespace",
+                "test",
+                "--database",
+                "test",
+                "upgrade",
+            ],
+        )
+        assert result.exit_code == 0
+
+
+class TestRollbackCommand:
+    """Tests for rollback command."""
+
+    def test_rollback_help(self, runner: "CliRunner", cli_command) -> None:
+        """Test rollback --help."""
+        result = runner.invoke(cli_command, ["rollback", "--help"])
+        assert result.exit_code == 0
+        assert "Rollback migrations" in result.output
+
+    def test_rollback_requires_target(self, runner: "CliRunner", cli_command) -> None:
+        """Test that rollback requires target argument."""
+        result = runner.invoke(cli_command, ["rollback"])
+        assert result.exit_code != 0
+        assert "Missing argument" in result.output or "TARGET" in result.output
+
+    @patch("src.surreal_orm.cli.commands.run_async")
+    def test_rollback_to_target(self, mock_run_async, runner: "CliRunner", cli_command, temp_migrations_dir: Path) -> None:
+        """Test rollback to specific target."""
+        mock_run_async.return_value = ["0003_third", "0002_second"]
+
+        result = runner.invoke(
+            cli_command,
+            [
+                "--migrations-dir",
+                str(temp_migrations_dir),
+                "--namespace",
+                "test",
+                "--database",
+                "test",
+                "rollback",
+                "0001_initial",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Rolled back 2 migration" in result.output
+
+
+class TestStatusCommand:
+    """Tests for status command."""
+
+    def test_status_help(self, runner: "CliRunner", cli_command) -> None:
+        """Test status --help."""
+        result = runner.invoke(cli_command, ["status", "--help"])
+        assert result.exit_code == 0
+        assert "Show migration status" in result.output
+
+    @patch("src.surreal_orm.cli.commands.run_async")
+    def test_status_no_migrations(self, mock_run_async, runner: "CliRunner", cli_command, temp_migrations_dir: Path) -> None:
+        """Test status with no migrations."""
+        mock_run_async.return_value = {}
+
+        result = runner.invoke(
+            cli_command,
+            [
+                "--migrations-dir",
+                str(temp_migrations_dir),
+                "--namespace",
+                "test",
+                "--database",
+                "test",
+                "status",
+            ],
+        )
+        assert "No migrations found" in result.output
+
+    @patch("src.surreal_orm.cli.commands.run_async")
+    def test_status_shows_migrations(self, mock_run_async, runner: "CliRunner", cli_command, temp_migrations_dir: Path) -> None:
+        """Test status shows migration list."""
+        mock_run_async.return_value = {
+            "0001_initial": {"applied": True, "reversible": True, "has_data": False, "operations": 3},
+            "0002_add_field": {"applied": False, "reversible": True, "has_data": True, "operations": 1},
+        }
+
+        result = runner.invoke(
+            cli_command,
+            [
+                "--migrations-dir",
+                str(temp_migrations_dir),
+                "--namespace",
+                "test",
+                "--database",
+                "test",
+                "status",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Migration status" in result.output
+        assert "0001_initial" in result.output
+        assert "0002_add_field" in result.output
+        assert "[X]" in result.output  # Applied marker
+        assert "[ ]" in result.output  # Not applied marker
+
+
+class TestSqlMigrateCommand:
+    """Tests for sqlmigrate command."""
+
+    def test_sqlmigrate_help(self, runner: "CliRunner", cli_command) -> None:
+        """Test sqlmigrate --help."""
+        result = runner.invoke(cli_command, ["sqlmigrate", "--help"])
+        assert result.exit_code == 0
+        assert "Show SQL for MIGRATION" in result.output
+
+    def test_sqlmigrate_requires_migration(self, runner: "CliRunner", cli_command) -> None:
+        """Test that sqlmigrate requires migration argument."""
+        result = runner.invoke(cli_command, ["sqlmigrate"])
+        assert result.exit_code != 0
+
+    @patch("src.surreal_orm.cli.commands.run_async")
+    def test_sqlmigrate_shows_sql(self, mock_run_async, runner: "CliRunner", cli_command, temp_migrations_dir: Path) -> None:
+        """Test sqlmigrate shows SQL."""
+        mock_run_async.return_value = "DEFINE TABLE users SCHEMAFULL;\nDEFINE FIELD name ON users TYPE string;"
+
+        result = runner.invoke(
+            cli_command,
+            [
+                "--migrations-dir",
+                str(temp_migrations_dir),
+                "sqlmigrate",
+                "0001_initial",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "DEFINE TABLE" in result.output
+
+    @patch("src.surreal_orm.cli.commands.run_async")
+    def test_sqlmigrate_not_found(self, mock_run_async, runner: "CliRunner", cli_command, temp_migrations_dir: Path) -> None:
+        """Test sqlmigrate with non-existent migration."""
+        mock_run_async.side_effect = FileNotFoundError("Migration not found")
+
+        result = runner.invoke(
+            cli_command,
+            [
+                "--migrations-dir",
+                str(temp_migrations_dir),
+                "sqlmigrate",
+                "nonexistent",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+
+class TestEnvironmentVariables:
+    """Tests for environment variable support."""
+
+    def test_url_from_env(self, runner: "CliRunner", cli_command) -> None:
+        """Test SURREAL_URL environment variable."""
+        result = runner.invoke(
+            cli_command,
+            ["--help"],
+            env={"SURREAL_URL": "http://custom:9000"},
+        )
+        assert result.exit_code == 0
+
+    def test_namespace_from_env(self, runner: "CliRunner", cli_command) -> None:
+        """Test SURREAL_NAMESPACE environment variable."""
+        result = runner.invoke(
+            cli_command,
+            ["--help"],
+            env={"SURREAL_NAMESPACE": "myns"},
+        )
+        assert result.exit_code == 0
+
+    def test_database_from_env(self, runner: "CliRunner", cli_command) -> None:
+        """Test SURREAL_DATABASE environment variable."""
+        result = runner.invoke(
+            cli_command,
+            ["--help"],
+            env={"SURREAL_DATABASE": "mydb"},
+        )
+        assert result.exit_code == 0

--- a/tests/test_encrypted_field.py
+++ b/tests/test_encrypted_field.py
@@ -1,0 +1,157 @@
+"""
+Unit tests for Encrypted field type.
+"""
+
+from pydantic import BaseModel
+
+from src.surreal_orm.fields.encrypted import (
+    Encrypted,
+    EncryptedField,
+    EncryptedFieldInfo,
+    get_encryption_info,
+    is_encrypted_field,
+)
+from src.surreal_orm.types import EncryptionAlgorithm
+
+
+class TestEncryptedFieldInfo:
+    """Tests for EncryptedFieldInfo dataclass."""
+
+    def test_default_algorithm(self) -> None:
+        """Test default encryption algorithm is argon2."""
+        info = EncryptedFieldInfo()
+        assert info.algorithm == EncryptionAlgorithm.ARGON2
+
+    def test_custom_algorithm(self) -> None:
+        """Test setting custom encryption algorithm."""
+        info = EncryptedFieldInfo(algorithm=EncryptionAlgorithm.BCRYPT)
+        assert info.algorithm == EncryptionAlgorithm.BCRYPT
+
+    def test_compare_function(self) -> None:
+        """Test compare function generation."""
+        info = EncryptedFieldInfo(algorithm=EncryptionAlgorithm.ARGON2)
+        assert info.compare_function == "crypto::argon2::compare"
+
+        info_bcrypt = EncryptedFieldInfo(algorithm=EncryptionAlgorithm.BCRYPT)
+        assert info_bcrypt.compare_function == "crypto::bcrypt::compare"
+
+    def test_generate_function(self) -> None:
+        """Test generate function generation."""
+        info = EncryptedFieldInfo(algorithm=EncryptionAlgorithm.ARGON2)
+        assert info.generate_function == "crypto::argon2::generate"
+
+        info_scrypt = EncryptedFieldInfo(algorithm=EncryptionAlgorithm.SCRYPT)
+        assert info_scrypt.generate_function == "crypto::scrypt::generate"
+
+
+class TestEncryptedType:
+    """Tests for Encrypted type alias."""
+
+    def test_encrypted_in_pydantic_model(self) -> None:
+        """Test that Encrypted works in a Pydantic model."""
+
+        class UserModel(BaseModel):
+            email: str
+            password: Encrypted
+
+        # Should not raise
+        user = UserModel(email="test@example.com", password="secret123")
+        assert user.email == "test@example.com"
+        assert user.password == "secret123"
+
+    def test_encrypted_validates_as_string(self) -> None:
+        """Test that Encrypted validates string values."""
+
+        class UserModel(BaseModel):
+            password: Encrypted
+
+        # Valid string password
+        user = UserModel(password="mypassword")
+        assert user.password == "mypassword"
+
+    def test_encrypted_json_schema(self) -> None:
+        """Test that Encrypted produces proper JSON schema."""
+
+        class UserModel(BaseModel):
+            password: Encrypted
+
+        schema = UserModel.model_json_schema()
+        # Password field should be in schema
+        assert "password" in schema["properties"]
+
+
+class TestEncryptedField:
+    """Tests for EncryptedField factory function."""
+
+    def test_encrypted_field_default_algorithm(self) -> None:
+        """Test EncryptedField with default algorithm."""
+        field_type = EncryptedField()
+        assert is_encrypted_field(field_type) is True
+
+    def test_encrypted_field_custom_algorithm(self) -> None:
+        """Test EncryptedField with custom algorithm."""
+        field_type = EncryptedField(EncryptionAlgorithm.BCRYPT)
+        info = get_encryption_info(field_type)
+        assert info is not None
+        assert info.algorithm == EncryptionAlgorithm.BCRYPT
+
+    def test_encrypted_field_in_model(self) -> None:
+        """Test EncryptedField in a Pydantic model."""
+        BcryptField = EncryptedField(EncryptionAlgorithm.BCRYPT)
+
+        class SecureModel(BaseModel):
+            password: BcryptField  # type: ignore
+
+        model = SecureModel(password="secret")
+        assert model.password == "secret"
+
+
+class TestIsEncryptedField:
+    """Tests for is_encrypted_field helper function."""
+
+    def test_detects_encrypted_type(self) -> None:
+        """Test detection of Encrypted type."""
+        assert is_encrypted_field(Encrypted) is True
+
+    def test_detects_encrypted_field(self) -> None:
+        """Test detection of EncryptedField type."""
+        field_type = EncryptedField()
+        assert is_encrypted_field(field_type) is True
+
+    def test_rejects_non_encrypted_type(self) -> None:
+        """Test rejection of non-Encrypted types."""
+        assert is_encrypted_field(str) is False
+        assert is_encrypted_field(int) is False
+        assert is_encrypted_field(list) is False
+
+    def test_rejects_none(self) -> None:
+        """Test rejection of None type."""
+        assert is_encrypted_field(None) is False
+
+
+class TestGetEncryptionInfo:
+    """Tests for get_encryption_info helper function."""
+
+    def test_returns_info_for_encrypted_field(self) -> None:
+        """Test that info is returned for Encrypted types."""
+        info = get_encryption_info(Encrypted)
+        assert info is not None
+        assert isinstance(info, EncryptedFieldInfo)
+
+    def test_returns_none_for_non_encrypted(self) -> None:
+        """Test that None is returned for non-Encrypted types."""
+        assert get_encryption_info(str) is None
+        assert get_encryption_info(int) is None
+
+    def test_default_algorithm_in_info(self) -> None:
+        """Test that default algorithm is argon2."""
+        info = get_encryption_info(Encrypted)
+        assert info is not None
+        assert info.algorithm == EncryptionAlgorithm.ARGON2
+
+    def test_custom_algorithm_in_info(self) -> None:
+        """Test extracting custom algorithm."""
+        field_type = EncryptedField(EncryptionAlgorithm.SCRYPT)
+        info = get_encryption_info(field_type)
+        assert info is not None
+        assert info.algorithm == EncryptionAlgorithm.SCRYPT

--- a/tests/test_migrations_generator.py
+++ b/tests/test_migrations_generator.py
@@ -1,0 +1,260 @@
+"""
+Unit tests for migration file generator.
+"""
+
+import pytest
+from pathlib import Path
+import tempfile
+import shutil
+
+from src.surreal_orm.migrations.generator import MigrationGenerator, generate_empty_migration
+from src.surreal_orm.migrations.operations import (
+    AddField,
+    CreateTable,
+)
+
+
+@pytest.fixture
+def temp_migrations_dir() -> Path:
+    """Create a temporary migrations directory."""
+    temp_dir = Path(tempfile.mkdtemp())
+    yield temp_dir
+    shutil.rmtree(temp_dir)
+
+
+class TestMigrationGenerator:
+    """Tests for MigrationGenerator class."""
+
+    def test_ensure_directory_creates_dir(self, temp_migrations_dir: Path) -> None:
+        """Test that ensure_directory creates the migrations directory."""
+        migrations_dir = temp_migrations_dir / "new_migrations"
+        generator = MigrationGenerator(migrations_dir)
+        generator.ensure_directory()
+
+        assert migrations_dir.exists()
+        assert (migrations_dir / "__init__.py").exists()
+
+    def test_get_next_number_empty_dir(self, temp_migrations_dir: Path) -> None:
+        """Test get_next_number with empty directory."""
+        generator = MigrationGenerator(temp_migrations_dir)
+        assert generator.get_next_number() == 1
+
+    def test_get_next_number_with_existing(self, temp_migrations_dir: Path) -> None:
+        """Test get_next_number with existing migrations."""
+        generator = MigrationGenerator(temp_migrations_dir)
+        generator.ensure_directory()
+
+        # Create some migration files
+        (temp_migrations_dir / "0001_initial.py").touch()
+        (temp_migrations_dir / "0002_add_users.py").touch()
+
+        assert generator.get_next_number() == 3
+
+    def test_generate_basic_migration(self, temp_migrations_dir: Path) -> None:
+        """Test generating a basic migration file."""
+        generator = MigrationGenerator(temp_migrations_dir)
+
+        operations = [
+            CreateTable(name="users", schema_mode="SCHEMAFULL"),
+            AddField(table="users", name="email", field_type="string"),
+        ]
+
+        filepath = generator.generate(name="initial", operations=operations)
+
+        assert filepath.exists()
+        assert filepath.name == "0001_initial.py"
+
+        content = filepath.read_text()
+        assert "Migration: 0001_initial" in content
+        assert "from surreal_orm.migrations import Migration" in content
+        assert "CreateTable" in content
+        assert "AddField" in content
+
+    def test_generate_migration_with_dependencies(self, temp_migrations_dir: Path) -> None:
+        """Test generating migration with dependencies."""
+        generator = MigrationGenerator(temp_migrations_dir)
+
+        # Create first migration
+        generator.generate(name="initial", operations=[CreateTable(name="users")])
+
+        # Create second migration with dependency
+        filepath = generator.generate(
+            name="add_email",
+            operations=[AddField(table="users", name="email", field_type="string")],
+            dependencies=["0001_initial"],
+        )
+
+        content = filepath.read_text()
+        assert "dependencies=['0001_initial']" in content
+
+    def test_generate_sequential_migrations(self, temp_migrations_dir: Path) -> None:
+        """Test generating multiple migrations with sequential numbering."""
+        generator = MigrationGenerator(temp_migrations_dir)
+
+        path1 = generator.generate(name="first", operations=[])
+        path2 = generator.generate(name="second", operations=[])
+        path3 = generator.generate(name="third", operations=[])
+
+        assert path1.name == "0001_first.py"
+        assert path2.name == "0002_second.py"
+        assert path3.name == "0003_third.py"
+
+    def test_generate_migration_content_is_valid_python(self, temp_migrations_dir: Path) -> None:
+        """Test that generated migration file is valid Python."""
+        generator = MigrationGenerator(temp_migrations_dir)
+
+        operations = [
+            CreateTable(name="users", schema_mode="SCHEMAFULL"),
+            AddField(table="users", name="email", field_type="string", default="test@example.com"),
+        ]
+
+        filepath = generator.generate(name="test_python", operations=operations)
+
+        # Try to compile the file
+        content = filepath.read_text()
+        try:
+            compile(content, filepath, "exec")
+        except SyntaxError as e:
+            pytest.fail(f"Generated migration is not valid Python: {e}")
+
+    def test_render_operation_simple(self, temp_migrations_dir: Path) -> None:
+        """Test rendering simple operation."""
+        generator = MigrationGenerator(temp_migrations_dir)
+
+        op = CreateTable(name="users")
+        rendered = generator._render_operation(op)
+
+        assert "CreateTable" in rendered
+        assert "name='users'" in rendered
+
+    def test_render_operation_with_dict(self, temp_migrations_dir: Path) -> None:
+        """Test rendering operation with dict parameter."""
+        generator = MigrationGenerator(temp_migrations_dir)
+
+        op = CreateTable(
+            name="users",
+            permissions={"select": "true", "update": "$auth.id = id"},
+        )
+        rendered = generator._render_operation(op)
+
+        assert "permissions=" in rendered
+
+    def test_render_operation_with_list(self, temp_migrations_dir: Path) -> None:
+        """Test rendering operation with list parameter."""
+        generator = MigrationGenerator(temp_migrations_dir)
+
+        from src.surreal_orm.migrations.operations import CreateIndex
+
+        op = CreateIndex(table="users", name="email_idx", fields=["email", "name"])
+        rendered = generator._render_operation(op)
+
+        assert "fields=['email', 'name']" in rendered
+
+    def test_format_value_strings(self, temp_migrations_dir: Path) -> None:
+        """Test value formatting for strings."""
+        generator = MigrationGenerator(temp_migrations_dir)
+
+        assert generator._format_value("test") == "'test'"
+        assert generator._format_value("it's a test") == '"it\'s a test"'
+
+    def test_format_value_booleans(self, temp_migrations_dir: Path) -> None:
+        """Test value formatting for booleans."""
+        generator = MigrationGenerator(temp_migrations_dir)
+
+        assert generator._format_value(True) == "True"
+        assert generator._format_value(False) == "False"
+
+    def test_format_value_numbers(self, temp_migrations_dir: Path) -> None:
+        """Test value formatting for numbers."""
+        generator = MigrationGenerator(temp_migrations_dir)
+
+        assert generator._format_value(42) == "42"
+        assert generator._format_value(3.14) == "3.14"
+
+
+class TestGenerateEmptyMigration:
+    """Tests for generate_empty_migration function."""
+
+    def test_generate_empty_migration(self, temp_migrations_dir: Path) -> None:
+        """Test generating an empty migration file."""
+        filepath = generate_empty_migration(temp_migrations_dir, "manual_changes")
+
+        assert filepath.exists()
+        assert "0001_manual_changes.py" in str(filepath)
+
+        content = filepath.read_text()
+        assert "operations=[]" in content
+
+    def test_generate_empty_migration_with_dependencies(self, temp_migrations_dir: Path) -> None:
+        """Test generating empty migration with dependencies."""
+        filepath = generate_empty_migration(
+            temp_migrations_dir,
+            "depends_on_initial",
+            dependencies=["0001_initial"],
+        )
+
+        content = filepath.read_text()
+        assert "dependencies=['0001_initial']" in content
+
+
+class TestMigrationFileLoading:
+    """Tests for loading generated migration files."""
+
+    def test_generated_migration_is_loadable(self, temp_migrations_dir: Path) -> None:
+        """Test that generated migration file can be loaded."""
+        generator = MigrationGenerator(temp_migrations_dir)
+
+        operations = [
+            CreateTable(name="users", schema_mode="SCHEMAFULL"),
+            AddField(table="users", name="email", field_type="string"),
+        ]
+
+        filepath = generator.generate(name="loadable", operations=operations)
+
+        # Load the migration
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("migration", filepath)
+        assert spec is not None
+        assert spec.loader is not None
+
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        migration = getattr(module, "migration", None)
+        assert migration is not None
+        # Check it has expected Migration attributes (avoid isinstance due to import path differences)
+        assert hasattr(migration, "name")
+        assert hasattr(migration, "operations")
+        assert migration.name == "0001_loadable"
+        assert len(migration.operations) == 2
+
+    def test_loaded_migration_generates_sql(self, temp_migrations_dir: Path) -> None:
+        """Test that loaded migration generates correct SQL."""
+        generator = MigrationGenerator(temp_migrations_dir)
+
+        operations = [
+            CreateTable(name="products", schema_mode="SCHEMAFULL"),
+            AddField(table="products", name="name", field_type="string"),
+            AddField(table="products", name="price", field_type="float"),
+        ]
+
+        filepath = generator.generate(name="products", operations=operations)
+
+        # Load and get SQL
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("migration", filepath)
+        assert spec is not None
+        assert spec.loader is not None
+
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        migration = module.migration
+        sql_statements = migration.forwards_sql()
+
+        assert len(sql_statements) == 3
+        assert any("DEFINE TABLE products" in sql for sql in sql_statements)
+        assert any("DEFINE FIELD name ON products" in sql for sql in sql_statements)
+        assert any("DEFINE FIELD price ON products" in sql for sql in sql_statements)

--- a/tests/test_migrations_integration.py
+++ b/tests/test_migrations_integration.py
@@ -1,0 +1,351 @@
+"""
+Integration tests for migrations with SurrealDB.
+
+These tests require a running SurrealDB instance.
+Run with: pytest -m integration tests/test_migrations_integration.py
+"""
+
+import pytest
+import tempfile
+import shutil
+from pathlib import Path
+
+from src import surreal_orm
+from src.surreal_orm.model_base import (
+    BaseSurrealModel,
+    SurrealConfigDict,
+    clear_model_registry,
+)
+from src.surreal_orm.types import SchemaMode
+from src.surreal_orm.migrations.executor import MigrationExecutor, MIGRATIONS_TABLE
+from src.surreal_orm.migrations.generator import MigrationGenerator
+from src.surreal_orm.migrations.introspector import introspect_models
+from src.surreal_orm.migrations.state import SchemaState
+from src.surreal_orm.migrations.operations import CreateTable, AddField
+
+
+SURREALDB_URL = "http://localhost:8000"
+SURREALDB_USER = "root"
+SURREALDB_PASS = "root"
+SURREALDB_NAMESPACE = "test"
+SURREALDB_DATABASE = "test_migrations"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_surrealdb() -> None:
+    """Setup SurrealDB connection for tests."""
+    surreal_orm.SurrealDBConnectionManager.set_connection(
+        SURREALDB_URL,
+        SURREALDB_USER,
+        SURREALDB_PASS,
+        SURREALDB_NAMESPACE,
+        SURREALDB_DATABASE,
+    )
+
+
+@pytest.fixture
+def temp_migrations_dir() -> Path:
+    """Create a temporary migrations directory."""
+    temp_dir = Path(tempfile.mkdtemp())
+    yield temp_dir
+    shutil.rmtree(temp_dir)
+
+
+@pytest.fixture
+def clean_registry() -> None:
+    """Clear model registry for isolated tests."""
+    clear_model_registry()
+
+
+@pytest.fixture
+async def clean_database():
+    """Clean up test tables before and after each test."""
+    tables_to_clean = [
+        "MigrationTestModel",
+        "MigrationUser",
+        "TestProduct",
+        "WorkflowTable",
+        "RollbackTable",
+        "FirstTable",
+        "SecondTable",
+        "ThirdTable",
+        "SqlTable",
+        "StatusTable",
+        MIGRATIONS_TABLE,
+    ]
+
+    async def cleanup() -> None:
+        try:
+            client = await surreal_orm.SurrealDBConnectionManager.get_client()
+            for table in tables_to_clean:
+                try:
+                    await client.query(f"REMOVE TABLE IF EXISTS {table};")
+                except Exception:
+                    pass
+        except Exception:
+            pass
+
+    # Setup: clean before test
+    await cleanup()
+
+    yield  # Run test
+
+    # Teardown: clean after test
+    await cleanup()
+
+
+@pytest.mark.integration
+class TestMigrationExecutor:
+    """Integration tests for MigrationExecutor."""
+
+    async def test_ensure_migrations_table(self, temp_migrations_dir: Path, clean_database: None) -> None:
+        """Test that migrations table is created."""
+        executor = MigrationExecutor(temp_migrations_dir)
+        await executor.ensure_migrations_table()
+
+        client = await surreal_orm.SurrealDBConnectionManager.get_client()
+        result = await client.query(f"INFO FOR TABLE {MIGRATIONS_TABLE};")
+
+        # Table should exist
+        assert result is not None
+
+    async def test_get_applied_migrations_empty(self, temp_migrations_dir: Path, clean_database: None) -> None:
+        """Test getting applied migrations when none exist."""
+        executor = MigrationExecutor(temp_migrations_dir)
+        applied = await executor.get_applied_migrations()
+
+        assert applied == []
+
+    async def test_migrate_creates_table(self, temp_migrations_dir: Path, clean_database: None) -> None:
+        """Test that migration creates table in database."""
+        # Generate migration
+        generator = MigrationGenerator(temp_migrations_dir)
+        generator.generate(
+            name="create_test",
+            operations=[
+                CreateTable(name="MigrationTestModel", schema_mode="SCHEMAFULL"),
+                AddField(
+                    table="MigrationTestModel",
+                    name="name",
+                    field_type="string",
+                ),
+            ],
+        )
+
+        # Apply migration
+        executor = MigrationExecutor(temp_migrations_dir)
+        applied = await executor.migrate()
+
+        assert len(applied) == 1
+        assert "0001_create_test" in applied
+
+        # Verify table exists
+        client = await surreal_orm.SurrealDBConnectionManager.get_client()
+        result = await client.query("INFO FOR TABLE MigrationTestModel;")
+        assert result is not None
+
+    async def test_migrate_records_applied(self, temp_migrations_dir: Path, clean_database: None) -> None:
+        """Test that applied migrations are recorded."""
+        generator = MigrationGenerator(temp_migrations_dir)
+        generator.generate(
+            name="test_record",
+            operations=[CreateTable(name="TestProduct", schema_mode="SCHEMAFULL")],
+        )
+
+        executor = MigrationExecutor(temp_migrations_dir)
+        await executor.migrate()
+
+        # Check applied migrations
+        applied = await executor.get_applied_migrations()
+        assert "0001_test_record" in applied
+
+    async def test_migrate_skip_already_applied(self, temp_migrations_dir: Path, clean_database: None) -> None:
+        """Test that already applied migrations are skipped."""
+        generator = MigrationGenerator(temp_migrations_dir)
+        generator.generate(
+            name="skip_test",
+            operations=[CreateTable(name="TestProduct", schema_mode="SCHEMAFULL")],
+        )
+
+        executor = MigrationExecutor(temp_migrations_dir)
+
+        # Apply first time
+        first_applied = await executor.migrate()
+        assert len(first_applied) == 1
+
+        # Apply second time - should skip
+        second_applied = await executor.migrate()
+        assert len(second_applied) == 0
+
+    async def test_migrate_fake(self, temp_migrations_dir: Path, clean_database: None) -> None:
+        """Test fake migration marks as applied without executing."""
+        generator = MigrationGenerator(temp_migrations_dir)
+        generator.generate(
+            name="fake_test",
+            operations=[CreateTable(name="FakeTable", schema_mode="SCHEMAFULL")],
+        )
+
+        executor = MigrationExecutor(temp_migrations_dir)
+        await executor.migrate(fake=True)
+
+        # Should be recorded as applied
+        applied = await executor.get_applied_migrations()
+        assert "0001_fake_test" in applied
+
+        # But table should NOT exist
+        client = await surreal_orm.SurrealDBConnectionManager.get_client()
+        try:
+            result = await client.query("SELECT * FROM FakeTable;")
+            # If we get here without error, table might exist
+            # Check if empty result
+            assert result.is_empty
+        except Exception:
+            pass  # Table doesn't exist, which is expected
+
+    async def test_get_migration_status(self, temp_migrations_dir: Path, clean_database: None) -> None:
+        """Test getting migration status."""
+        generator = MigrationGenerator(temp_migrations_dir)
+        generator.generate(
+            name="status_test",
+            operations=[CreateTable(name="StatusTable")],
+        )
+
+        executor = MigrationExecutor(temp_migrations_dir)
+        status = await executor.get_migration_status()
+
+        assert "0001_status_test" in status
+        assert status["0001_status_test"]["applied"] is False
+
+        await executor.migrate()
+
+        status = await executor.get_migration_status()
+        assert status["0001_status_test"]["applied"] is True
+
+    async def test_show_sql(self, temp_migrations_dir: Path) -> None:
+        """Test showing SQL for a migration."""
+        generator = MigrationGenerator(temp_migrations_dir)
+        generator.generate(
+            name="sql_test",
+            operations=[
+                CreateTable(name="SqlTable", schema_mode="SCHEMAFULL"),
+                AddField(table="SqlTable", name="value", field_type="int"),
+            ],
+        )
+
+        executor = MigrationExecutor(temp_migrations_dir)
+        sql = await executor.show_sql("0001_sql_test")
+
+        assert "DEFINE TABLE SqlTable SCHEMAFULL" in sql
+        assert "DEFINE FIELD value ON SqlTable TYPE int" in sql
+
+
+@pytest.mark.integration
+class TestMigrationRollback:
+    """Integration tests for migration rollback."""
+
+    async def test_rollback_removes_table(self, temp_migrations_dir: Path, clean_database: None) -> None:
+        """Test that rollback removes created table."""
+        generator = MigrationGenerator(temp_migrations_dir)
+        generator.generate(
+            name="rollback_test",
+            operations=[CreateTable(name="RollbackTable", schema_mode="SCHEMAFULL")],
+        )
+
+        executor = MigrationExecutor(temp_migrations_dir)
+
+        # Apply migration
+        await executor.migrate()
+
+        # Verify table exists
+        client = await surreal_orm.SurrealDBConnectionManager.get_client()
+        result = await client.query("INFO FOR TABLE RollbackTable;")
+        assert result is not None
+
+        # Rollback (to before any migrations)
+        rolled_back = await executor.rollback("")
+
+        assert "0001_rollback_test" in rolled_back
+
+        # Verify table is gone
+        result = await client.query("SELECT * FROM RollbackTable;")
+        assert result.is_empty
+
+    async def test_rollback_to_target(self, temp_migrations_dir: Path, clean_database: None) -> None:
+        """Test rolling back to a specific migration."""
+        generator = MigrationGenerator(temp_migrations_dir)
+
+        # Create multiple migrations
+        generator.generate(
+            name="first",
+            operations=[CreateTable(name="FirstTable")],
+        )
+        generator.generate(
+            name="second",
+            operations=[CreateTable(name="SecondTable")],
+        )
+        generator.generate(
+            name="third",
+            operations=[CreateTable(name="ThirdTable")],
+        )
+
+        executor = MigrationExecutor(temp_migrations_dir)
+
+        # Apply all
+        await executor.migrate()
+
+        # Rollback to first migration
+        rolled_back = await executor.rollback("0001_first")
+
+        assert "0003_third" in rolled_back
+        assert "0002_second" in rolled_back
+        assert "0001_first" not in rolled_back
+
+        # Verify first table still exists
+        client = await surreal_orm.SurrealDBConnectionManager.get_client()
+        result = await client.query("INFO FOR TABLE FirstTable;")
+        assert result is not None
+
+
+@pytest.mark.integration
+class TestEndToEndMigrationWorkflow:
+    """End-to-end tests for the complete migration workflow."""
+
+    async def test_full_migration_workflow(self, temp_migrations_dir: Path, clean_database: None, clean_registry: None) -> None:
+        """Test complete workflow: define model -> generate migration -> apply."""
+        clear_model_registry()
+
+        # Define a model
+        class WorkflowModel(BaseSurrealModel):
+            model_config = SurrealConfigDict(
+                table_name="WorkflowTable",
+                schema_mode=SchemaMode.SCHEMAFULL,
+            )
+            id: str | None = None
+            name: str
+            value: int = 0
+
+        # Introspect models
+        desired_state = introspect_models([WorkflowModel])
+        current_state = SchemaState()
+
+        # Generate operations
+        operations = current_state.diff(desired_state)
+
+        # Generate migration file
+        generator = MigrationGenerator(temp_migrations_dir)
+        generator.generate(name="workflow", operations=operations)
+
+        # Apply migration
+        executor = MigrationExecutor(temp_migrations_dir)
+        applied = await executor.migrate()
+
+        assert len(applied) == 1
+
+        # Verify we can use the model
+        client = await surreal_orm.SurrealDBConnectionManager.get_client()
+        await client.query("CREATE WorkflowTable SET name = 'test', value = 42;")
+
+        result = await client.query("SELECT * FROM WorkflowTable;")
+        assert not result.is_empty
+        assert result.first["name"] == "test"
+        assert result.first["value"] == 42

--- a/tests/test_migrations_introspector.py
+++ b/tests/test_migrations_introspector.py
@@ -1,0 +1,272 @@
+"""
+Unit tests for model introspection.
+"""
+
+import pytest
+
+from src.surreal_orm.model_base import (
+    BaseSurrealModel,
+    SurrealConfigDict,
+    clear_model_registry,
+    get_registered_models,
+)
+from src.surreal_orm.types import SchemaMode, TableType
+from src.surreal_orm.fields import Encrypted
+from src.surreal_orm.migrations.introspector import ModelIntrospector, introspect_models
+
+
+@pytest.fixture(autouse=True)
+def clear_registry() -> None:
+    """Clear model registry before each test."""
+    clear_model_registry()
+
+
+class TestModelRegistry:
+    """Tests for model registration."""
+
+    def test_model_auto_registered(self) -> None:
+        """Test that models are automatically registered."""
+        clear_model_registry()
+
+        class TestModel(BaseSurrealModel):
+            id: str | None = None
+            name: str
+
+        models = get_registered_models()
+        assert TestModel in models
+
+    def test_clear_registry(self) -> None:
+        """Test clearing the model registry."""
+
+        class TempModel(BaseSurrealModel):
+            id: str | None = None
+
+        clear_model_registry()
+        assert len(get_registered_models()) == 0
+
+
+class TestModelIntrospector:
+    """Tests for ModelIntrospector class."""
+
+    def test_introspect_simple_model(self) -> None:
+        """Test introspection of a simple model."""
+
+        class SimpleModel(BaseSurrealModel):
+            id: str | None = None
+            name: str
+            age: int
+
+        introspector = ModelIntrospector([SimpleModel])
+        state = introspector.introspect()
+
+        assert "SimpleModel" in state.tables
+        table = state.tables["SimpleModel"]
+        assert "name" in table.fields
+        assert "age" in table.fields
+        assert table.fields["name"].field_type == "string"
+        assert table.fields["age"].field_type == "int"
+
+    def test_introspect_model_with_config(self) -> None:
+        """Test introspection with custom configuration."""
+
+        class ConfiguredModel(BaseSurrealModel):
+            model_config = SurrealConfigDict(
+                table_name="custom_table",
+                table_type=TableType.STREAM,
+                schema_mode=SchemaMode.SCHEMAFULL,
+                changefeed="7d",
+            )
+            id: str | None = None
+            data: str
+
+        introspector = ModelIntrospector([ConfiguredModel])
+        state = introspector.introspect()
+
+        assert "custom_table" in state.tables
+        table = state.tables["custom_table"]
+        assert table.schema_mode == "SCHEMAFULL"
+        assert table.table_type == "stream"
+        assert table.changefeed == "7d"
+
+    def test_introspect_user_table(self) -> None:
+        """Test introspection of USER type table."""
+
+        class UserModel(BaseSurrealModel):
+            model_config = SurrealConfigDict(table_type=TableType.USER)
+            id: str | None = None
+            email: str
+            password: Encrypted
+
+        introspector = ModelIntrospector([UserModel])
+        state = introspector.introspect()
+
+        table = state.tables["UserModel"]
+        # USER tables must be SCHEMAFULL
+        assert table.schema_mode == "SCHEMAFULL"
+        assert table.table_type == "user"
+        # Should have access definition
+        assert table.access is not None
+        assert table.access.name == "usermodel_auth"
+
+    def test_introspect_encrypted_field(self) -> None:
+        """Test introspection of encrypted fields."""
+
+        class SecureModel(BaseSurrealModel):
+            model_config = SurrealConfigDict(table_type=TableType.USER)
+            id: str | None = None
+            email: str
+            password: Encrypted
+
+        introspector = ModelIntrospector([SecureModel])
+        state = introspector.introspect()
+
+        table = state.tables["SecureModel"]
+        assert table.fields["password"].encrypted is True
+        assert table.fields["email"].encrypted is False
+
+    def test_introspect_optional_fields(self) -> None:
+        """Test introspection of optional fields."""
+
+        class OptionalModel(BaseSurrealModel):
+            id: str | None = None
+            required_field: str
+            optional_field: str | None = None
+
+        introspector = ModelIntrospector([OptionalModel])
+        state = introspector.introspect()
+
+        table = state.tables["OptionalModel"]
+        assert table.fields["required_field"].nullable is False
+        assert table.fields["optional_field"].nullable is True
+
+    def test_introspect_with_defaults(self) -> None:
+        """Test introspection of fields with defaults."""
+
+        class DefaultModel(BaseSurrealModel):
+            id: str | None = None
+            status: str = "active"
+            count: int = 0
+
+        introspector = ModelIntrospector([DefaultModel])
+        state = introspector.introspect()
+
+        table = state.tables["DefaultModel"]
+        assert table.fields["status"].default == "active"
+        assert table.fields["count"].default == 0
+
+    def test_introspect_hash_table_schemaless(self) -> None:
+        """Test that HASH tables default to SCHEMALESS."""
+
+        class CacheModel(BaseSurrealModel):
+            model_config = SurrealConfigDict(table_type=TableType.HASH)
+            id: str | None = None
+            data: dict
+
+        introspector = ModelIntrospector([CacheModel])
+        state = introspector.introspect()
+
+        table = state.tables["CacheModel"]
+        assert table.schema_mode == "SCHEMALESS"
+
+    def test_introspect_permissions(self) -> None:
+        """Test introspection of table permissions."""
+
+        class ProtectedModel(BaseSurrealModel):
+            model_config = SurrealConfigDict(
+                permissions={
+                    "select": "$auth.id = owner_id",
+                    "update": "$auth.id = owner_id",
+                }
+            )
+            id: str | None = None
+            owner_id: str
+            data: str
+
+        introspector = ModelIntrospector([ProtectedModel])
+        state = introspector.introspect()
+
+        table = state.tables["ProtectedModel"]
+        assert table.permissions["select"] == "$auth.id = owner_id"
+        assert table.permissions["update"] == "$auth.id = owner_id"
+
+    def test_introspect_multiple_models(self) -> None:
+        """Test introspection of multiple models."""
+
+        class Model1(BaseSurrealModel):
+            id: str | None = None
+            field1: str
+
+        class Model2(BaseSurrealModel):
+            id: str | None = None
+            field2: int
+
+        introspector = ModelIntrospector([Model1, Model2])
+        state = introspector.introspect()
+
+        assert len(state.tables) == 2
+        assert "Model1" in state.tables
+        assert "Model2" in state.tables
+
+
+class TestIntrospectModelsFunction:
+    """Tests for introspect_models convenience function."""
+
+    def test_introspect_models_with_list(self) -> None:
+        """Test introspect_models with explicit model list."""
+
+        class ExplicitModel(BaseSurrealModel):
+            id: str | None = None
+            name: str
+
+        state = introspect_models([ExplicitModel])
+        assert "ExplicitModel" in state.tables
+
+    def test_introspect_models_from_registry(self) -> None:
+        """Test introspect_models using registered models."""
+        clear_model_registry()
+
+        class RegisteredModel(BaseSurrealModel):
+            id: str | None = None
+            value: str
+
+        # Should pick up from registry
+        state = introspect_models()
+        assert "RegisteredModel" in state.tables
+
+
+class TestTypeMapping:
+    """Tests for Python to SurrealDB type mapping."""
+
+    def test_basic_types(self) -> None:
+        """Test mapping of basic Python types."""
+
+        class TypesModel(BaseSurrealModel):
+            id: str | None = None
+            string_field: str
+            int_field: int
+            float_field: float
+            bool_field: bool
+
+        introspector = ModelIntrospector([TypesModel])
+        state = introspector.introspect()
+        table = state.tables["TypesModel"]
+
+        assert table.fields["string_field"].field_type == "string"
+        assert table.fields["int_field"].field_type == "int"
+        assert table.fields["float_field"].field_type == "float"
+        assert table.fields["bool_field"].field_type == "bool"
+
+    def test_container_types(self) -> None:
+        """Test mapping of container types."""
+
+        class ContainerModel(BaseSurrealModel):
+            id: str | None = None
+            list_field: list
+            dict_field: dict
+
+        introspector = ModelIntrospector([ContainerModel])
+        state = introspector.introspect()
+        table = state.tables["ContainerModel"]
+
+        assert table.fields["list_field"].field_type == "array"
+        assert table.fields["dict_field"].field_type == "object"

--- a/tests/test_migrations_operations.py
+++ b/tests/test_migrations_operations.py
@@ -1,0 +1,355 @@
+"""
+Unit tests for migration operations.
+"""
+
+import pytest
+
+from src.surreal_orm.migrations.operations import (
+    AddField,
+    AlterField,
+    CreateIndex,
+    CreateTable,
+    DataMigration,
+    DefineAccess,
+    DropField,
+    DropIndex,
+    DropTable,
+    RawSQL,
+    RemoveAccess,
+)
+
+
+class TestCreateTable:
+    """Tests for CreateTable operation."""
+
+    def test_basic_create_table(self) -> None:
+        """Test basic table creation."""
+        op = CreateTable(name="users")
+        sql = op.forwards()
+        assert "DEFINE TABLE users" in sql
+        assert "SCHEMAFULL" in sql
+
+    def test_create_table_schemaless(self) -> None:
+        """Test schemaless table creation."""
+        op = CreateTable(name="cache", schema_mode="SCHEMALESS")
+        sql = op.forwards()
+        assert "SCHEMALESS" in sql
+        assert "SCHEMAFULL" not in sql
+
+    def test_create_table_with_changefeed(self) -> None:
+        """Test table with changefeed."""
+        op = CreateTable(name="orders", changefeed="7d")
+        sql = op.forwards()
+        assert "CHANGEFEED 7d" in sql
+
+    def test_create_table_with_permissions(self) -> None:
+        """Test table with permissions."""
+        op = CreateTable(
+            name="posts",
+            permissions={"select": "true", "update": "$auth.id = author_id"},
+        )
+        sql = op.forwards()
+        assert "PERMISSIONS" in sql
+        assert "FOR select WHERE true" in sql
+        assert "FOR update WHERE $auth.id = author_id" in sql
+
+    def test_create_table_backwards(self) -> None:
+        """Test table drop on rollback."""
+        op = CreateTable(name="users")
+        sql = op.backwards()
+        assert sql == "REMOVE TABLE users;"
+
+    def test_create_table_describe(self) -> None:
+        """Test operation description."""
+        op = CreateTable(name="users")
+        assert op.describe() == "Create table users"
+
+    def test_create_table_reversible(self) -> None:
+        """Test that create table is reversible."""
+        op = CreateTable(name="users")
+        assert op.reversible is True
+
+
+class TestDropTable:
+    """Tests for DropTable operation."""
+
+    def test_drop_table(self) -> None:
+        """Test table drop."""
+        op = DropTable(name="users")
+        sql = op.forwards()
+        assert sql == "REMOVE TABLE users;"
+
+    def test_drop_table_not_reversible(self) -> None:
+        """Test that drop table is not reversible."""
+        op = DropTable(name="users")
+        assert op.reversible is False
+
+    def test_drop_table_backwards_empty(self) -> None:
+        """Test that backwards returns empty string."""
+        op = DropTable(name="users")
+        assert op.backwards() == ""
+
+
+class TestAddField:
+    """Tests for AddField operation."""
+
+    def test_basic_add_field(self) -> None:
+        """Test basic field addition."""
+        op = AddField(table="users", name="email", field_type="string")
+        sql = op.forwards()
+        assert "DEFINE FIELD email ON users TYPE string" in sql
+
+    def test_add_field_with_default(self) -> None:
+        """Test field with default value."""
+        op = AddField(table="users", name="status", field_type="string", default="active")
+        sql = op.forwards()
+        assert "DEFAULT 'active'" in sql
+
+    def test_add_field_with_function_default(self) -> None:
+        """Test field with function default."""
+        op = AddField(table="users", name="created_at", field_type="datetime", default="time::now()")
+        sql = op.forwards()
+        assert "DEFAULT time::now()" in sql
+
+    def test_add_encrypted_field(self) -> None:
+        """Test encrypted field."""
+        op = AddField(table="users", name="password", field_type="string", encrypted=True)
+        sql = op.forwards()
+        assert "VALUE crypto::argon2::generate($value)" in sql
+
+    def test_add_field_with_assertion(self) -> None:
+        """Test field with assertion."""
+        op = AddField(
+            table="users",
+            name="email",
+            field_type="string",
+            assertion="is::email($value)",
+        )
+        sql = op.forwards()
+        assert "ASSERT is::email($value)" in sql
+
+    def test_add_field_backwards(self) -> None:
+        """Test field removal on rollback."""
+        op = AddField(table="users", name="email", field_type="string")
+        sql = op.backwards()
+        assert sql == "REMOVE FIELD email ON users;"
+
+    def test_add_field_describe(self) -> None:
+        """Test operation description."""
+        op = AddField(table="users", name="email", field_type="string")
+        assert op.describe() == "Add field email to users"
+
+
+class TestDropField:
+    """Tests for DropField operation."""
+
+    def test_drop_field(self) -> None:
+        """Test field drop."""
+        op = DropField(table="users", name="old_field")
+        sql = op.forwards()
+        assert sql == "REMOVE FIELD old_field ON users;"
+
+    def test_drop_field_not_reversible(self) -> None:
+        """Test that drop field is not reversible."""
+        op = DropField(table="users", name="old_field")
+        assert op.reversible is False
+
+
+class TestAlterField:
+    """Tests for AlterField operation."""
+
+    def test_alter_field_type(self) -> None:
+        """Test altering field type."""
+        op = AlterField(
+            table="users",
+            name="age",
+            field_type="int",
+            previous_type="string",
+        )
+        sql = op.forwards()
+        assert "DEFINE FIELD age ON users TYPE int" in sql
+
+    def test_alter_field_backwards(self) -> None:
+        """Test rollback restores previous type."""
+        op = AlterField(
+            table="users",
+            name="age",
+            field_type="int",
+            previous_type="string",
+        )
+        sql = op.backwards()
+        assert "TYPE string" in sql
+
+    def test_alter_field_reversible_with_previous(self) -> None:
+        """Test reversibility depends on previous_type."""
+        op_reversible = AlterField(table="users", name="age", field_type="int", previous_type="string")
+        assert op_reversible.reversible is True
+
+        op_not_reversible = AlterField(table="users", name="age", field_type="int")
+        assert op_not_reversible.reversible is False
+
+
+class TestCreateIndex:
+    """Tests for CreateIndex operation."""
+
+    def test_basic_index(self) -> None:
+        """Test basic index creation."""
+        op = CreateIndex(table="users", name="email_idx", fields=["email"])
+        sql = op.forwards()
+        assert "DEFINE INDEX email_idx ON users FIELDS email" in sql
+
+    def test_unique_index(self) -> None:
+        """Test unique index creation."""
+        op = CreateIndex(table="users", name="email_idx", fields=["email"], unique=True)
+        sql = op.forwards()
+        assert "UNIQUE" in sql
+
+    def test_composite_index(self) -> None:
+        """Test composite index with multiple fields."""
+        op = CreateIndex(table="orders", name="user_date_idx", fields=["user_id", "created_at"])
+        sql = op.forwards()
+        assert "FIELDS user_id, created_at" in sql
+
+    def test_index_backwards(self) -> None:
+        """Test index removal on rollback."""
+        op = CreateIndex(table="users", name="email_idx", fields=["email"])
+        sql = op.backwards()
+        assert sql == "REMOVE INDEX email_idx ON users;"
+
+
+class TestDropIndex:
+    """Tests for DropIndex operation."""
+
+    def test_drop_index(self) -> None:
+        """Test index drop."""
+        op = DropIndex(table="users", name="email_idx")
+        sql = op.forwards()
+        assert sql == "REMOVE INDEX email_idx ON users;"
+
+    def test_drop_index_not_reversible(self) -> None:
+        """Test that drop index is not reversible."""
+        op = DropIndex(table="users", name="email_idx")
+        assert op.reversible is False
+
+
+class TestDefineAccess:
+    """Tests for DefineAccess operation."""
+
+    def test_basic_access_definition(self) -> None:
+        """Test basic access definition."""
+        op = DefineAccess(
+            name="user_auth",
+            table="User",
+            signup_fields={
+                "email": "$email",
+                "password": "crypto::argon2::generate($password)",
+            },
+            signin_where="email = $email AND crypto::argon2::compare(password, $password)",
+        )
+        sql = op.forwards()
+        assert "DEFINE ACCESS user_auth ON DATABASE TYPE RECORD" in sql
+        assert "SIGNUP (CREATE User SET" in sql
+        assert "SIGNIN (SELECT * FROM User WHERE" in sql
+        assert "DURATION FOR TOKEN 15m, FOR SESSION 12h" in sql
+
+    def test_custom_durations(self) -> None:
+        """Test custom token/session durations."""
+        op = DefineAccess(
+            name="user_auth",
+            table="User",
+            signup_fields={"email": "$email"},
+            signin_where="email = $email",
+            duration_token="1h",
+            duration_session="24h",
+        )
+        sql = op.forwards()
+        assert "FOR TOKEN 1h" in sql
+        assert "FOR SESSION 24h" in sql
+
+    def test_access_backwards(self) -> None:
+        """Test access removal on rollback."""
+        op = DefineAccess(
+            name="user_auth",
+            table="User",
+            signup_fields={"email": "$email"},
+            signin_where="email = $email",
+        )
+        sql = op.backwards()
+        assert sql == "REMOVE ACCESS user_auth ON DATABASE;"
+
+
+class TestRemoveAccess:
+    """Tests for RemoveAccess operation."""
+
+    def test_remove_access(self) -> None:
+        """Test access removal."""
+        op = RemoveAccess(name="user_auth")
+        sql = op.forwards()
+        assert sql == "REMOVE ACCESS user_auth ON DATABASE;"
+
+    def test_remove_access_not_reversible(self) -> None:
+        """Test that remove access is not reversible."""
+        op = RemoveAccess(name="user_auth")
+        assert op.reversible is False
+
+
+class TestDataMigration:
+    """Tests for DataMigration operation."""
+
+    def test_data_migration_sql(self) -> None:
+        """Test data migration with SQL."""
+        op = DataMigration(
+            forwards_sql="UPDATE users SET status = 'active' WHERE status IS NULL;",
+            backwards_sql="UPDATE users SET status = NULL WHERE status = 'active';",
+        )
+        assert op.forwards() == "UPDATE users SET status = 'active' WHERE status IS NULL;"
+        assert op.backwards() == "UPDATE users SET status = NULL WHERE status = 'active';"
+
+    def test_data_migration_reversibility(self) -> None:
+        """Test data migration reversibility based on backwards_sql."""
+        op_reversible = DataMigration(
+            forwards_sql="UPDATE ...",
+            backwards_sql="UPDATE ...",
+        )
+        assert op_reversible.reversible is True
+
+        op_not_reversible = DataMigration(forwards_sql="UPDATE ...")
+        assert op_not_reversible.reversible is False
+
+    def test_data_migration_requires_forward(self) -> None:
+        """Test that data migration requires forwards_sql or forwards_func."""
+        with pytest.raises(ValueError):
+            DataMigration()
+
+    def test_has_func_property(self) -> None:
+        """Test has_func property."""
+        op_sql = DataMigration(forwards_sql="UPDATE ...")
+        assert op_sql.has_func is False
+
+        async def migrate_func() -> None:
+            pass
+
+        op_func = DataMigration(forwards_func=migrate_func)
+        assert op_func.has_func is True
+
+
+class TestRawSQL:
+    """Tests for RawSQL operation."""
+
+    def test_raw_sql(self) -> None:
+        """Test raw SQL execution."""
+        op = RawSQL(sql="DEFINE EVENT ... ;")
+        assert op.forwards() == "DEFINE EVENT ... ;"
+
+    def test_raw_sql_reversible(self) -> None:
+        """Test raw SQL reversibility."""
+        op_reversible = RawSQL(sql="CREATE ...", reverse_sql="DELETE ...")
+        assert op_reversible.reversible is True
+
+        op_not_reversible = RawSQL(sql="CREATE ...")
+        assert op_not_reversible.reversible is False
+
+    def test_raw_sql_describe(self) -> None:
+        """Test custom description."""
+        op = RawSQL(sql="...", description="Create custom event")
+        assert op.describe() == "Create custom event"

--- a/tests/test_migrations_state.py
+++ b/tests/test_migrations_state.py
@@ -1,0 +1,386 @@
+"""
+Unit tests for migration state and diff logic.
+"""
+
+from src.surreal_orm.migrations.state import (
+    AccessState,
+    FieldState,
+    IndexState,
+    SchemaState,
+    TableState,
+)
+from src.surreal_orm.migrations.operations import (
+    AddField,
+    CreateIndex,
+    CreateTable,
+    DefineAccess,
+    DropField,
+    DropIndex,
+    DropTable,
+)
+
+
+class TestFieldState:
+    """Tests for FieldState dataclass."""
+
+    def test_field_state_creation(self) -> None:
+        """Test basic field state creation."""
+        field = FieldState(name="email", field_type="string")
+        assert field.name == "email"
+        assert field.field_type == "string"
+        assert field.nullable is True
+        assert field.default is None
+        assert field.encrypted is False
+
+    def test_field_state_with_options(self) -> None:
+        """Test field state with all options."""
+        field = FieldState(
+            name="password",
+            field_type="string",
+            nullable=False,
+            default=None,
+            encrypted=True,
+            assertion="string::len($value) > 8",
+        )
+        assert field.encrypted is True
+        assert field.assertion == "string::len($value) > 8"
+
+    def test_field_state_equality(self) -> None:
+        """Test field state equality comparison."""
+        field1 = FieldState(name="email", field_type="string")
+        field2 = FieldState(name="email", field_type="string")
+        field3 = FieldState(name="email", field_type="int")
+
+        assert field1 == field2
+        assert field1 != field3
+
+    def test_field_state_has_changed(self) -> None:
+        """Test has_changed method."""
+        field1 = FieldState(name="email", field_type="string")
+        field2 = FieldState(name="email", field_type="string")
+        field3 = FieldState(name="email", field_type="string", default="test@example.com")
+
+        assert field1.has_changed(field2) is False
+        assert field1.has_changed(field3) is True
+
+
+class TestIndexState:
+    """Tests for IndexState dataclass."""
+
+    def test_index_state_creation(self) -> None:
+        """Test basic index state creation."""
+        index = IndexState(name="email_idx", fields=["email"])
+        assert index.name == "email_idx"
+        assert index.fields == ["email"]
+        assert index.unique is False
+
+    def test_index_state_unique(self) -> None:
+        """Test unique index state."""
+        index = IndexState(name="email_idx", fields=["email"], unique=True)
+        assert index.unique is True
+
+    def test_index_state_equality(self) -> None:
+        """Test index state equality."""
+        idx1 = IndexState(name="email_idx", fields=["email"], unique=True)
+        idx2 = IndexState(name="email_idx", fields=["email"], unique=True)
+        idx3 = IndexState(name="email_idx", fields=["email"], unique=False)
+
+        assert idx1 == idx2
+        assert idx1 != idx3
+
+
+class TestAccessState:
+    """Tests for AccessState dataclass."""
+
+    def test_access_state_creation(self) -> None:
+        """Test access state creation."""
+        access = AccessState(
+            name="user_auth",
+            table="User",
+            signup_fields={"email": "$email", "password": "crypto::argon2::generate($password)"},
+            signin_where="email = $email AND crypto::argon2::compare(password, $password)",
+        )
+        assert access.name == "user_auth"
+        assert access.table == "User"
+        assert access.duration_token == "15m"
+        assert access.duration_session == "12h"
+
+    def test_access_state_equality(self) -> None:
+        """Test access state equality."""
+        access1 = AccessState(
+            name="user_auth",
+            table="User",
+            signup_fields={"email": "$email"},
+            signin_where="email = $email",
+        )
+        access2 = AccessState(
+            name="user_auth",
+            table="User",
+            signup_fields={"email": "$email"},
+            signin_where="email = $email",
+        )
+        access3 = AccessState(
+            name="user_auth",
+            table="User",
+            signup_fields={"email": "$email"},
+            signin_where="email = $email",
+            duration_token="1h",  # Different
+        )
+
+        assert access1 == access2
+        assert access1 != access3
+
+
+class TestTableState:
+    """Tests for TableState dataclass."""
+
+    def test_table_state_creation(self) -> None:
+        """Test basic table state creation."""
+        table = TableState(name="users")
+        assert table.name == "users"
+        assert table.schema_mode == "SCHEMAFULL"
+        assert table.table_type == "normal"
+        assert table.fields == {}
+        assert table.changefeed is None
+
+    def test_table_state_with_fields(self) -> None:
+        """Test table state with fields."""
+        table = TableState(
+            name="users",
+            fields={
+                "email": FieldState(name="email", field_type="string"),
+                "age": FieldState(name="age", field_type="int"),
+            },
+        )
+        assert len(table.fields) == 2
+        assert "email" in table.fields
+        assert "age" in table.fields
+
+    def test_table_state_with_access(self) -> None:
+        """Test table state with access definition."""
+        access = AccessState(
+            name="user_auth",
+            table="User",
+            signup_fields={"email": "$email"},
+            signin_where="email = $email",
+        )
+        table = TableState(name="User", table_type="user", access=access)
+        assert table.access is not None
+        assert table.access.name == "user_auth"
+
+
+class TestSchemaState:
+    """Tests for SchemaState dataclass."""
+
+    def test_empty_schema_state(self) -> None:
+        """Test empty schema state."""
+        state = SchemaState()
+        assert state.tables == {}
+        assert state.applied_migrations == []
+
+    def test_add_table(self) -> None:
+        """Test adding a table to schema state."""
+        state = SchemaState()
+        table = TableState(name="users")
+        state.add_table(table)
+        assert "users" in state.tables
+
+    def test_remove_table(self) -> None:
+        """Test removing a table from schema state."""
+        state = SchemaState()
+        state.add_table(TableState(name="users"))
+        state.remove_table("users")
+        assert "users" not in state.tables
+
+    def test_get_table(self) -> None:
+        """Test getting a table by name."""
+        state = SchemaState()
+        table = TableState(name="users")
+        state.add_table(table)
+
+        assert state.get_table("users") is table
+        assert state.get_table("nonexistent") is None
+
+    def test_clone(self) -> None:
+        """Test cloning schema state."""
+        state = SchemaState()
+        state.add_table(TableState(name="users"))
+        state.applied_migrations = ["0001_initial"]
+
+        cloned = state.clone()
+        assert cloned.tables == state.tables
+        assert cloned.applied_migrations == state.applied_migrations
+        # Should be different objects
+        assert cloned is not state
+
+
+class TestSchemaStateDiff:
+    """Tests for SchemaState diff logic."""
+
+    def test_diff_empty_to_table(self) -> None:
+        """Test diff from empty state to state with table."""
+        current = SchemaState()
+        target = SchemaState()
+        target.add_table(
+            TableState(
+                name="users",
+                fields={"email": FieldState(name="email", field_type="string")},
+            )
+        )
+
+        operations = current.diff(target)
+
+        # Should have CreateTable and AddField operations
+        assert any(isinstance(op, CreateTable) and op.name == "users" for op in operations)
+        assert any(isinstance(op, AddField) and op.name == "email" and op.table == "users" for op in operations)
+
+    def test_diff_table_to_empty(self) -> None:
+        """Test diff from state with table to empty state."""
+        current = SchemaState()
+        current.add_table(TableState(name="users"))
+        target = SchemaState()
+
+        operations = current.diff(target)
+
+        # Should have DropTable operation
+        assert any(isinstance(op, DropTable) and op.name == "users" for op in operations)
+
+    def test_diff_add_field(self) -> None:
+        """Test diff when adding a field to existing table."""
+        current = SchemaState()
+        current.add_table(
+            TableState(
+                name="users",
+                fields={"email": FieldState(name="email", field_type="string")},
+            )
+        )
+
+        target = SchemaState()
+        target.add_table(
+            TableState(
+                name="users",
+                fields={
+                    "email": FieldState(name="email", field_type="string"),
+                    "name": FieldState(name="name", field_type="string"),
+                },
+            )
+        )
+
+        operations = current.diff(target)
+
+        # Should have AddField operation for 'name'
+        add_ops = [op for op in operations if isinstance(op, AddField)]
+        assert len(add_ops) == 1
+        assert add_ops[0].name == "name"
+        assert add_ops[0].table == "users"
+
+    def test_diff_drop_field(self) -> None:
+        """Test diff when dropping a field from existing table."""
+        current = SchemaState()
+        current.add_table(
+            TableState(
+                name="users",
+                fields={
+                    "email": FieldState(name="email", field_type="string"),
+                    "old_field": FieldState(name="old_field", field_type="string"),
+                },
+            )
+        )
+
+        target = SchemaState()
+        target.add_table(
+            TableState(
+                name="users",
+                fields={"email": FieldState(name="email", field_type="string")},
+            )
+        )
+
+        operations = current.diff(target)
+
+        # Should have DropField operation
+        drop_ops = [op for op in operations if isinstance(op, DropField)]
+        assert len(drop_ops) == 1
+        assert drop_ops[0].name == "old_field"
+
+    def test_diff_add_index(self) -> None:
+        """Test diff when adding an index."""
+        current = SchemaState()
+        current.add_table(TableState(name="users"))
+
+        target = SchemaState()
+        target.add_table(
+            TableState(
+                name="users",
+                indexes={"email_idx": IndexState(name="email_idx", fields=["email"])},
+            )
+        )
+
+        operations = current.diff(target)
+
+        # Should have CreateIndex operation
+        assert any(isinstance(op, CreateIndex) and op.name == "email_idx" for op in operations)
+
+    def test_diff_drop_index(self) -> None:
+        """Test diff when dropping an index."""
+        current = SchemaState()
+        current.add_table(
+            TableState(
+                name="users",
+                indexes={"old_idx": IndexState(name="old_idx", fields=["old_field"])},
+            )
+        )
+
+        target = SchemaState()
+        target.add_table(TableState(name="users"))
+
+        operations = current.diff(target)
+
+        # Should have DropIndex operation
+        assert any(isinstance(op, DropIndex) and op.name == "old_idx" for op in operations)
+
+    def test_diff_add_access(self) -> None:
+        """Test diff when adding access definition."""
+        current = SchemaState()
+        current.add_table(TableState(name="User", table_type="user"))
+
+        target = SchemaState()
+        target.add_table(
+            TableState(
+                name="User",
+                table_type="user",
+                access=AccessState(
+                    name="user_auth",
+                    table="User",
+                    signup_fields={"email": "$email"},
+                    signin_where="email = $email",
+                ),
+            )
+        )
+
+        operations = current.diff(target)
+
+        # Should have DefineAccess operation
+        assert any(isinstance(op, DefineAccess) and op.name == "user_auth" for op in operations)
+
+    def test_diff_no_changes(self) -> None:
+        """Test diff when states are identical."""
+        state1 = SchemaState()
+        state1.add_table(
+            TableState(
+                name="users",
+                fields={"email": FieldState(name="email", field_type="string")},
+            )
+        )
+
+        state2 = SchemaState()
+        state2.add_table(
+            TableState(
+                name="users",
+                fields={"email": FieldState(name="email", field_type="string")},
+            )
+        )
+
+        operations = state1.diff(state2)
+
+        # Should have no operations
+        assert len(operations) == 0

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,111 @@
+"""
+Unit tests for types.py - Enums and type definitions.
+"""
+
+import pytest
+
+from src.surreal_orm.types import (
+    EncryptionAlgorithm,
+    FieldType,
+    PYTHON_TO_SURREAL_TYPE,
+    SchemaMode,
+    TableType,
+)
+
+
+class TestTableType:
+    """Tests for TableType enum."""
+
+    def test_table_type_values(self) -> None:
+        """Test that TableType has expected values."""
+        assert TableType.NORMAL == "normal"
+        assert TableType.USER == "user"
+        assert TableType.STREAM == "stream"
+        assert TableType.HASH == "hash"
+
+    def test_table_type_is_string(self) -> None:
+        """Test that TableType values are strings."""
+        assert isinstance(TableType.NORMAL, str)
+        assert isinstance(TableType.USER, str)
+
+    def test_table_type_from_string(self) -> None:
+        """Test creating TableType from string."""
+        assert TableType("normal") == TableType.NORMAL
+        assert TableType("user") == TableType.USER
+
+    def test_table_type_invalid(self) -> None:
+        """Test that invalid values raise ValueError."""
+        with pytest.raises(ValueError):
+            TableType("invalid")
+
+
+class TestSchemaMode:
+    """Tests for SchemaMode enum."""
+
+    def test_schema_mode_values(self) -> None:
+        """Test that SchemaMode has expected values."""
+        assert SchemaMode.SCHEMAFULL == "SCHEMAFULL"
+        assert SchemaMode.SCHEMALESS == "SCHEMALESS"
+
+    def test_schema_mode_uppercase(self) -> None:
+        """Test that SchemaMode values are uppercase for SurrealQL."""
+        assert SchemaMode.SCHEMAFULL.isupper()
+        assert SchemaMode.SCHEMALESS.isupper()
+
+
+class TestFieldType:
+    """Tests for FieldType enum."""
+
+    def test_field_type_basic_values(self) -> None:
+        """Test basic FieldType values."""
+        assert FieldType.STRING == "string"
+        assert FieldType.INT == "int"
+        assert FieldType.FLOAT == "float"
+        assert FieldType.BOOL == "bool"
+
+    def test_field_type_advanced_values(self) -> None:
+        """Test advanced FieldType values."""
+        assert FieldType.DATETIME == "datetime"
+        assert FieldType.ARRAY == "array"
+        assert FieldType.OBJECT == "object"
+        assert FieldType.RECORD == "record"
+
+    def test_field_type_any(self) -> None:
+        """Test that ANY type exists for flexible fields."""
+        assert FieldType.ANY == "any"
+
+
+class TestEncryptionAlgorithm:
+    """Tests for EncryptionAlgorithm enum."""
+
+    def test_encryption_algorithm_values(self) -> None:
+        """Test supported encryption algorithms."""
+        assert EncryptionAlgorithm.ARGON2 == "argon2"
+        assert EncryptionAlgorithm.BCRYPT == "bcrypt"
+        assert EncryptionAlgorithm.PBKDF2 == "pbkdf2"
+        assert EncryptionAlgorithm.SCRYPT == "scrypt"
+
+    def test_default_algorithm_is_argon2(self) -> None:
+        """Test that argon2 is the recommended default."""
+        # Argon2 is the most modern and secure
+        assert EncryptionAlgorithm.ARGON2.value == "argon2"
+
+
+class TestPythonToSurrealTypeMapping:
+    """Tests for Python to SurrealDB type mapping."""
+
+    def test_basic_type_mapping(self) -> None:
+        """Test mapping of basic Python types."""
+        assert PYTHON_TO_SURREAL_TYPE[str] == FieldType.STRING
+        assert PYTHON_TO_SURREAL_TYPE[int] == FieldType.INT
+        assert PYTHON_TO_SURREAL_TYPE[float] == FieldType.FLOAT
+        assert PYTHON_TO_SURREAL_TYPE[bool] == FieldType.BOOL
+
+    def test_container_type_mapping(self) -> None:
+        """Test mapping of container types."""
+        assert PYTHON_TO_SURREAL_TYPE[list] == FieldType.ARRAY
+        assert PYTHON_TO_SURREAL_TYPE[dict] == FieldType.OBJECT
+
+    def test_bytes_type_mapping(self) -> None:
+        """Test mapping of bytes type."""
+        assert PYTHON_TO_SURREAL_TYPE[bytes] == FieldType.BYTES

--- a/uv.lock
+++ b/uv.lock
@@ -1527,7 +1527,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb-orm"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1536,8 +1536,15 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+all = [
+    { name = "cbor2" },
+    { name = "click" },
+]
 cbor = [
     { name = "cbor2" },
+]
+cli = [
+    { name = "click" },
 ]
 
 [package.dev-dependencies]
@@ -1561,11 +1568,14 @@ lint = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0" },
+    { name = "cbor2", marker = "extra == 'all'", specifier = ">=5.6.0" },
     { name = "cbor2", marker = "extra == 'cbor'", specifier = ">=5.6.0" },
+    { name = "click", marker = "extra == 'all'", specifier = ">=8.1.0" },
+    { name = "click", marker = "extra == 'cli'", specifier = ">=8.1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]
-provides-extras = ["cbor"]
+provides-extras = ["cbor", "cli", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
- Migration system with operations (CreateTable, AddField, DefineAccess, etc.)
- CLI commands: makemigrations, migrate, rollback, status, sqlmigrate, shell
- Table types: USER, STREAM, HASH, NORMAL
- Encrypted field type with argon2/bcrypt/pbkdf2/scrypt support
- JWT authentication via AuthenticatedUserMixin (signup, signin, authenticate_token)
- DEFINE ACCESS ... TYPE RECORD generation for SurrealDB native auth
- Extended SurrealConfigDict with permissions, changefeed, token durations
- Model registry for auto-registration
- 198 tests (56% coverage)
- Documentation: docs/migrations.md, docs/auth.md
- Updated SurrealDB requirement to 2.6.0+