### PR TITLE
fix(v0.5.3.3): clear fields_set in from_db() for proper exclude_unset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,12 @@
 
 ---
 
-## Current Version: 0.5.3.2 (Alpha)
+## Current Version: 0.5.3.3 (Alpha)
+
+### What's New in 0.5.3.3
+
+- **Bug Fix**
+  - **`from_db()` fields_set** - Fixed bug where `from_db()` marked all fields as "user-set", causing `exclude_unset=True` to include DB-loaded fields (like `created_at`) in subsequent saves. Now `from_db()` clears `__pydantic_fields_set__` so only user-modified fields are sent during updates.
 
 ### What's New in 0.5.3.2
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
 
 ## What's New in 0.5.x
 
+### v0.5.3.3 - Bug Fix
+
+- **`from_db()` fields_set fix** - Fixed bug where DB-loaded fields were incorrectly included in updates via `exclude_unset=True`
+
 ### v0.5.3.2 - Critical Bug Fix
 
 - **QuerySet table name fix** - Fixed critical bug where QuerySet used class name instead of `table_name` from config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surrealdb-orm"
-version = "0.5.3.2"
+version = "0.5.3.3"
 description = "SurrealDB ORM as 'DJango style' for Python with async support. Works with pydantic validation."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/surreal_orm/model_base.py
+++ b/src/surreal_orm/model_base.py
@@ -322,6 +322,9 @@ class BaseSurrealModel(BaseModel):
 
         instance = cls(**record)
         instance._db_persisted = True
+        # Clear fields_set so DB-loaded fields aren't considered "user-set"
+        # This allows exclude_unset=True to work correctly on subsequent saves
+        object.__setattr__(instance, "__pydantic_fields_set__", set())
         return instance
 
     @model_validator(mode="before")

--- a/uv.lock
+++ b/uv.lock
@@ -1527,7 +1527,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb-orm"
-version = "0.5.3.2"
+version = "0.5.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Bug #8: datetime fields included in updates even when not modified

Root cause: from_db() creates instance via cls(**record) which marks ALL fields as "user-set" in __pydantic_fields_set__. This causes exclude_unset=True to include DB-loaded fields in subsequent saves.

Fix: Clear __pydantic_fields_set__ after creating instance in from_db(). Now only user-modified fields are sent during save/update operations.

Before: get() → fields_set={'id','name','created_at'} → save sends all
After:  get() → fields_set={} → modify name → fields_set={'name'} → save sends only name