### PR TITLE
fix(dependabot): remove docker ecosystem config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,18 +51,3 @@ updates:
       - "github-actions"
     commit-message:
       prefix: "chore(actions)"
-
-  # Docker dependencies (SurrealDB image)
-  - package-ecosystem: "docker"
-    directory: "/devops"
-    schedule:
-      interval: "daily"
-      time: "06:00"
-      timezone: "America/Montreal"
-    open-pull-requests-limit: 3
-    labels:
-      - "dependencies"
-      - "surrealdb"
-      - "security"
-    commit-message:
-      prefix: "chore(docker)"


### PR DESCRIPTION
The docker ecosystem only supports Dockerfiles and Kubernetes YAML, not docker-compose.yml files. SurrealDB version monitoring is already handled by the surrealdb-security.yml workflow.