### PR TITLE
feat(v0.5.3): ORM improvements, upsert behavior, bug fixes

### DIFF
--- a/.github/workflows/surrealdb-security.yml
+++ b/.github/workflows/surrealdb-security.yml
@@ -25,7 +25,7 @@ permissions:
   issues: write
 
 env:
-  SURREALDB_URL: http://localhost:8000
+  SURREALDB_URL: http://localhost:8001
   SURREALDB_USER: root
   SURREALDB_PASS: root
   SURREALDB_NAMESPACE: test
@@ -146,18 +146,18 @@ jobs:
         run: |
           echo "Testing with SurrealDB version: $SURREALDB_VERSION"
 
-          # Start SurrealDB with specific version
+          # Start SurrealDB with specific version on port 8001 (matching conftest.py TEST_PORT)
           docker run -d \
             --name surrealdb-test \
-            -p 8000:8000 \
+            -p 8001:8000 \
             "surrealdb/surrealdb:v${SURREALDB_VERSION}" \
             start --log error --user root --pass root memory
 
           # Wait for healthy
-          ./devops/wait-for-healthy.sh localhost 8000 60
+          ./devops/wait-for-healthy.sh localhost 8001 60
 
           # Verify version
-          RUNNING_VERSION=$(curl -s http://localhost:8000/version || echo "unknown")
+          RUNNING_VERSION=$(curl -s http://localhost:8001/version || echo "unknown")
           echo "Running SurrealDB version: $RUNNING_VERSION"
 
       - name: Run unit tests

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,52 @@ and adheres to [SemVer](https://semver.org/) versioning.
 
 ---
 
+## [0.5.3] - 2026-02-02
+
+### Added
+
+- **`upsert()` Method** - New SDK method for create-or-update operations
+  - Added to `BaseSurrealConnection` and all transaction types
+  - Enables idempotent save behavior for existing records
+
+- **`server_fields` Config Option** - Exclude server-generated fields from saves
+  - New `server_fields` option in `SurrealConfigDict`
+  - Automatically excludes fields like `created_at`, `updated_at` from save/update
+  - Prevents datetime serialization errors on subsequent saves
+
+- **`_update_from_db()` Helper** - Internal method for DB data loading
+  - Updates model fields without marking them as user-set
+  - Preserves `__pydantic_fields_set__` for correct `exclude_unset` behavior
+
+### Fixed
+
+- **Bug #2: NULL Values** - `exclude_unset=True` now works after loading from DB
+  - `_update_from_db()` preserves original `__pydantic_fields_set__`
+  - Subsequent saves don't include DB-loaded fields as user-set
+
+- **Bug #7: save() Returns New Instance** - Now updates original instance
+  - `save()` updates `self` attributes in place instead of returning new object
+  - Uses `_update_from_db()` for consistent field handling
+
+- **Bug #8: datetime Serialization for UPDATE** - Fixed via `server_fields`
+  - Server-generated datetime fields excluded from save operations
+  - No more "expected datetime" errors on second save
+
+- **Bug #9: merge() Returns None** - Now returns `self`
+  - `merge()` method signature updated to return `Self`
+  - Updates local instance with merged data before returning
+
+### Changed
+
+- **`save()` Uses Upsert** - Idempotent behavior for existing records
+  - When ID is set, `save()` now uses `upsert` instead of `create`
+  - No more "record already exists" errors on duplicate saves
+  - **Breaking:** save() with duplicate ID now updates instead of failing
+
+- Version bump to 0.5.3
+
+---
+
 ## [0.5.2] - 2026-02-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,22 @@
 
 ---
 
-## Current Version: 0.5.2 (Alpha)
+## Current Version: 0.5.3 (Alpha)
+
+### What's New in 0.5.3
+
+- **ORM Improvements** - Better save/update behavior
+  - **Upsert behavior** - `save()` now uses `upsert` for existing records (idempotent, Django-like)
+  - **`server_fields` config** - Exclude server-generated fields (created_at, updated_at) from save/update
+  - **`merge()` returns self** - Now returns the updated model instance instead of None
+  - **`save()` updates self** - No longer returns new instance, updates original in place
+
+- **Bug Fixes** - Critical fixes for ORM
+  - **NULL values fix** - `_update_from_db()` preserves `__pydantic_fields_set__` so `exclude_unset=True` works after DB load
+  - **datetime for UPDATE** - Server fields excluded via `server_fields` config option
+
+- **SDK Enhancements**
+  - **`upsert()` method** - Added to `BaseSurrealConnection` and transactions for create-or-update operations
 
 ### What's New in 0.5.2
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@
 
 ## What's New in 0.5.x
 
+### v0.5.3 - ORM Improvements
+
+- **Upsert save behavior** - `save()` now uses `upsert` for existing records (idempotent, Django-like)
+- **`server_fields` config** - Exclude server-generated fields (created_at, updated_at) from saves
+- **`merge()` returns self** - Now returns the updated model instance instead of None
+- **`save()` updates self** - Updates original instance attributes instead of returning new object
+- **NULL values fix** - `exclude_unset=True` now works correctly after loading from DB
+
 ### v0.5.2 - Bug Fixes & FieldType Improvements
 
 - **FieldType enum** - Enhanced migration type system with `generic()` and `from_python_type()` methods

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,10 @@
 | 0.3.0     | Released     | ORM Transactions + Aggregations                               |
 | 0.3.1     | Released     | Bulk Operations + Bug Fixes                                   |
 | 0.4.0     | Released     | Relations & Graph Traversal                                   |
-| **0.5.0** | **Released** | **SDK Real-time: Live Select, Auto-Resubscribe, Typed Calls** |
+| 0.5.0     | Released     | SDK Real-time: Live Select, Auto-Resubscribe, Typed Calls     |
+| 0.5.1     | Released     | Security Workflows (Dependabot, SurrealDB monitoring)         |
+| 0.5.2     | Released     | Bug Fixes & FieldType Improvements                            |
+| **0.5.3** | **Released** | **ORM Improvements: Upsert, server_fields, merge() fix**      |
 | 0.5.5     | Planned      | Computed Fields                                               |
 | 0.6.x     | Planned      | ORM Live Models + Signals                                     |
 
@@ -307,7 +310,84 @@ Rich change notification with:
 
 ---
 
-## v0.5.1 - Computed Fields (Planned)
+## v0.5.1 - Security Workflows (Released)
+
+**Goal:** Automated security update management for dependencies and SurrealDB.
+
+**Status:** Implemented and released.
+
+### Dependabot Integration
+
+- Auto-merge for Dependabot PRs after CI passes
+- Patch version tagging (x.x.x.1, x.x.x.2, etc.) for security updates
+- Automatic GitHub releases for security patches
+
+### SurrealDB Security Monitoring
+
+- Daily checks for new SurrealDB releases
+- Automatic integration tests with new DB versions
+- Auto-update of DB requirements on security patches
+- Issue creation for compatibility failures
+
+---
+
+## v0.5.2 - Bug Fixes & FieldType Improvements (Released)
+
+**Goal:** Critical bug fixes and enhanced migration type system.
+
+**Status:** Implemented and released.
+
+### FieldType Enum Improvements
+
+- Added `NUMBER`, `SET`, `REGEX` types
+- `generic(inner_type)` method for parameterized types (`array<string>`, `record<users>`)
+- `from_python_type(type)` class method for automatic type mapping
+- Comprehensive docstrings with SurrealDB type documentation
+
+### Bug Fixes
+
+- **datetime Serialization** - Custom JSON encoder for RPC requests
+- **NULL Values** - `exclude_unset=True` prevents None from overriding DB defaults
+- **Fluent API** - `connect()` returns `self` for method chaining
+- **Session Cleanup** - WebSocket callback tasks properly tracked and cancelled
+- **Parameter Alias** - `username` parameter alias for `user` in ConnectionManager
+
+---
+
+## v0.5.3 - ORM Improvements (Released)
+
+**Goal:** Better save/update behavior with upsert support and server field handling.
+
+**Status:** Implemented and released.
+
+### Upsert Behavior
+
+- `save()` now uses `upsert` for existing records (idempotent, Django-like)
+- No more "record already exists" errors on duplicate saves
+- SDK `upsert()` method added to connections and transactions
+
+### Server Fields Config
+
+```python
+class MyModel(BaseSurrealModel):
+    model_config = SurrealConfigDict(
+        server_fields=["created_at", "updated_at"],  # Excluded from save/update
+    )
+
+    name: str
+    created_at: datetime | None = None  # Server-generated
+    updated_at: datetime | None = None  # Server-generated
+```
+
+### Bug Fixes
+
+- **merge() returns self** - Now returns the updated model instance
+- **save() updates self** - Updates original instance instead of returning new object
+- **NULL values fix** - `_update_from_db()` preserves `__pydantic_fields_set__`
+
+---
+
+## v0.5.5 - Computed Fields (Planned)
 
 **Goal:** Server-side computed fields using SurrealDB functions.
 
@@ -440,7 +520,10 @@ users = await User.objects().filter(age__gt=18).using_index("idx_age").all()
 | Live Select Stream           | 0.5.0   | High     | Done    | SDK WebSocket    |
 | Auto-Resubscribe             | 0.5.0   | High     | Done    | Live Select      |
 | Typed Function Calls         | 0.5.0   | Medium   | Done    | SDK functions    |
-| Computed Fields              | 0.5.1   | Medium   | Planned | SDK functions    |
+| Security Workflows           | 0.5.1   | High     | Done    | -                |
+| FieldType Improvements       | 0.5.2   | Medium   | Done    | -                |
+| Upsert & server_fields       | 0.5.3   | High     | Done    | -                |
+| Computed Fields              | 0.5.5   | Medium   | Planned | SDK functions    |
 | ORM Live Models              | 0.6.0   | Medium   | Planned | SDK live queries |
 | Model Signals                | 0.6.0   | Low      | Planned | Live Models      |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surrealdb-orm"
-version = "0.5.2"
+version = "0.5.3"
 description = "SurrealDB ORM as 'DJango style' for Python with async support. Works with pydantic validation."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/surreal_sdk/connection/base.py
+++ b/src/surreal_sdk/connection/base.py
@@ -315,6 +315,23 @@ class BaseSurrealConnection(ABC):
         result = await self.rpc("update", [thing, data])
         return RecordsResponse.from_rpc_result(result)
 
+    async def upsert(self, thing: str, data: dict[str, Any]) -> RecordsResponse:
+        """
+        Upsert record(s) - create if not exists, update if exists.
+
+        This is the recommended method for save operations when you have
+        a specific ID and want idempotent behavior.
+
+        Args:
+            thing: Table name or record ID
+            data: Record data
+
+        Returns:
+            RecordsResponse containing upserted record(s)
+        """
+        result = await self.rpc("upsert", [thing, data])
+        return RecordsResponse.from_rpc_result(result)
+
     async def merge(self, thing: str, data: dict[str, Any]) -> RecordsResponse:
         """
         Merge data into record(s), updating only specified fields.

--- a/tests/test_bugfix_0_5_3.py
+++ b/tests/test_bugfix_0_5_3.py
@@ -1,0 +1,367 @@
+"""
+Tests for v0.5.3 bug fixes.
+
+Bug #2: NULL values for unset fields (fixed with _update_from_db)
+Bug #7: save() returns new instance instead of updating self
+Bug #8: datetime serialization for UPDATE (fixed with server_fields)
+Bug #9: merge() returns None instead of self
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.surreal_orm import SurrealDBConnectionManager
+from src.surreal_orm.model_base import BaseSurrealModel, SurrealConfigDict
+
+
+# Test URLs - use same ports as other integration tests
+SURREALDB_URL = "http://localhost:8001"
+SURREALDB_WS_URL = "ws://localhost:8001"
+
+
+# =============================================================================
+# Test Models
+# =============================================================================
+
+
+class SimpleModel(BaseSurrealModel):
+    """Simple model for basic tests."""
+
+    id: str | None = None
+    name: str
+    status: str = "pending"
+
+
+class ModelWithOptionalField(BaseSurrealModel):
+    """Model with optional field for Bug #2 tests."""
+
+    id: str | None = None
+    name: str
+    email: str | None = None
+    age: int | None = None
+
+
+class ModelWithServerFields(BaseSurrealModel):
+    """Model with server-generated fields for Bug #8 tests."""
+
+    model_config = SurrealConfigDict(
+        server_fields=["created_at", "updated_at"],
+    )
+
+    id: str | None = None
+    name: str
+    status: str = "pending"
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+# =============================================================================
+# Bug #2: NULL values for None fields
+# =============================================================================
+
+
+class TestBug2NullValues:
+    """Test that unset optional fields are not sent as NULL."""
+
+    def test_model_dump_excludes_unset_fields(self):
+        """Unset optional fields should not be in model_dump with exclude_unset."""
+        model = ModelWithOptionalField(name="Alice")
+
+        # Only 'name' was explicitly set
+        data = model.model_dump(exclude={"id"}, exclude_unset=True)
+
+        assert "name" in data
+        assert data["name"] == "Alice"
+        assert "email" not in data
+        assert "age" not in data
+
+    def test_update_from_db_preserves_fields_set(self):
+        """_update_from_db should not mark fields as user-set."""
+        model = ModelWithOptionalField(name="Alice")
+
+        # Verify only 'name' is marked as set
+        assert model.__pydantic_fields_set__ == {"name"}
+
+        # Simulate loading from DB
+        db_record = {"id": "123", "name": "Alice", "email": "alice@example.com", "age": 30}
+        model._update_from_db(db_record)
+
+        # Fields should be updated
+        assert model.id == "123"
+        assert model.email == "alice@example.com"
+        assert model.age == 30
+
+        # But only 'name' should still be in fields_set
+        assert model.__pydantic_fields_set__ == {"name"}
+
+        # So exclude_unset should still exclude email and age
+        data = model.model_dump(exclude={"id"}, exclude_unset=True)
+        assert "name" in data
+        assert "email" not in data
+        assert "age" not in data
+
+    def test_explicitly_set_none_is_included(self):
+        """If user explicitly sets field to None, it should be included."""
+        model = ModelWithOptionalField(name="Alice", email=None)
+
+        # Both 'name' and 'email' were explicitly set
+        assert "name" in model.__pydantic_fields_set__
+        assert "email" in model.__pydantic_fields_set__
+
+        data = model.model_dump(exclude={"id"}, exclude_unset=True)
+        assert "name" in data
+        assert "email" in data
+        assert data["email"] is None
+
+
+# =============================================================================
+# Bug #7: save() returns new instance instead of updating self
+# =============================================================================
+
+
+class TestBug7SaveUpdatesSelf:
+    """Test that save() updates the original instance."""
+
+    def test_update_from_db_updates_instance(self):
+        """_update_from_db should update the instance in place."""
+        model = SimpleModel(name="Original")
+
+        # Verify initial state
+        assert model.name == "Original"
+        assert model.id is None
+
+        # Simulate DB response with generated ID
+        db_record = {"id": "SimpleModel:abc123", "name": "Original", "status": "active"}
+        model._update_from_db(db_record)
+
+        # Instance should be updated in place
+        assert model.id == "abc123"  # ID is parsed from record format
+        assert model.status == "active"
+
+    def test_save_preserves_identity(self):
+        """After save(), the returned object should be the same instance (or at least same ID)."""
+        # This is a unit test that verifies the code structure
+        # Integration test would verify actual DB behavior
+        model = SimpleModel(name="Test")
+        original_id = id(model)
+
+        # Simulate what happens after save when ID is provided
+        model_id = "test123"
+        object.__setattr__(model, "id", model_id)
+
+        # Verify the instance is the same object
+        assert id(model) == original_id
+        assert model.id == "test123"
+
+
+# =============================================================================
+# Bug #8: datetime serialization for UPDATE (server_fields)
+# =============================================================================
+
+
+class TestBug8ServerFields:
+    """Test that server_fields are excluded from save/update."""
+
+    def test_get_server_fields_returns_configured_fields(self):
+        """get_server_fields should return the configured set."""
+        server_fields = ModelWithServerFields.get_server_fields()
+
+        assert isinstance(server_fields, set)
+        assert "created_at" in server_fields
+        assert "updated_at" in server_fields
+
+    def test_get_server_fields_empty_when_not_configured(self):
+        """get_server_fields should return empty set when not configured."""
+        server_fields = SimpleModel.get_server_fields()
+
+        assert isinstance(server_fields, set)
+        assert len(server_fields) == 0
+
+    def test_model_dump_excludes_server_fields(self):
+        """Server fields should be excluded from model_dump for save."""
+        now = datetime.now(timezone.utc)
+        model = ModelWithServerFields(
+            name="Test",
+            status="active",
+            created_at=now,
+            updated_at=now,
+        )
+
+        # Build exclude set like save() does
+        exclude_fields = {"id"} | model.get_server_fields()
+        data = model.model_dump(exclude=exclude_fields, exclude_unset=True)
+
+        assert "name" in data
+        assert "status" in data
+        assert "created_at" not in data
+        assert "updated_at" not in data
+
+    def test_server_fields_in_model_config(self):
+        """server_fields should be accessible via model_config."""
+        config = ModelWithServerFields.model_config
+        assert "server_fields" in config
+        assert config["server_fields"] == ["created_at", "updated_at"]
+
+
+# =============================================================================
+# Bug #9: merge() returns None instead of self
+# =============================================================================
+
+
+class TestBug9MergeReturnsSelf:
+    """Test that merge() returns the updated model instance."""
+
+    def test_merge_return_type_is_self(self):
+        """merge() method signature should return Self."""
+        import inspect
+
+        sig = inspect.signature(BaseSurrealModel.merge)
+        # Check return annotation is Self
+        assert sig.return_annotation.__name__ == "Self"
+
+
+# =============================================================================
+# Integration Tests
+# =============================================================================
+
+
+@pytest.fixture(scope="module", autouse=True)
+async def setup_connection():
+    """Setup connection for integration tests."""
+    SurrealDBConnectionManager.set_connection(
+        SURREALDB_URL,
+        "root",
+        "root",
+        "test",
+        "test_bugfix_053",
+    )
+    yield
+    await SurrealDBConnectionManager.close_connection()
+    await SurrealDBConnectionManager.unset_connection()
+
+
+@pytest.fixture(autouse=True)
+async def cleanup_tables():
+    """Clean up test tables before and after each test."""
+    tables = ["SimpleModel", "ModelWithOptionalField", "ModelWithServerFields"]
+    try:
+        client = await SurrealDBConnectionManager.get_client()
+        for table in tables:
+            try:
+                await client.query(f"DELETE {table};")
+            except Exception:
+                pass
+    except Exception:
+        pass
+    yield
+    try:
+        client = await SurrealDBConnectionManager.get_client()
+        for table in tables:
+            try:
+                await client.query(f"DELETE {table};")
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+
+@pytest.mark.integration
+class TestBug7Integration:
+    """Integration tests for Bug #7: save() updates self."""
+
+    async def test_save_updates_self_with_generated_id(self):
+        """save() should update self with the generated ID."""
+        model = SimpleModel(name="TestUser")
+
+        # Before save, no ID
+        assert model.id is None
+
+        # Save returns self
+        returned = await model.save()
+
+        # Both should have the ID
+        assert model.id is not None
+        assert returned.id == model.id
+
+        # They should be the same instance (or at least have same ID)
+        assert returned.id == model.id
+
+
+@pytest.mark.integration
+class TestBug9Integration:
+    """Integration tests for Bug #9: merge() returns self."""
+
+    async def test_merge_returns_updated_model(self):
+        """merge() should return the updated model instance."""
+        # Create model
+        model = SimpleModel(id="merge_test_1", name="Original")
+        await model.save()
+
+        # Merge and check return
+        result = await model.merge(status="updated")
+
+        # Should return self
+        assert result is not None
+        assert result.status == "updated"
+        assert result.id == "merge_test_1"
+
+
+@pytest.mark.integration
+class TestBug2Integration:
+    """Integration tests for Bug #2: NULL values."""
+
+    async def test_unset_optional_fields_not_in_dump(self):
+        """Unset optional fields should not be included in model_dump."""
+        # Create model with only required field
+        model = ModelWithOptionalField(name="TestUser")
+
+        # Build exclude set like save() does
+        exclude_fields = {"id"} | model.get_server_fields()
+        data = model.model_dump(exclude=exclude_fields, exclude_unset=True)
+
+        # Only 'name' should be in the data, not email or age
+        assert "name" in data
+        assert "email" not in data
+        assert "age" not in data
+
+    async def test_save_preserves_fields_set_tracking(self):
+        """After save, fields_set should still only track user-set fields."""
+        model = ModelWithOptionalField(name="TestUser")
+
+        # Only 'name' should be marked as set
+        assert model.__pydantic_fields_set__ == {"name"}
+
+        # Save the model
+        await model.save()
+
+        # After save with auto-generated ID, fields_set should still only have 'name'
+        # (id is added by _update_from_db but not marked as user-set)
+        assert "name" in model.__pydantic_fields_set__
+        # Note: 'id' might be in fields_set depending on implementation,
+        # but the important thing is that email/age are NOT
+
+
+@pytest.mark.integration
+class TestBug8Integration:
+    """Integration tests for Bug #8: server_fields excluded."""
+
+    async def test_second_save_excludes_server_fields(self):
+        """Second save should not send server_fields back to DB."""
+        # Create model
+        model = ModelWithServerFields(name="TestUser", status="pending")
+
+        # First save
+        await model.save()
+        first_id = model.id
+
+        # Simulate server setting created_at (normally done by DB)
+        model.created_at = datetime.now(timezone.utc)
+
+        # Change status and save again
+        model.status = "active"
+        await model.save()
+
+        # Should still have same ID (no error from datetime)
+        assert model.id == first_id
+        assert model.status == "active"

--- a/uv.lock
+++ b/uv.lock
@@ -1527,7 +1527,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb-orm"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## New Features

- **Upsert behavior** - `save()` now uses `upsert` for existing records
  - Idempotent save (Django-like behavior)
  - No more "record already exists" errors on duplicate saves
  - SDK `upsert()` method added to connections and transactions

- **`server_fields` config** - Exclude server-generated fields from saves
  - New `server_fields` option in `SurrealConfigDict`
  - Automatically excludes fields like `created_at`, `updated_at`

- **`_update_from_db()` helper** - Updates model without marking fields as user-set
  - Preserves `__pydantic_fields_set__` for correct `exclude_unset` behavior

## Bug Fixes

- **#2 NULL values** - `exclude_unset=True` now works after loading from DB
- **#7 save() returns new instance** - Now updates original instance in place
- **#8 datetime for UPDATE** - Server fields excluded via `server_fields` config
- **#9 merge() returns None** - Now returns `self`

## Breaking Changes

- `save()` with existing ID now performs upsert instead of failing

## Documentation

- Updated CLAUDE.md, README.md, CHANGELOG, docs/roadmap.md
- Added v0.5.1, v0.5.2, v0.5.3 sections to roadmap
- Moved Computed Fields from v0.5.1 to v0.5.5