### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI SurrealDB-ORM
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/EulogySnowfall/SurrealDB-ORM/security/code-scanning/2](https://github.com/EulogySnowfall/SurrealDB-ORM/security/code-scanning/2)

In general, this should be fixed by explicitly specifying `permissions` for the `GITHUB_TOKEN` at the workflow level (or per job) and granting only the minimum scopes needed. Since the shown jobs only need to read the repository (for `checkout`) and interact with external services (Codecov, artifacts) that don’t require additional GitHub write scopes, the minimal reasonable permission is `contents: read`.

The single best fix without changing functionality is to add a workflow-level `permissions` block right after the `name:` declaration (before `on:`). This will apply to all jobs that don’t define their own `permissions` block. We’ll set:
```yaml
permissions:
  contents: read
```
No other scopes (like `pull-requests`, `checks`, etc.) appear necessary from the snippet. All changes are confined to `.github/workflows/ci.yml`, lines 1–3 region, by inserting the new block between line 1 and the existing `on:` block. No imports or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
