### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, test-unit, test-integration, coverage]
     if: always()
+    permissions: {}
     steps:
       - name: Check all jobs passed
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/EulogySnowfall/SurrealDB-ORM/security/code-scanning/7](https://github.com/EulogySnowfall/SurrealDB-ORM/security/code-scanning/7)

In general, fix this by adding an explicit `permissions` block that grants the least privileges required, either at the workflow root (applies to all jobs) or per job. Since this workflow mainly checks out code, runs tests, uploads artifacts, and reports to Codecov, read‑only repository access (`contents: read`) is sufficient; the `ci-success` job itself doesn’t need any permissions at all.

The least intrusive and clearest fix for the flagged issue is to add a `permissions` block to the `ci-success` job, since that is what CodeQL highlighted. For this job, we can safely disable `GITHUB_TOKEN` entirely by setting `permissions: {}`. This preserves existing functionality, because the job only runs a shell script that checks `needs.*.result` and doesn’t call any GitHub APIs or actions that require the token.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Under the `ci-success` job definition (around line 174–178), insert a `permissions: {}` line at the same indentation level as `runs-on`, `needs`, and `if`.
- No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
