### PR TITLE
feat(v0.5.3.2): fix QuerySet table name + add id= to get()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,15 @@
 
 ---
 
-## Current Version: 0.5.3.1 (Alpha)
+## Current Version: 0.5.3.2 (Alpha)
+
+### What's New in 0.5.3.2
+
+- **Critical Bug Fix**
+  - **QuerySet table name** - Fixed critical bug where QuerySet used class name (`MyModel`) instead of configured `table_name` from `model_config`. This caused queries to fail silently when using custom table names.
+
+- **API Improvements**
+  - **`QuerySet.get()` signature** - Now accepts both `id=` keyword and positional `id_item` parameter for better usability. All these work: `get("id")`, `get(id="id")`, `get(id_item="id")`.
 
 ### What's New in 0.5.3.1
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@
 
 ## What's New in 0.5.x
 
+### v0.5.3.2 - Critical Bug Fix
+
+- **QuerySet table name fix** - Fixed critical bug where QuerySet used class name instead of `table_name` from config
+- **`QuerySet.get()` signature** - Now accepts `id=` keyword argument in addition to positional `id_item`
+
 ### v0.5.3.1 - Bug Fixes
 
 - **Partial updates for persisted records** - `save()` now uses `merge()` for already-persisted records, only sending modified fields

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surrealdb-orm"
-version = "0.5.3.1"
+version = "0.5.3.2"
 description = "SurrealDB ORM as 'DJango style' for Python with async support. Works with pydantic validation."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1527,7 +1527,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb-orm"
-version = "0.5.3.1"
+version = "0.5.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Critical Bug Fix:
- QuerySet now uses model.get_table_name() instead of model.__name__
- This fixes queries failing when using custom table_name in model_config
- Root cause of reported "HTTP Auth not working" bug (Bug #10)

API Improvement:
- QuerySet.get() now accepts `id=` keyword argument as alias for `id_item`
- All three variants now work:
  - get("record_id")        # positional
  - get(id="record_id")     # new keyword
  - get(id_item="record_id") # original keyword