### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Build Package
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/EulogySnowfall/SurrealDB-ORM/security/code-scanning/1](https://github.com/EulogySnowfall/SurrealDB-ORM/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block for the `build` job so that `GITHUB_TOKEN` is limited to the minimum needed. Since the `build` job only needs to read the repository contents (for `actions/checkout`) and does not interact with issues, PRs, or releases, it should only require `contents: read`. This both documents the intended access and prevents escalation if the repo/org default is (or becomes) more permissive.

Concretely, in `.github/workflows/publish.yml`, under `jobs.build` (around line 10), add a `permissions:` block at the same indentation level as `runs-on:` and `steps:`. Set `contents: read` as the only permission. No additional imports or external definitions are needed; this is a pure YAML configuration change within the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
