### PR TITLE
feat: Relations & Graph Traversal (v0.4.0)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,78 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'  # Trigger on version tags (v0.4.0, v1.0.0, etc.)
+
+jobs:
+  build:
+    name: Build Package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Build package
+        run: uv build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # Required for trusted publishing
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # Uses trusted publishing - no API token needed
+        # Configure at: https://pypi.org/manage/project/surrealdb-orm/settings/publishing/
+
+  github-release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,96 @@ and adheres to [SemVer](https://semver.org/) versioning.
 
 ---
 
+## [0.4.0] - 2026-02-01
+
+### Added
+
+- **Relation Field Types** - Declarative relation definitions
+  - `ForeignKey(to, on_delete, related_name)` - Single record reference
+  - `ManyToMany(to, through, related_name)` - Multiple record reference
+  - `Relation(edge, to, reverse)` - SurrealDB graph edges
+
+- **Relation Operations** - Django-style relation management
+  - `RelationManager` class for lazy loading and operations
+  - `add(*objects)`, `remove(*objects)`, `set(objects)`, `clear()` methods
+  - `all()`, `filter(**kwargs)`, `count()`, `contains(obj)` query methods
+
+- **Graph Traversal** - SurrealDB graph capabilities
+  - `RelationQuerySet` for chained multi-hop traversal
+  - `graph_query(traversal)` for raw graph queries on QuerySet
+  - `traverse(path)` method for graph path queries
+
+- **Prefetch Related** - N+1 query prevention
+  - `select_related(*relations)` - Eager load in same query
+  - `prefetch_related(*relations)` - Separate optimized queries
+
+- **Model Methods** - Low-level graph operations
+  - `relate(relation, to, tx, **edge_data)` - Create graph edge
+  - `remove_relation(relation, to, tx)` - Delete graph edge
+  - `get_related(relation, direction, model_class)` - Query edges
+
+- **Relation Helpers**
+  - `is_relation_field()`, `is_foreign_key()`, `is_many_to_many()`, `is_graph_relation()`
+  - `get_relation_info()` for metadata extraction
+  - `RelationInfo` dataclass for relation metadata
+
+### Changed
+
+- Version bump to 0.4.0
+
+---
+
+## [0.3.1] - 2026-02-01
+
+### Added
+
+- **Bulk Operations** - Efficient batch operations
+  - `bulk_create(instances, atomic=False, batch_size=None)` - Create multiple records
+  - `bulk_update(data, atomic=False)` - Update matching records
+  - `bulk_delete(atomic=False)` - Delete matching records
+  - Transaction support with `atomic=True` for all-or-nothing operations
+
+### Fixed
+
+- ORDER BY clause position (now correctly placed before LIMIT/START in SurrealQL)
+- Typo in error message: "primirary_key" corrected to "primary_key"
+
+---
+
+## [0.3.0] - 2026-02-01
+
+### Added
+
+- **ORM Transactions** - Transaction support integrated into ORM layer
+  - `tx` parameter added to `save()`, `update()`, `merge()`, `delete()` methods
+  - `Model.transaction()` class method shortcut for creating transactions
+  - `SurrealDBConnectionManager.transaction()` context manager
+
+- **Aggregations** - Django-style aggregation classes
+  - `Count()` - Count records
+  - `Sum(field)` - Sum field values
+  - `Avg(field)` - Average field values
+  - `Min(field)` - Minimum field value
+  - `Max(field)` - Maximum field value
+
+- **GROUP BY Support**
+  - `values(*fields)` method for specifying GROUP BY fields
+  - `annotate(**aggregations)` method for computed aggregations
+  - GROUP ALL behavior when `annotate()` used without `values()`
+
+- **QuerySet Aggregation Methods**
+  - `count()` - Count matching records
+  - `sum(field)` - Sum field values
+  - `avg(field)` - Average field values
+  - `min(field)` - Minimum field value
+  - `max(field)` - Maximum field value
+
+### Changed
+
+- Version bump to 0.3.0
+
+---
+
 ## [0.2.2] - 2026-02-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,24 @@
 
 ---
 
-## Current Version: 0.2.2 (Alpha)
+## Current Version: 0.4.0 (Alpha)
 
-### What's New
+### What's New in 0.4.0
+
+- **Relations & Graph Traversal** - Declarative relation definitions
+  - `ForeignKey`, `ManyToMany`, `Relation` field types
+  - `RelationManager` for lazy loading and operations (add, remove, set, clear)
+  - Graph traversal with `traverse()` and `graph_query()`
+  - `select_related()` and `prefetch_related()` for N+1 prevention
+  - Model methods: `relate()`, `remove_relation()`, `get_related()`
+
+### What's New in 0.3.x
+
+- **ORM Transactions** (v0.3.0) - `tx` parameter on save/update/delete, `Model.transaction()` shortcut
+- **Aggregations** (v0.3.0) - `Count`, `Sum`, `Avg`, `Min`, `Max` + GROUP BY with `values()`/`annotate()`
+- **Bulk Operations** (v0.3.1) - `bulk_create()`, `bulk_update()`, `bulk_delete()` with atomic support
+
+### What's New in 0.2.x
 
 - **Atomic Transactions** - Context manager for atomic operations with auto-commit/rollback
 - **Typed Functions API** - Fluent API for SurrealDB built-in and custom functions
@@ -29,10 +44,14 @@ src/
 ├── surreal_orm/                 # Django-style ORM
 │   ├── __init__.py              # Public API exports
 │   ├── connection_manager.py    # Connection singleton (uses surreal_sdk)
-│   ├── model_base.py            # BaseSurrealModel with CRUD methods
-│   ├── query_set.py             # Fluent query builder
+│   ├── model_base.py            # BaseSurrealModel with CRUD + relation methods
+│   ├── query_set.py             # Fluent query builder + graph traversal
+│   ├── relations.py             # RelationManager, RelationQuerySet, RelationDescriptor
+│   ├── aggregations.py          # Count, Sum, Avg, Min, Max
 │   ├── auth.py                  # JWT authentication mixin
-│   ├── fields.py                # Encrypted field type
+│   ├── fields/                  # Field types
+│   │   ├── encrypted.py         # Encrypted field type
+│   │   └── relation.py          # ForeignKey, ManyToMany, Relation
 │   ├── types.py                 # TableType enum, SurrealConfigDict
 │   └── migrations/              # Migration system
 │       ├── operations.py        # CreateTable, AddField, etc.
@@ -268,26 +287,27 @@ See full roadmap: [docs/roadmap.md](docs/roadmap.md)
 - [x] Live Queries
 - [x] Change Feeds
 
-### v0.3.0 (Next) - ORM Transactions & Aggregations
+### Completed (0.3.0) - ORM Transactions & Aggregations
 
-- [ ] Model-level transactions (`user.save(tx=tx)`)
-- [ ] QuerySet aggregations (`count()`, `sum()`, `avg()`, `min()`, `max()`)
-- [ ] GROUP BY with `values()` and `annotate()`
+- [x] Model-level transactions (`user.save(tx=tx)`)
+- [x] QuerySet aggregations (`count()`, `sum()`, `avg()`, `min()`, `max()`)
+- [x] GROUP BY with `values()` and `annotate()`
 
-### v0.3.1 - Bulk Operations
+### Completed (0.3.1) - Bulk Operations
 
-- [ ] `bulk_create()` with atomic option
-- [ ] `bulk_update()` for filtered querysets
-- [ ] `bulk_delete()` with transaction support
+- [x] `bulk_create()` with atomic option
+- [x] `bulk_update()` for filtered querysets
+- [x] `bulk_delete()` with transaction support
 
-### v0.4.x - Relations & Graph
+### Completed (0.4.0) - Relations & Graph
 
-- [ ] `ForeignKey`, `ManyToMany` fields
-- [ ] `Relation` for graph edges (SurrealDB's `->edge->`)
-- [ ] Graph traversal queries
-- [ ] `prefetch_related()` for eager loading
+- [x] `ForeignKey`, `ManyToMany` fields
+- [x] `Relation` for graph edges (SurrealDB's `->edge->`)
+- [x] Graph traversal queries (`traverse()`, `graph_query()`)
+- [x] `select_related()` and `prefetch_related()` for eager loading
+- [x] Model methods: `relate()`, `remove_relation()`, `get_related()`
 
-### v0.5.x - Real-time
+### v0.5.x (Next) - Real-time
 
 - [ ] Live Models (real-time sync)
 - [ ] Model signals (pre_save, post_save, etc.)

--- a/README.md
+++ b/README.md
@@ -13,10 +13,13 @@
 
 ---
 
-## What's New in 0.3.1
+## What's New in 0.4.0
 
-- **Bulk Operations** - `bulk_create()`, `bulk_update()`, `bulk_delete()` for efficient batch operations
-- **Bug Fixes** - Fixed ORDER BY position in queries, typos in error messages
+- **Relations & Graph Traversal** - Django-style relation definitions with SurrealDB graph support
+  - `ForeignKey`, `ManyToMany`, `Relation` field types
+  - Relation operations: `add()`, `remove()`, `set()`, `clear()`, `all()`, `filter()`, `count()`
+  - Model methods: `relate()`, `remove_relation()`, `get_related()`
+  - QuerySet extensions: `select_related()`, `prefetch_related()`, `traverse()`, `graph_query()`
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,18 +2,37 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+The following versions of SurrealDB-ORM are currently supported with security updates:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.1.x   | :white_check_mark: |
+| 0.4.x   | :white_check_mark: |
+| 0.3.x   | :white_check_mark: |
+| 0.2.x   | :white_check_mark: |
+| 0.1.x   | :x:                |
 | 0.0.x   | :x:                |
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+If you discover a security vulnerability in SurrealDB-ORM, please report it responsibly:
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+1. **Do NOT** open a public GitHub issue for security vulnerabilities
+2. **Email** the maintainer directly at: <croteau.yannick@gmail.com>
+3. Include:
+   - Description of the vulnerability
+   - Steps to reproduce
+   - Potential impact
+   - Suggested fix (if any)
+
+### Response Timeline
+
+- **Acknowledgment**: Within 48 hours
+- **Initial Assessment**: Within 7 days
+- **Fix Timeline**: Depends on severity (critical: ASAP, high: 14 days, medium: 30 days)
+
+### What to Expect
+
+- We will acknowledge receipt of your report
+- We will investigate and validate the vulnerability
+- We will work on a fix and coordinate disclosure
+- Credit will be given to reporters (unless anonymity is requested)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,8 +11,8 @@
 | 0.1.x         | Released     | Basic ORM (Models, QuerySet, CRUD)    |
 | 0.2.x         | Released     | Custom SDK, Migrations, JWT Auth, CLI |
 | 0.3.0         | Released     | ORM Transactions + Aggregations       |
-| **0.3.1**     | **Released** | **Bulk Operations + Bug Fixes**       |
-| 0.4.x         | Planned      | Relations & Graph Traversal           |
+| 0.3.1         | Released     | Bulk Operations + Bug Fixes           |
+| **0.4.0**     | **Released** | **Relations & Graph Traversal**       |
 | 0.5.x         | Planned      | Real-time Features (Live Models)      |
 
 ---
@@ -152,9 +152,11 @@ deleted = await Order.objects().filter(
 
 ---
 
-## v0.4.0 - Relations & Graph Traversal
+## v0.4.0 - Relations & Graph Traversal (Released)
 
 **Goal:** Leverage SurrealDB's graph capabilities with declarative relations.
+
+**Status:** Implemented and released.
 
 ### Relation Field Types
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 license = {file = "LICENSE"}
 authors = [
-    { name = "Yannick Croteau", email = "yannick.croteau@gmail.com" }
+    { name = "Yannick Croteau", email = "croteau.yannick@gmail.com" }
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/src/surreal_orm/__init__.py
+++ b/src/surreal_orm/__init__.py
@@ -25,6 +25,17 @@ from .types import (
     TableType,
 )
 from .fields import Encrypted
+from .fields import (
+    ForeignKey,
+    ManyToMany,
+    Relation,
+    RelationInfo,
+    get_relation_info,
+    is_foreign_key,
+    is_graph_relation,
+    is_many_to_many,
+    is_relation_field,
+)
 from .auth import AuthenticatedUserMixin
 from .aggregations import Aggregation, Count, Sum, Avg, Min, Max
 
@@ -53,8 +64,18 @@ __all__ = [
     "EncryptionAlgorithm",
     # Fields
     "Encrypted",
+    # Relations
+    "ForeignKey",
+    "ManyToMany",
+    "Relation",
+    "RelationInfo",
+    "get_relation_info",
+    "is_foreign_key",
+    "is_graph_relation",
+    "is_many_to_many",
+    "is_relation_field",
     # Auth
     "AuthenticatedUserMixin",
 ]
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"

--- a/src/surreal_orm/fields/__init__.py
+++ b/src/surreal_orm/fields/__init__.py
@@ -6,5 +6,31 @@ built-in functions for encryption, validation, and other operations.
 """
 
 from .encrypted import Encrypted, EncryptedField, EncryptedFieldInfo
+from .relation import (
+    ForeignKey,
+    ManyToMany,
+    Relation,
+    RelationInfo,
+    get_relation_info,
+    is_foreign_key,
+    is_graph_relation,
+    is_many_to_many,
+    is_relation_field,
+)
 
-__all__ = ["Encrypted", "EncryptedField", "EncryptedFieldInfo"]
+__all__ = [
+    # Encrypted fields
+    "Encrypted",
+    "EncryptedField",
+    "EncryptedFieldInfo",
+    # Relation fields
+    "ForeignKey",
+    "ManyToMany",
+    "Relation",
+    "RelationInfo",
+    "get_relation_info",
+    "is_foreign_key",
+    "is_graph_relation",
+    "is_many_to_many",
+    "is_relation_field",
+]

--- a/src/surreal_orm/fields/relation.py
+++ b/src/surreal_orm/fields/relation.py
@@ -1,0 +1,465 @@
+"""
+Relation field types for SurrealDB ORM.
+
+This module provides relation field types that leverage SurrealDB's
+graph capabilities for defining relationships between models.
+
+Example:
+    from surreal_orm import BaseSurrealModel
+    from surreal_orm.fields import ForeignKey, ManyToMany, Relation
+
+    class User(BaseSurrealModel):
+        id: str | None = None
+        name: str
+
+        # Graph relations (SurrealDB edges)
+        followers: Relation("follows", "User", reverse=True)
+        following: Relation("follows", "User")
+
+        # Traditional relations
+        profile: ForeignKey("Profile", on_delete="CASCADE")
+        groups: ManyToMany("Group", through="membership")
+"""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Annotated, Any, Literal, get_args, get_origin
+
+from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import CoreSchema, core_schema
+
+if TYPE_CHECKING:
+    pass
+
+
+@dataclass
+class RelationInfo:
+    """
+    Metadata for relation fields used during schema generation and querying.
+
+    Attributes:
+        to_model: The target model name (string to allow forward references)
+        relation_type: Type of relation (foreign_key, many_to_many, relation)
+        edge_table: Name of the edge table for graph relations
+        reverse: Whether to traverse in reverse direction (<- vs ->)
+        on_delete: Delete behavior for foreign keys (CASCADE, SET_NULL, PROTECT)
+        related_name: Name for the reverse relation on the target model
+        through: Intermediate table for many-to-many relations
+    """
+
+    to_model: str
+    relation_type: Literal["foreign_key", "many_to_many", "relation"]
+    edge_table: str | None = None
+    reverse: bool = False
+    on_delete: Literal["CASCADE", "SET_NULL", "PROTECT"] | None = None
+    related_name: str | None = None
+    through: str | None = None
+
+    @property
+    def traversal_direction(self) -> str:
+        """Get the SurrealDB traversal direction operator."""
+        return "<-" if self.reverse else "->"
+
+    def get_traversal_query(self, from_table: str, from_id: str) -> str:
+        """
+        Generate the SurrealDB traversal query.
+
+        Args:
+            from_table: Source table name
+            from_id: Source record ID
+
+        Returns:
+            SurrealQL traversal query string
+        """
+        if self.relation_type == "relation":
+            if self.reverse:
+                return f"SELECT * FROM {from_table}:{from_id}<-{self.edge_table}<-{self.to_model}"
+            return f"SELECT * FROM {from_table}:{from_id}->{self.edge_table}->{self.to_model}"
+        elif self.relation_type == "foreign_key":
+            return f"SELECT * FROM {self.to_model} WHERE id = {from_table}:{from_id}.{self.edge_table}"
+        else:  # many_to_many
+            through = self.through or f"{from_table}_{self.to_model}"
+            return f"SELECT * FROM {from_table}:{from_id}->{through}->{self.to_model}"
+
+
+class _ForeignKeyMarker:
+    """
+    Marker class for ForeignKey fields.
+
+    Foreign keys represent a single reference to another record,
+    stored as a record ID in the source table.
+    """
+
+    to: str
+    on_delete: Literal["CASCADE", "SET_NULL", "PROTECT"]
+    related_name: str | None
+
+    def __init__(
+        self,
+        to: str,
+        on_delete: Literal["CASCADE", "SET_NULL", "PROTECT"] = "CASCADE",
+        related_name: str | None = None,
+    ):
+        self.to = to
+        self.on_delete = on_delete
+        self.related_name = related_name
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        source_type: Any,
+        handler: GetCoreSchemaHandler,
+    ) -> CoreSchema:
+        """Build the Pydantic core schema for validation."""
+        # ForeignKey stores a record ID (string) or None
+        to_model = ""
+        on_delete: Literal["CASCADE", "SET_NULL", "PROTECT"] = "CASCADE"
+        related_name = None
+
+        args = get_args(source_type)
+        for arg in args:
+            if isinstance(arg, _ForeignKeyMarker):
+                to_model = arg.to
+                on_delete = arg.on_delete
+                related_name = arg.related_name
+                break
+
+        return core_schema.nullable_schema(
+            core_schema.str_schema(
+                metadata={
+                    "relation_type": "foreign_key",
+                    "to_model": to_model,
+                    "on_delete": on_delete,
+                    "related_name": related_name,
+                    "surreal_type": "record",
+                }
+            )
+        )
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        core_schema_obj: CoreSchema,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        """Generate JSON schema for OpenAPI documentation."""
+        return {"type": "string", "format": "record-id", "nullable": True}
+
+
+class _ManyToManyMarker:
+    """
+    Marker class for ManyToMany fields.
+
+    Many-to-many relations are implemented using SurrealDB graph edges,
+    with an optional intermediate table for storing relation metadata.
+    """
+
+    to: str
+    through: str | None
+    related_name: str | None
+
+    def __init__(
+        self,
+        to: str,
+        through: str | None = None,
+        related_name: str | None = None,
+    ):
+        self.to = to
+        self.through = through
+        self.related_name = related_name
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        source_type: Any,
+        handler: GetCoreSchemaHandler,
+    ) -> CoreSchema:
+        """Build the Pydantic core schema for validation."""
+        to_model = ""
+        through = None
+        related_name = None
+
+        args = get_args(source_type)
+        for arg in args:
+            if isinstance(arg, _ManyToManyMarker):
+                to_model = arg.to
+                through = arg.through
+                related_name = arg.related_name
+                break
+
+        # ManyToMany is represented as a list of record IDs (virtual field)
+        return core_schema.list_schema(
+            core_schema.str_schema(),
+            metadata={
+                "relation_type": "many_to_many",
+                "to_model": to_model,
+                "through": through,
+                "related_name": related_name,
+                "surreal_type": "virtual",
+            },
+        )
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        core_schema_obj: CoreSchema,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        """Generate JSON schema for OpenAPI documentation."""
+        return {"type": "array", "items": {"type": "string", "format": "record-id"}}
+
+
+class _RelationMarker:
+    """
+    Marker class for graph Relation fields.
+
+    Relations use SurrealDB's native graph capabilities with RELATE
+    statements and edge traversal (-> and <-).
+    """
+
+    edge: str
+    to: str
+    reverse: bool
+
+    def __init__(
+        self,
+        edge: str,
+        to: str,
+        reverse: bool = False,
+    ):
+        self.edge = edge
+        self.to = to
+        self.reverse = reverse
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        source_type: Any,
+        handler: GetCoreSchemaHandler,
+    ) -> CoreSchema:
+        """Build the Pydantic core schema for validation."""
+        edge = ""
+        to_model = ""
+        reverse = False
+
+        args = get_args(source_type)
+        for arg in args:
+            if isinstance(arg, _RelationMarker):
+                edge = arg.edge
+                to_model = arg.to
+                reverse = arg.reverse
+                break
+
+        # Relation is represented as a list of related objects (virtual field)
+        return core_schema.list_schema(
+            core_schema.any_schema(),
+            metadata={
+                "relation_type": "relation",
+                "edge_table": edge,
+                "to_model": to_model,
+                "reverse": reverse,
+                "surreal_type": "virtual",
+            },
+        )
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        core_schema_obj: CoreSchema,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        """Generate JSON schema for OpenAPI documentation."""
+        return {"type": "array", "items": {"type": "object"}}
+
+
+def ForeignKey(
+    to: str,
+    on_delete: Literal["CASCADE", "SET_NULL", "PROTECT"] = "CASCADE",
+    related_name: str | None = None,
+) -> Any:
+    """
+    Create a ForeignKey field type.
+
+    A ForeignKey represents a single reference to another model,
+    stored as a record ID in the database.
+
+    Args:
+        to: Target model name (string for forward references)
+        on_delete: Behavior when referenced record is deleted
+            - CASCADE: Delete this record too
+            - SET_NULL: Set the field to null
+            - PROTECT: Prevent deletion of referenced record
+        related_name: Name for reverse relation on target model
+
+    Returns:
+        Annotated type for use in model definition
+
+    Example:
+        class Post(BaseSurrealModel):
+            author: ForeignKey("User", related_name="posts")
+    """
+    return Annotated[str | None, _ForeignKeyMarker(to, on_delete, related_name)]
+
+
+def ManyToMany(
+    to: str,
+    through: str | None = None,
+    related_name: str | None = None,
+) -> Any:
+    """
+    Create a ManyToMany field type.
+
+    A ManyToMany relation uses SurrealDB graph edges to connect
+    multiple records. An optional intermediate table can store
+    additional metadata about the relationship.
+
+    Args:
+        to: Target model name (string for forward references)
+        through: Intermediate edge table name (auto-generated if not specified)
+        related_name: Name for reverse relation on target model
+
+    Returns:
+        Annotated type for use in model definition
+
+    Example:
+        class User(BaseSurrealModel):
+            groups: ManyToMany("Group", through="membership")
+
+        class Group(BaseSurrealModel):
+            members: ManyToMany("User", through="membership", related_name="groups")
+    """
+    return Annotated[list, _ManyToManyMarker(to, through, related_name)]
+
+
+def Relation(
+    edge: str,
+    to: str,
+    reverse: bool = False,
+) -> Any:
+    """
+    Create a graph Relation field type.
+
+    A Relation uses SurrealDB's native graph capabilities for
+    traversing edges between records. This is the most flexible
+    relation type, supporting arbitrary graph structures.
+
+    Args:
+        edge: Name of the edge table (e.g., "follows", "likes")
+        to: Target model name (string for forward references)
+        reverse: Whether to traverse in reverse direction
+            - False (default): Forward traversal (->)
+            - True: Reverse traversal (<-)
+
+    Returns:
+        Annotated type for use in model definition
+
+    Example:
+        class User(BaseSurrealModel):
+            # People this user follows (outgoing edges)
+            following: Relation("follows", "User")
+
+            # People who follow this user (incoming edges)
+            followers: Relation("follows", "User", reverse=True)
+
+    SurrealQL equivalent:
+        - following: SELECT * FROM user:id->follows->User
+        - followers: SELECT * FROM user:id<-follows<-User
+    """
+    return Annotated[list, _RelationMarker(edge, to, reverse)]
+
+
+def is_relation_field(field_type: Any) -> bool:
+    """
+    Check if a field type is a relation type.
+
+    Args:
+        field_type: The type annotation to check
+
+    Returns:
+        True if the field is a ForeignKey, ManyToMany, or Relation
+    """
+    origin = get_origin(field_type)
+
+    if origin is Annotated:
+        args = get_args(field_type)
+        for arg in args:
+            if isinstance(arg, (_ForeignKeyMarker, _ManyToManyMarker, _RelationMarker)):
+                return True
+
+    return False
+
+
+def is_foreign_key(field_type: Any) -> bool:
+    """Check if a field type is a ForeignKey."""
+    origin = get_origin(field_type)
+    if origin is Annotated:
+        args = get_args(field_type)
+        for arg in args:
+            if isinstance(arg, _ForeignKeyMarker):
+                return True
+    return False
+
+
+def is_many_to_many(field_type: Any) -> bool:
+    """Check if a field type is a ManyToMany relation."""
+    origin = get_origin(field_type)
+    if origin is Annotated:
+        args = get_args(field_type)
+        for arg in args:
+            if isinstance(arg, _ManyToManyMarker):
+                return True
+    return False
+
+
+def is_graph_relation(field_type: Any) -> bool:
+    """Check if a field type is a graph Relation."""
+    origin = get_origin(field_type)
+    if origin is Annotated:
+        args = get_args(field_type)
+        for arg in args:
+            if isinstance(arg, _RelationMarker):
+                return True
+    return False
+
+
+def get_relation_info(field_type: Any) -> RelationInfo | None:
+    """
+    Extract relation information from a field type.
+
+    Args:
+        field_type: The type annotation to extract from
+
+    Returns:
+        RelationInfo if the field is a relation, None otherwise
+    """
+    if not is_relation_field(field_type):
+        return None
+
+    origin = get_origin(field_type)
+
+    if origin is Annotated:
+        args = get_args(field_type)
+        for arg in args:
+            if isinstance(arg, _ForeignKeyMarker):
+                return RelationInfo(
+                    to_model=arg.to,
+                    relation_type="foreign_key",
+                    on_delete=arg.on_delete,
+                    related_name=arg.related_name,
+                )
+            elif isinstance(arg, _ManyToManyMarker):
+                return RelationInfo(
+                    to_model=arg.to,
+                    relation_type="many_to_many",
+                    through=arg.through,
+                    related_name=arg.related_name,
+                )
+            elif isinstance(arg, _RelationMarker):
+                return RelationInfo(
+                    to_model=arg.to,
+                    relation_type="relation",
+                    edge_table=arg.edge,
+                    reverse=arg.reverse,
+                )
+
+    return None

--- a/src/surreal_orm/relations.py
+++ b/src/surreal_orm/relations.py
@@ -1,0 +1,645 @@
+"""
+Relation management for SurrealDB ORM.
+
+This module provides classes for managing lazy loading and operations
+on related objects, including graph traversal capabilities.
+
+Example:
+    # Using RelationManager through model instance
+    followers = await alice.followers.all()
+    await alice.following.add(bob)
+    await alice.following.remove(charlie)
+
+    # Multi-hop traversal
+    friends_of_friends = await alice.following.following.all()
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Literal
+
+from .connection_manager import SurrealDBConnectionManager
+from .fields.relation import RelationInfo
+
+if TYPE_CHECKING:
+    from .model_base import BaseSurrealModel
+
+logger = logging.getLogger(__name__)
+
+
+class RelationQuerySet:
+    """
+    QuerySet for chained relation traversal.
+
+    Allows building multi-hop graph queries with filters at each level.
+
+    Example:
+        # Simple traversal
+        following = await user.following.all()
+
+        # Multi-hop
+        friends_of_friends = await user.following.following.all()
+
+        # With filters
+        active_fof = await user.following.filter(active=True).following.all()
+    """
+
+    def __init__(
+        self,
+        instance: "BaseSurrealModel",
+        relation_info: RelationInfo,
+        traversal_path: list[tuple[RelationInfo, dict[str, Any]]] | None = None,
+    ):
+        """
+        Initialize a RelationQuerySet.
+
+        Args:
+            instance: The source model instance
+            relation_info: Information about the current relation
+            traversal_path: List of (relation_info, filters) for chained traversals
+        """
+        self._instance = instance
+        self._relation_info = relation_info
+        self._traversal_path = traversal_path or [(relation_info, {})]
+        self._filters: dict[str, Any] = {}
+
+    def filter(self, **kwargs: Any) -> "RelationQuerySet":
+        """
+        Add filters to the current traversal level.
+
+        Args:
+            **kwargs: Filter conditions (field=value or field__lookup=value)
+
+        Returns:
+            RelationQuerySet for chaining
+        """
+        # Update filters for the current level
+        new_path = self._traversal_path.copy()
+        if new_path:
+            current_info, current_filters = new_path[-1]
+            new_filters = {**current_filters, **kwargs}
+            new_path[-1] = (current_info, new_filters)
+
+        new_qs = RelationQuerySet(
+            self._instance,
+            self._relation_info,
+            new_path,
+        )
+        return new_qs
+
+    def __getattr__(self, name: str) -> "RelationQuerySet":
+        """
+        Enable chained traversal via attribute access.
+
+        Example:
+            user.following.following.all()
+        """
+        # Try to get the relation from the target model
+        # This requires model registry lookup
+        from .model_base import get_registered_models
+
+        target_model_name = self._relation_info.to_model
+        target_model = None
+
+        for model in get_registered_models():
+            if model.__name__ == target_model_name:
+                target_model = model
+                break
+
+        if target_model is None:
+            raise AttributeError(f"Model '{target_model_name}' not found in registry")
+
+        # Check if the target model has this relation
+        if hasattr(target_model, "__annotations__"):
+            from .fields.relation import get_relation_info as get_rel_info
+
+            annotations = target_model.__annotations__
+            if name in annotations:
+                field_type = annotations[name]
+                rel_info = get_rel_info(field_type)
+                if rel_info:
+                    # Chain the traversal
+                    new_path = self._traversal_path.copy()
+                    new_path.append((rel_info, {}))
+                    return RelationQuerySet(
+                        self._instance,
+                        rel_info,
+                        new_path,
+                    )
+
+        raise AttributeError(f"'{target_model_name}' has no relation '{name}'")
+
+    def _build_traversal_query(self) -> tuple[str, dict[str, Any]]:
+        """
+        Build the SurrealQL traversal query from the path.
+
+        Returns:
+            Tuple of (query_string, variables)
+        """
+        source_table = self._instance.get_table_name()
+        source_id = self._instance.get_id()
+
+        if not source_id:
+            raise ValueError("Cannot traverse relations from unsaved instance")
+
+        # Build the traversal path
+        path_parts = [f"{source_table}:{source_id}"]
+        variables: dict[str, Any] = {}
+        where_clauses: list[str] = []
+        var_counter = 0
+
+        for rel_info, filters in self._traversal_path:
+            # Add traversal direction and edge
+            if rel_info.relation_type == "relation":
+                direction = "<-" if rel_info.reverse else "->"
+                path_parts.append(f"{direction}{rel_info.edge_table}{direction}{rel_info.to_model}")
+            elif rel_info.relation_type == "many_to_many":
+                through = rel_info.through or f"_{rel_info.to_model.lower()}"
+                path_parts.append(f"->{through}->{rel_info.to_model}")
+            else:  # foreign_key - different handling
+                pass
+
+            # Add filters for this level
+            for field, value in filters.items():
+                var_name = f"filter_{var_counter}"
+                var_counter += 1
+
+                # Handle lookup operators
+                if "__" in field:
+                    parts = field.split("__", 1)
+                    field_name = parts[0]
+                    operator = parts[1]
+                    clause = self._get_filter_clause(field_name, operator, var_name)
+                else:
+                    clause = f"{field} = ${var_name}"
+
+                where_clauses.append(clause)
+                variables[var_name] = value
+
+        query = "SELECT * FROM " + "".join(path_parts)
+
+        if where_clauses:
+            query += " WHERE " + " AND ".join(where_clauses)
+
+        return query + ";", variables
+
+    def _get_filter_clause(self, field: str, operator: str, var_name: str) -> str:
+        """Convert filter operator to SurrealQL."""
+        operator_map = {
+            "exact": f"{field} = ${var_name}",
+            "gt": f"{field} > ${var_name}",
+            "gte": f"{field} >= ${var_name}",
+            "lt": f"{field} < ${var_name}",
+            "lte": f"{field} <= ${var_name}",
+            "in": f"{field} IN ${var_name}",
+            "contains": f"{field} CONTAINS ${var_name}",
+            "startswith": f"string::starts_with({field}, ${var_name})",
+            "endswith": f"string::ends_with({field}, ${var_name})",
+            "isnull": f"{field} IS NULL",
+        }
+        return operator_map.get(operator, f"{field} = ${var_name}")
+
+    async def all(self) -> list[Any]:
+        """
+        Execute the traversal and return all results.
+
+        Returns:
+            List of related model instances
+        """
+        query, variables = self._build_traversal_query()
+
+        client = await SurrealDBConnectionManager.get_client()
+        result = await client.query(query, variables)
+
+        # Convert results to model instances
+        from .model_base import get_registered_models
+
+        target_model_name = self._traversal_path[-1][0].to_model
+        target_model = None
+
+        for model in get_registered_models():
+            if model.__name__ == target_model_name:
+                target_model = model
+                break
+
+        if target_model and result.all_records:
+            return [target_model.from_db(record) for record in result.all_records]
+
+        return list(result.all_records) if result.all_records else []
+
+    async def first(self) -> Any | None:
+        """
+        Execute the traversal and return the first result.
+
+        Returns:
+            First related model instance or None
+        """
+        results = await self.all()
+        return results[0] if results else None
+
+    async def count(self) -> int:
+        """
+        Count the related records.
+
+        Returns:
+            Number of related records
+        """
+        results = await self.all()
+        return len(results)
+
+
+class RelationManager:
+    """
+    Manages lazy loading and operations on related objects.
+
+    Provides a Django-like interface for working with relations,
+    including add/remove operations and query methods.
+
+    Example:
+        # Operations
+        await alice.following.add(bob)
+        await alice.following.add(charlie, david)
+        await alice.following.remove(bob)
+        await alice.following.set([charlie, david])
+        await alice.following.clear()
+
+        # Queries
+        followers = await alice.followers.all()
+        active = await alice.followers.filter(active=True)
+        count = await alice.followers.count()
+        is_following = await alice.following.contains(bob)
+    """
+
+    def __init__(
+        self,
+        instance: "BaseSurrealModel",
+        relation_info: RelationInfo,
+        field_name: str,
+    ):
+        """
+        Initialize a RelationManager.
+
+        Args:
+            instance: The model instance owning this relation
+            relation_info: Metadata about the relation
+            field_name: Name of the relation field
+        """
+        self._instance = instance
+        self._relation_info = relation_info
+        self._field_name = field_name
+        self._cache: list[Any] | None = None
+
+    def __repr__(self) -> str:
+        return f"<RelationManager({self._instance.__class__.__name__}.{self._field_name})>"
+
+    # ==================== Operations ====================
+
+    async def add(self, *objects: "BaseSurrealModel", **edge_data: Any) -> None:
+        """
+        Add objects to this relation.
+
+        For graph relations, creates RELATE edges.
+        For many-to-many, creates through table records.
+
+        Args:
+            *objects: Model instances to relate to
+            **edge_data: Additional data to store on the edge
+
+        Example:
+            await alice.following.add(bob)
+            await alice.following.add(charlie, david, since="2025-01-01")
+        """
+        if not self._instance.get_id():
+            raise ValueError("Cannot add relations to unsaved instance")
+
+        client = await SurrealDBConnectionManager.get_client()
+        source_table = self._instance.get_table_name()
+        source_id = self._instance.get_id()
+
+        for obj in objects:
+            if not obj.get_id():
+                raise ValueError("Cannot relate to unsaved instance")
+
+            target_table = obj.get_table_name()
+            target_id = obj.get_id()
+
+            if self._relation_info.relation_type == "relation":
+                # Use RELATE for graph relations
+                edge = self._relation_info.edge_table
+                if edge is None:
+                    raise ValueError("Relation edge_table is required for graph relations")
+                if self._relation_info.reverse:
+                    # Reverse relation: target -> edge -> source
+                    await client.relate(
+                        f"{target_table}:{target_id}",
+                        edge,
+                        f"{source_table}:{source_id}",
+                        edge_data if edge_data else None,
+                    )
+                else:
+                    # Forward relation: source -> edge -> target
+                    await client.relate(
+                        f"{source_table}:{source_id}",
+                        edge,
+                        f"{target_table}:{target_id}",
+                        edge_data if edge_data else None,
+                    )
+            elif self._relation_info.relation_type == "many_to_many":
+                # Use intermediate table for many-to-many
+                through = self._relation_info.through or f"{source_table}_{target_table}"
+                await client.relate(
+                    f"{source_table}:{source_id}",
+                    through,
+                    f"{target_table}:{target_id}",
+                    edge_data if edge_data else None,
+                )
+
+        # Invalidate cache
+        self._cache = None
+
+    async def remove(self, *objects: "BaseSurrealModel") -> None:
+        """
+        Remove objects from this relation.
+
+        Deletes the edge records connecting the objects.
+
+        Args:
+            *objects: Model instances to unrelate
+
+        Example:
+            await alice.following.remove(bob)
+        """
+        if not self._instance.get_id():
+            raise ValueError("Cannot remove relations from unsaved instance")
+
+        client = await SurrealDBConnectionManager.get_client()
+        source_table = self._instance.get_table_name()
+        source_id = self._instance.get_id()
+
+        for obj in objects:
+            if not obj.get_id():
+                continue
+
+            target_table = obj.get_table_name()
+            target_id = obj.get_id()
+
+            if self._relation_info.relation_type == "relation":
+                edge = self._relation_info.edge_table
+                if self._relation_info.reverse:
+                    # Delete edges where target -> edge -> source
+                    query = f"DELETE {edge} WHERE in = {target_table}:{target_id} AND out = {source_table}:{source_id};"
+                else:
+                    # Delete edges where source -> edge -> target
+                    query = f"DELETE {edge} WHERE in = {source_table}:{source_id} AND out = {target_table}:{target_id};"
+                await client.query(query)
+            elif self._relation_info.relation_type == "many_to_many":
+                through = self._relation_info.through or f"{source_table}_{target_table}"
+                query = f"DELETE {through} WHERE in = {source_table}:{source_id} AND out = {target_table}:{target_id};"
+                await client.query(query)
+
+        # Invalidate cache
+        self._cache = None
+
+    async def set(self, objects: list["BaseSurrealModel"]) -> None:
+        """
+        Replace all relations with the given objects.
+
+        Clears existing relations and adds the new ones.
+
+        Args:
+            objects: List of model instances to set as relations
+
+        Example:
+            await alice.following.set([bob, charlie])
+        """
+        await self.clear()
+        if objects:
+            await self.add(*objects)
+
+    async def clear(self) -> None:
+        """
+        Remove all relations.
+
+        Example:
+            await alice.following.clear()
+        """
+        if not self._instance.get_id():
+            raise ValueError("Cannot clear relations from unsaved instance")
+
+        client = await SurrealDBConnectionManager.get_client()
+        source_table = self._instance.get_table_name()
+        source_id = self._instance.get_id()
+
+        if self._relation_info.relation_type == "relation":
+            edge = self._relation_info.edge_table
+            if self._relation_info.reverse:
+                # Delete all edges pointing to this record
+                query = f"DELETE {edge} WHERE out = {source_table}:{source_id};"
+            else:
+                # Delete all edges from this record
+                query = f"DELETE {edge} WHERE in = {source_table}:{source_id};"
+            await client.query(query)
+        elif self._relation_info.relation_type == "many_to_many":
+            through = self._relation_info.through or f"{source_table}_"
+            query = f"DELETE {through} WHERE in = {source_table}:{source_id};"
+            await client.query(query)
+
+        # Invalidate cache
+        self._cache = None
+
+    # ==================== Queries ====================
+
+    async def all(self) -> list[Any]:
+        """
+        Get all related objects.
+
+        Returns:
+            List of related model instances
+        """
+        if self._cache is not None:
+            return self._cache
+
+        qs = RelationQuerySet(self._instance, self._relation_info)
+        results = await qs.all()
+        self._cache = results
+        return results
+
+    def filter(self, **kwargs: Any) -> RelationQuerySet:
+        """
+        Filter related objects.
+
+        Returns a RelationQuerySet that can be further filtered or traversed.
+
+        Args:
+            **kwargs: Filter conditions
+
+        Returns:
+            RelationQuerySet for chaining
+
+        Example:
+            active_followers = await alice.followers.filter(active=True)
+        """
+        qs = RelationQuerySet(self._instance, self._relation_info)
+        return qs.filter(**kwargs)
+
+    async def count(self) -> int:
+        """
+        Count related objects.
+
+        Returns:
+            Number of related records
+        """
+        results = await self.all()
+        return len(results)
+
+    async def contains(self, obj: "BaseSurrealModel") -> bool:
+        """
+        Check if an object is in this relation.
+
+        Args:
+            obj: Model instance to check
+
+        Returns:
+            True if the object is related
+        """
+        if not obj.get_id():
+            return False
+
+        results = await self.all()
+        target_id = obj.get_id()
+
+        for related in results:
+            if hasattr(related, "get_id") and related.get_id() == target_id:
+                return True
+
+        return False
+
+    async def first(self) -> Any | None:
+        """
+        Get the first related object.
+
+        Returns:
+            First related model instance or None
+        """
+        results = await self.all()
+        return results[0] if results else None
+
+    async def exists(self) -> bool:
+        """
+        Check if any related objects exist.
+
+        Returns:
+            True if there are any related records
+        """
+        count = await self.count()
+        return count > 0
+
+    # ==================== Chained Traversal ====================
+
+    def __getattr__(self, name: str) -> Any:
+        """
+        Enable chained traversal via attribute access.
+
+        Example:
+            friends_of_friends = await alice.following.following.all()
+        """
+        qs = RelationQuerySet(self._instance, self._relation_info)
+        return getattr(qs, name)
+
+
+class RelationDescriptor:
+    """
+    Descriptor for transparent relation access on models.
+
+    This descriptor is automatically applied to relation fields,
+    enabling access like `user.followers` to return a RelationManager.
+
+    Example:
+        class User(BaseSurrealModel):
+            followers: Relation("follows", "User", reverse=True)
+
+        # Access returns RelationManager
+        manager = user.followers
+        followers = await manager.all()
+    """
+
+    def __init__(self, field_name: str, relation_info: RelationInfo):
+        """
+        Initialize the descriptor.
+
+        Args:
+            field_name: Name of the relation field
+            relation_info: Metadata about the relation
+        """
+        self.field_name = field_name
+        self.relation_info = relation_info
+        self._cache_attr = f"_relation_cache_{field_name}"
+
+    def __get__(
+        self,
+        obj: "BaseSurrealModel | None",
+        objtype: type["BaseSurrealModel"] | None = None,
+    ) -> "RelationManager | RelationDescriptor":
+        """
+        Get the RelationManager for this field.
+
+        Args:
+            obj: Model instance (None if accessed on class)
+            objtype: Model class
+
+        Returns:
+            RelationManager if accessed on instance, self if on class
+        """
+        if obj is None:
+            # Accessed on class, return descriptor
+            return self
+
+        # Check for cached manager
+        if not hasattr(obj, self._cache_attr):
+            manager = RelationManager(obj, self.relation_info, self.field_name)
+            setattr(obj, self._cache_attr, manager)
+
+        cached_manager: RelationManager = getattr(obj, self._cache_attr)
+        return cached_manager
+
+    def __set__(
+        self,
+        obj: "BaseSurrealModel",
+        value: Any,
+    ) -> None:
+        """
+        Setting relation values directly is not supported.
+
+        Use the RelationManager methods (add, remove, set) instead.
+        """
+        raise AttributeError(
+            f"Cannot set '{self.field_name}' directly. Use await {obj.__class__.__name__}.{self.field_name}.set([...]) instead."
+        )
+
+
+def get_related_objects(
+    instance: "BaseSurrealModel",
+    relation_name: str,
+    direction: Literal["out", "in", "both"] = "out",
+) -> RelationQuerySet:
+    """
+    Get related objects through a relation.
+
+    This is a utility function for programmatic access to relations.
+
+    Args:
+        instance: Source model instance
+        relation_name: Name of the edge table
+        direction: Traversal direction ("out", "in", or "both")
+
+    Returns:
+        RelationQuerySet for the relation
+    """
+    rel_info = RelationInfo(
+        to_model="",  # Will be determined by query results
+        relation_type="relation",
+        edge_table=relation_name,
+        reverse=(direction == "in"),
+    )
+    return RelationQuerySet(instance, rel_info)

--- a/tests/test_aggregations.py
+++ b/tests/test_aggregations.py
@@ -201,11 +201,15 @@ def test_aggregations_exported_from_init() -> None:
     assert Aggregation is not None
 
 
-def test_version_is_03x() -> None:
-    """Test that version is 0.3.x."""
+def test_version_exists() -> None:
+    """Test that version string exists and is valid."""
     from src.surreal_orm import __version__
 
-    assert __version__.startswith("0.3")
+    assert __version__ is not None
+    assert len(__version__) > 0
+    # Version should be in semver format
+    parts = __version__.split(".")
+    assert len(parts) >= 2
 
 
 # ==================== Model Transaction Tests (Unit) ====================

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -1,0 +1,442 @@
+"""Tests for ORM v0.4.0 features: relations and graph traversal."""
+
+from pydantic import Field
+from src.surreal_orm.model_base import BaseSurrealModel
+from src.surreal_orm.fields.relation import (
+    ForeignKey,
+    ManyToMany,
+    Relation,
+    RelationInfo,
+    get_relation_info,
+    is_foreign_key,
+    is_graph_relation,
+    is_many_to_many,
+    is_relation_field,
+)
+
+
+# ==================== Test Models ====================
+
+
+class User(BaseSurrealModel):
+    """Test model for relation tests."""
+
+    id: str | None = None
+    name: str = Field(...)
+    active: bool = Field(default=True)
+
+
+class Profile(BaseSurrealModel):
+    """Test model for ForeignKey relation."""
+
+    id: str | None = None
+    bio: str = Field(default="")
+
+
+class Group(BaseSurrealModel):
+    """Test model for ManyToMany relation."""
+
+    id: str | None = None
+    name: str = Field(...)
+
+
+# ==================== ForeignKey Field Tests ====================
+
+
+def test_foreign_key_creates_annotated_type() -> None:
+    """Test that ForeignKey creates an Annotated type."""
+    fk_type = ForeignKey("User")
+    assert is_relation_field(fk_type)
+    assert is_foreign_key(fk_type)
+
+
+def test_foreign_key_with_on_delete() -> None:
+    """Test ForeignKey with on_delete parameter."""
+    fk_cascade = ForeignKey("User", on_delete="CASCADE")
+    fk_set_null = ForeignKey("User", on_delete="SET_NULL")
+    fk_protect = ForeignKey("User", on_delete="PROTECT")
+
+    info_cascade = get_relation_info(fk_cascade)
+    info_set_null = get_relation_info(fk_set_null)
+    info_protect = get_relation_info(fk_protect)
+
+    assert info_cascade is not None
+    assert info_cascade.on_delete == "CASCADE"
+    assert info_set_null is not None
+    assert info_set_null.on_delete == "SET_NULL"
+    assert info_protect is not None
+    assert info_protect.on_delete == "PROTECT"
+
+
+def test_foreign_key_with_related_name() -> None:
+    """Test ForeignKey with related_name parameter."""
+    fk_type = ForeignKey("User", related_name="posts")
+    info = get_relation_info(fk_type)
+
+    assert info is not None
+    assert info.related_name == "posts"
+
+
+def test_foreign_key_relation_info() -> None:
+    """Test RelationInfo extraction from ForeignKey."""
+    fk_type = ForeignKey("Profile", on_delete="SET_NULL", related_name="owner")
+    info = get_relation_info(fk_type)
+
+    assert info is not None
+    assert info.to_model == "Profile"
+    assert info.relation_type == "foreign_key"
+    assert info.on_delete == "SET_NULL"
+    assert info.related_name == "owner"
+
+
+# ==================== ManyToMany Field Tests ====================
+
+
+def test_many_to_many_creates_annotated_type() -> None:
+    """Test that ManyToMany creates an Annotated type."""
+    m2m_type = ManyToMany("Group")
+    assert is_relation_field(m2m_type)
+    assert is_many_to_many(m2m_type)
+
+
+def test_many_to_many_with_through() -> None:
+    """Test ManyToMany with through table."""
+    m2m_type = ManyToMany("Group", through="membership")
+    info = get_relation_info(m2m_type)
+
+    assert info is not None
+    assert info.through == "membership"
+
+
+def test_many_to_many_with_related_name() -> None:
+    """Test ManyToMany with related_name."""
+    m2m_type = ManyToMany("Group", related_name="members")
+    info = get_relation_info(m2m_type)
+
+    assert info is not None
+    assert info.related_name == "members"
+
+
+def test_many_to_many_relation_info() -> None:
+    """Test RelationInfo extraction from ManyToMany."""
+    m2m_type = ManyToMany("Tag", through="post_tags", related_name="posts")
+    info = get_relation_info(m2m_type)
+
+    assert info is not None
+    assert info.to_model == "Tag"
+    assert info.relation_type == "many_to_many"
+    assert info.through == "post_tags"
+    assert info.related_name == "posts"
+
+
+# ==================== Relation (Graph) Field Tests ====================
+
+
+def test_relation_creates_annotated_type() -> None:
+    """Test that Relation creates an Annotated type."""
+    rel_type = Relation("follows", "User")
+    assert is_relation_field(rel_type)
+    assert is_graph_relation(rel_type)
+
+
+def test_relation_forward_direction() -> None:
+    """Test Relation in forward direction (default)."""
+    rel_type = Relation("follows", "User")
+    info = get_relation_info(rel_type)
+
+    assert info is not None
+    assert info.reverse is False
+    assert info.traversal_direction == "->"
+
+
+def test_relation_reverse_direction() -> None:
+    """Test Relation in reverse direction."""
+    rel_type = Relation("follows", "User", reverse=True)
+    info = get_relation_info(rel_type)
+
+    assert info is not None
+    assert info.reverse is True
+    assert info.traversal_direction == "<-"
+
+
+def test_relation_info() -> None:
+    """Test RelationInfo extraction from Relation."""
+    rel_type = Relation("likes", "Post", reverse=False)
+    info = get_relation_info(rel_type)
+
+    assert info is not None
+    assert info.to_model == "Post"
+    assert info.relation_type == "relation"
+    assert info.edge_table == "likes"
+    assert info.reverse is False
+
+
+# ==================== Type Detection Tests ====================
+
+
+def test_is_relation_field_detects_foreign_key() -> None:
+    """Test is_relation_field detects ForeignKey."""
+    fk_type = ForeignKey("User")
+    assert is_relation_field(fk_type) is True
+
+
+def test_is_relation_field_detects_many_to_many() -> None:
+    """Test is_relation_field detects ManyToMany."""
+    m2m_type = ManyToMany("Group")
+    assert is_relation_field(m2m_type) is True
+
+
+def test_is_relation_field_detects_relation() -> None:
+    """Test is_relation_field detects Relation."""
+    rel_type = Relation("follows", "User")
+    assert is_relation_field(rel_type) is True
+
+
+def test_is_relation_field_rejects_non_relation() -> None:
+    """Test is_relation_field rejects non-relation types."""
+    assert is_relation_field(str) is False
+    assert is_relation_field(int) is False
+    assert is_relation_field(list) is False
+
+
+def test_is_foreign_key_specific() -> None:
+    """Test is_foreign_key only matches ForeignKey."""
+    fk_type = ForeignKey("User")
+    m2m_type = ManyToMany("Group")
+    rel_type = Relation("follows", "User")
+
+    assert is_foreign_key(fk_type) is True
+    assert is_foreign_key(m2m_type) is False
+    assert is_foreign_key(rel_type) is False
+
+
+def test_is_many_to_many_specific() -> None:
+    """Test is_many_to_many only matches ManyToMany."""
+    fk_type = ForeignKey("User")
+    m2m_type = ManyToMany("Group")
+    rel_type = Relation("follows", "User")
+
+    assert is_many_to_many(fk_type) is False
+    assert is_many_to_many(m2m_type) is True
+    assert is_many_to_many(rel_type) is False
+
+
+def test_is_graph_relation_specific() -> None:
+    """Test is_graph_relation only matches Relation."""
+    fk_type = ForeignKey("User")
+    m2m_type = ManyToMany("Group")
+    rel_type = Relation("follows", "User")
+
+    assert is_graph_relation(fk_type) is False
+    assert is_graph_relation(m2m_type) is False
+    assert is_graph_relation(rel_type) is True
+
+
+# ==================== RelationInfo Tests ====================
+
+
+def test_relation_info_traversal_direction_forward() -> None:
+    """Test RelationInfo.traversal_direction for forward relations."""
+    info = RelationInfo(
+        to_model="User",
+        relation_type="relation",
+        edge_table="follows",
+        reverse=False,
+    )
+    assert info.traversal_direction == "->"
+
+
+def test_relation_info_traversal_direction_reverse() -> None:
+    """Test RelationInfo.traversal_direction for reverse relations."""
+    info = RelationInfo(
+        to_model="User",
+        relation_type="relation",
+        edge_table="follows",
+        reverse=True,
+    )
+    assert info.traversal_direction == "<-"
+
+
+def test_relation_info_traversal_query_forward() -> None:
+    """Test RelationInfo.get_traversal_query for forward relations."""
+    info = RelationInfo(
+        to_model="User",
+        relation_type="relation",
+        edge_table="follows",
+        reverse=False,
+    )
+    query = info.get_traversal_query("users", "alice")
+    assert "users:alice->follows->User" in query
+
+
+def test_relation_info_traversal_query_reverse() -> None:
+    """Test RelationInfo.get_traversal_query for reverse relations."""
+    info = RelationInfo(
+        to_model="User",
+        relation_type="relation",
+        edge_table="follows",
+        reverse=True,
+    )
+    query = info.get_traversal_query("users", "alice")
+    assert "users:alice<-follows<-User" in query
+
+
+# ==================== QuerySet Extension Tests ====================
+
+
+def test_queryset_has_select_related() -> None:
+    """Test that QuerySet has select_related method."""
+    qs = User.objects()
+    assert hasattr(qs, "select_related")
+    assert callable(getattr(qs, "select_related"))
+
+
+def test_queryset_select_related_is_chainable() -> None:
+    """Test that select_related returns self for chaining."""
+    qs = User.objects()
+    result = qs.select_related("profile")
+    assert result is qs
+
+
+def test_queryset_select_related_stores_relations() -> None:
+    """Test that select_related stores the relation names."""
+    qs = User.objects().select_related("profile", "settings")
+    assert qs._select_related == ["profile", "settings"]
+
+
+def test_queryset_has_prefetch_related() -> None:
+    """Test that QuerySet has prefetch_related method."""
+    qs = User.objects()
+    assert hasattr(qs, "prefetch_related")
+    assert callable(getattr(qs, "prefetch_related"))
+
+
+def test_queryset_prefetch_related_is_chainable() -> None:
+    """Test that prefetch_related returns self for chaining."""
+    qs = User.objects()
+    result = qs.prefetch_related("followers")
+    assert result is qs
+
+
+def test_queryset_prefetch_related_stores_relations() -> None:
+    """Test that prefetch_related stores the relation names."""
+    qs = User.objects().prefetch_related("followers", "posts")
+    assert qs._prefetch_related == ["followers", "posts"]
+
+
+def test_queryset_has_traverse() -> None:
+    """Test that QuerySet has traverse method."""
+    qs = User.objects()
+    assert hasattr(qs, "traverse")
+    assert callable(getattr(qs, "traverse"))
+
+
+def test_queryset_traverse_is_chainable() -> None:
+    """Test that traverse returns self for chaining."""
+    qs = User.objects()
+    result = qs.traverse("->follows->users")
+    assert result is qs
+
+
+def test_queryset_traverse_stores_path() -> None:
+    """Test that traverse stores the traversal path."""
+    qs = User.objects().traverse("->follows->users->likes->posts")
+    assert qs._traversal_path == "->follows->users->likes->posts"
+
+
+def test_queryset_has_graph_query() -> None:
+    """Test that QuerySet has graph_query method."""
+    qs = User.objects()
+    assert hasattr(qs, "graph_query")
+    assert callable(getattr(qs, "graph_query"))
+
+
+def test_queryset_chain_filter_and_traverse() -> None:
+    """Test chaining filter with traverse."""
+    qs = User.objects().filter(active=True).traverse("->follows->users")
+    assert qs._filters == [("active", "exact", True)]
+    assert qs._traversal_path == "->follows->users"
+
+
+# ==================== Model Method Tests ====================
+
+
+def test_model_has_relate_method() -> None:
+    """Test that BaseSurrealModel has relate method."""
+    assert hasattr(User, "relate")
+    assert callable(getattr(User, "relate"))
+
+
+def test_model_has_remove_relation_method() -> None:
+    """Test that BaseSurrealModel has remove_relation method."""
+    assert hasattr(User, "remove_relation")
+    assert callable(getattr(User, "remove_relation"))
+
+
+def test_model_has_get_related_method() -> None:
+    """Test that BaseSurrealModel has get_related method."""
+    assert hasattr(User, "get_related")
+    assert callable(getattr(User, "get_related"))
+
+
+def test_model_relate_signature() -> None:
+    """Test relate method signature."""
+    import inspect
+
+    sig = inspect.signature(User.relate)
+    params = list(sig.parameters.keys())
+    assert "relation" in params
+    assert "to" in params
+    assert "tx" in params
+
+
+def test_model_remove_relation_signature() -> None:
+    """Test remove_relation method signature."""
+    import inspect
+
+    sig = inspect.signature(User.remove_relation)
+    params = list(sig.parameters.keys())
+    assert "relation" in params
+    assert "to" in params
+    assert "tx" in params
+
+
+def test_model_get_related_signature() -> None:
+    """Test get_related method signature."""
+    import inspect
+
+    sig = inspect.signature(User.get_related)
+    params = list(sig.parameters.keys())
+    assert "relation" in params
+    assert "direction" in params
+    assert "model_class" in params
+
+
+# ==================== Import/Export Tests ====================
+
+
+def test_relation_types_exported_from_fields() -> None:
+    """Test that relation types are exported from fields module."""
+    from src.surreal_orm.fields import ForeignKey, ManyToMany, Relation, RelationInfo
+
+    assert ForeignKey is not None
+    assert ManyToMany is not None
+    assert Relation is not None
+    assert RelationInfo is not None
+
+
+def test_helper_functions_exported_from_fields() -> None:
+    """Test that helper functions are exported from fields module."""
+    from src.surreal_orm.fields import (
+        get_relation_info,
+        is_foreign_key,
+        is_graph_relation,
+        is_many_to_many,
+        is_relation_field,
+    )
+
+    assert is_relation_field is not None
+    assert is_foreign_key is not None
+    assert is_many_to_many is not None
+    assert is_graph_relation is not None
+    assert get_relation_info is not None

--- a/tests/test_relations_integration.py
+++ b/tests/test_relations_integration.py
@@ -1,0 +1,368 @@
+"""Integration tests for ORM v0.4.0 features: relations and graph traversal."""
+
+import pytest
+from pydantic import Field
+from typing import AsyncGenerator, Any
+from src.surreal_orm.model_base import BaseSurrealModel
+from src.surreal_orm import SurrealDBConnectionManager
+
+
+SURREALDB_URL = "http://localhost:8001"
+SURREALDB_USER = "root"
+SURREALDB_PASS = "root"
+SURREALDB_NAMESPACE = "test"
+SURREALDB_DATABASE = "test_relations"
+
+
+class User(BaseSurrealModel):
+    """Test model for relation tests."""
+
+    id: str | None = None
+    name: str = Field(...)
+    active: bool = Field(default=True)
+
+
+class Post(BaseSurrealModel):
+    """Test model for relation tests."""
+
+    id: str | None = None
+    title: str = Field(...)
+    content: str = Field(default="")
+
+
+@pytest.fixture(scope="module", autouse=True)
+async def setup_connection() -> AsyncGenerator[Any, Any]:
+    """Setup connection for the test module."""
+    SurrealDBConnectionManager.set_connection(
+        SURREALDB_URL,
+        SURREALDB_USER,
+        SURREALDB_PASS,
+        SURREALDB_NAMESPACE,
+        SURREALDB_DATABASE,
+    )
+    yield
+    await SurrealDBConnectionManager.close_connection()
+    await SurrealDBConnectionManager.unset_connection()
+
+
+@pytest.fixture(autouse=True)
+async def cleanup_tables() -> AsyncGenerator[Any, Any]:
+    """Clean up tables before and after each test."""
+    # Clean up before test
+    client = await SurrealDBConnectionManager.get_client()
+    try:
+        await client.query("DELETE User;")
+        await client.query("DELETE Post;")
+        await client.query("DELETE follows;")
+        await client.query("DELETE likes;")
+    except Exception:
+        pass
+    yield
+    # Clean up after test
+    try:
+        await client.query("DELETE User;")
+        await client.query("DELETE Post;")
+        await client.query("DELETE follows;")
+        await client.query("DELETE likes;")
+    except Exception:
+        pass
+
+
+@pytest.fixture
+async def sample_users() -> list[User]:
+    """Create sample users for testing."""
+    users = [
+        User(id="alice", name="Alice", active=True),
+        User(id="bob", name="Bob", active=True),
+        User(id="charlie", name="Charlie", active=True),
+        User(id="david", name="David", active=False),
+    ]
+    for user in users:
+        await user.save()
+    return users
+
+
+@pytest.fixture
+async def sample_posts() -> list[Post]:
+    """Create sample posts for testing."""
+    posts = [
+        Post(id="post1", title="First Post", content="Hello World"),
+        Post(id="post2", title="Second Post", content="Another post"),
+        Post(id="post3", title="Third Post", content="Yet another"),
+    ]
+    for post in posts:
+        await post.save()
+    return posts
+
+
+# ==================== Model.relate() Tests ====================
+
+
+@pytest.mark.integration
+async def test_relate_creates_edge(sample_users: list[User]) -> None:
+    """Test that relate() creates a graph edge."""
+    alice, bob = sample_users[0], sample_users[1]
+
+    # Create relation
+    result = await alice.relate("follows", bob)
+
+    assert result is not None
+    assert "in" in result or "out" in result
+
+
+@pytest.mark.integration
+async def test_relate_with_edge_data(sample_users: list[User]) -> None:
+    """Test relate() with edge data."""
+    alice, bob = sample_users[0], sample_users[1]
+
+    # Create relation with data
+    result = await alice.relate("follows", bob, since="2025-01-01", strength="strong")
+
+    assert result is not None
+
+
+@pytest.mark.integration
+async def test_relate_in_transaction(sample_users: list[User]) -> None:
+    """Test relate() within a transaction."""
+    alice, bob, charlie = sample_users[0], sample_users[1], sample_users[2]
+
+    async with await SurrealDBConnectionManager.transaction() as tx:
+        await alice.relate("follows", bob, tx=tx)
+        await alice.relate("follows", charlie, tx=tx)
+
+    # Verify relations were created
+    following = await alice.get_related("follows", direction="out", model_class=User)
+    assert len(following) == 2
+
+
+@pytest.mark.integration
+async def test_relate_raises_for_unsaved_source() -> None:
+    """Test that relate() raises error for unsaved source."""
+    alice = User(name="Alice")  # Not saved
+    bob = User(id="bob", name="Bob")
+    await bob.save()
+
+    with pytest.raises(Exception) as exc:
+        await alice.relate("follows", bob)
+
+    assert "unsaved" in str(exc.value).lower()
+
+
+@pytest.mark.integration
+async def test_relate_raises_for_unsaved_target(sample_users: list[User]) -> None:
+    """Test that relate() raises error for unsaved target."""
+    alice = sample_users[0]
+    eve = User(name="Eve")  # Not saved
+
+    with pytest.raises(Exception) as exc:
+        await alice.relate("follows", eve)
+
+    assert "unsaved" in str(exc.value).lower()
+
+
+# ==================== Model.get_related() Tests ====================
+
+
+@pytest.mark.integration
+async def test_get_related_outgoing(sample_users: list[User]) -> None:
+    """Test get_related() for outgoing relations."""
+    alice, bob, charlie = sample_users[0], sample_users[1], sample_users[2]
+
+    # Create relations
+    await alice.relate("follows", bob)
+    await alice.relate("follows", charlie)
+
+    # Get outgoing relations
+    following = await alice.get_related("follows", direction="out", model_class=User)
+
+    assert len(following) == 2
+    following_ids = {u.id for u in following}
+    assert "bob" in following_ids
+    assert "charlie" in following_ids
+
+
+@pytest.mark.integration
+async def test_get_related_incoming(sample_users: list[User]) -> None:
+    """Test get_related() for incoming relations."""
+    alice, bob, charlie = sample_users[0], sample_users[1], sample_users[2]
+
+    # Create relations where bob and charlie follow alice
+    await bob.relate("follows", alice)
+    await charlie.relate("follows", alice)
+
+    # Get incoming relations (followers)
+    followers = await alice.get_related("follows", direction="in", model_class=User)
+
+    assert len(followers) == 2
+    follower_ids = {u.id for u in followers}
+    assert "bob" in follower_ids
+    assert "charlie" in follower_ids
+
+
+@pytest.mark.integration
+async def test_get_related_returns_empty_when_none(sample_users: list[User]) -> None:
+    """Test get_related() returns empty list when no relations."""
+    alice = sample_users[0]
+
+    following = await alice.get_related("follows", direction="out", model_class=User)
+
+    assert following == []
+
+
+@pytest.mark.integration
+async def test_get_related_without_model_class(sample_users: list[User]) -> None:
+    """Test get_related() returns dicts when no model_class."""
+    alice, bob = sample_users[0], sample_users[1]
+
+    await alice.relate("follows", bob)
+
+    following = await alice.get_related("follows", direction="out")
+
+    assert len(following) == 1
+    assert isinstance(following[0], dict)
+
+
+# ==================== Model.remove_relation() Tests ====================
+
+
+@pytest.mark.integration
+async def test_remove_relation(sample_users: list[User]) -> None:
+    """Test remove_relation() removes the edge."""
+    alice, bob = sample_users[0], sample_users[1]
+
+    # Create then remove relation
+    await alice.relate("follows", bob)
+    await alice.remove_relation("follows", bob)
+
+    # Verify relation removed
+    following = await alice.get_related("follows", direction="out", model_class=User)
+    assert len(following) == 0
+
+
+@pytest.mark.integration
+async def test_remove_relation_in_transaction(sample_users: list[User]) -> None:
+    """Test remove_relation() within a transaction."""
+    alice, bob, charlie = sample_users[0], sample_users[1], sample_users[2]
+
+    # Create relations
+    await alice.relate("follows", bob)
+    await alice.relate("follows", charlie)
+
+    # Remove in transaction
+    async with await SurrealDBConnectionManager.transaction() as tx:
+        await alice.remove_relation("follows", bob, tx=tx)
+
+    # Verify only charlie remains
+    following = await alice.get_related("follows", direction="out", model_class=User)
+    assert len(following) == 1
+    assert following[0].id == "charlie"
+
+
+# ==================== Mixed Relations Tests ====================
+
+
+@pytest.mark.integration
+async def test_user_follows_user_and_likes_post(
+    sample_users: list[User],
+    sample_posts: list[Post],
+) -> None:
+    """Test multiple relation types."""
+    alice, bob = sample_users[0], sample_users[1]
+    post1, post2 = sample_posts[0], sample_posts[1]
+
+    # Alice follows Bob
+    await alice.relate("follows", bob)
+
+    # Alice likes posts
+    await alice.relate("likes", post1)
+    await alice.relate("likes", post2)
+
+    # Verify
+    following = await alice.get_related("follows", direction="out", model_class=User)
+    liked_posts = await alice.get_related("likes", direction="out", model_class=Post)
+
+    assert len(following) == 1
+    assert following[0].id == "bob"
+    assert len(liked_posts) == 2
+
+
+@pytest.mark.integration
+async def test_bidirectional_relations(sample_users: list[User]) -> None:
+    """Test mutual follow relationships."""
+    alice, bob = sample_users[0], sample_users[1]
+
+    # Mutual follow
+    await alice.relate("follows", bob)
+    await bob.relate("follows", alice)
+
+    # Check both directions
+    alice_following = await alice.get_related("follows", direction="out", model_class=User)
+    alice_followers = await alice.get_related("follows", direction="in", model_class=User)
+
+    assert len(alice_following) == 1
+    assert alice_following[0].id == "bob"
+    assert len(alice_followers) == 1
+    assert alice_followers[0].id == "bob"
+
+
+# ==================== QuerySet Traversal Tests ====================
+
+
+@pytest.mark.integration
+async def test_graph_query_basic(sample_users: list[User]) -> None:
+    """Test graph_query() method."""
+    alice, bob, charlie = sample_users[0], sample_users[1], sample_users[2]
+
+    # Create relations
+    await alice.relate("follows", bob)
+    await alice.relate("follows", charlie)
+
+    # Query using graph_query
+    result = await User.objects().filter(id="alice").graph_query("->follows->User")
+
+    assert len(result) == 2
+
+
+@pytest.mark.integration
+async def test_traverse_simple(sample_users: list[User]) -> None:
+    """Test traverse() method."""
+    alice, bob = sample_users[0], sample_users[1]
+
+    await alice.relate("follows", bob)
+
+    # Use traverse
+    qs = User.objects().filter(id="alice").traverse("->follows->User")
+
+    # Verify the path is stored
+    assert qs._traversal_path == "->follows->User"
+
+
+# ==================== Edge Cases ====================
+
+
+@pytest.mark.integration
+async def test_relate_same_user_twice(sample_users: list[User]) -> None:
+    """Test creating the same relation twice."""
+    alice, bob = sample_users[0], sample_users[1]
+
+    # Create same relation twice
+    await alice.relate("follows", bob)
+    await alice.relate("follows", bob)  # Should create another edge or be idempotent
+
+    # Check results
+    following = await alice.get_related("follows", direction="out", model_class=User)
+    # SurrealDB may create duplicate edges
+    assert len(following) >= 1
+
+
+@pytest.mark.integration
+async def test_self_relation(sample_users: list[User]) -> None:
+    """Test user can follow themselves."""
+    alice = sample_users[0]
+
+    # Self-follow
+    await alice.relate("follows", alice)
+
+    following = await alice.get_related("follows", direction="out", model_class=User)
+    assert len(following) == 1
+    assert following[0].id == "alice"


### PR DESCRIPTION
## Summary

- **Relation Field Types**: `ForeignKey`, `ManyToMany`, `Relation` for declarative relation definitions
- **Relation Operations**: `RelationManager` with `add()`, `remove()`, `set()`, `clear()`, `all()`, `filter()`, `count()`, `contains()`
- **Graph Traversal**: `traverse()` and `graph_query()` for SurrealDB graph queries
- **Eager Loading**: `select_related()` and `prefetch_related()` for N+1 prevention
- **Model Methods**: `relate()`, `remove_relation()`, `get_related()` for low-level graph operations
- **CI/CD**: Automatic PyPI publish workflow on version tags

## Test Plan

- [x] Unit tests pass (86 tests)
- [ ] Integration tests pass in CI
- [ ] Linting passes (ruff, mypy)