### PR TITLE
fix(ci): add SURREALDB_SKIP_CONTAINER to security workflow

### DIFF
--- a/.github/workflows/surrealdb-security.yml
+++ b/.github/workflows/surrealdb-security.yml
@@ -168,6 +168,9 @@ jobs:
             --cov-branch
 
       - name: Run integration tests
+        env:
+          # Tell conftest.py to skip container management - we already started it
+          SURREALDB_SKIP_CONTAINER: "true"
         run: |
           uv run pytest tests/ -m integration \
             --junitxml=junit-integration.xml \


### PR DESCRIPTION
The workflow starts a container with `docker run`, but conftest.py was also trying to start one via docker compose with the same name.

Add SURREALDB_SKIP_CONTAINER=true to tell conftest.py to skip container management when the container is already running.