### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI SurrealDB-ORM
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/EulogySnowfall/SurrealDB-ORM/security/code-scanning/3](https://github.com/EulogySnowfall/SurrealDB-ORM/security/code-scanning/3)

In general, this problem is fixed by explicitly specifying a minimal `permissions` block for the GITHUB_TOKEN, either at the workflow root (applies to all jobs) or per job. For a typical test/lint CI workflow that only needs to read the repository, `contents: read` is sufficient; additional scopes are only needed if a job writes to PRs, issues, releases, etc.

For this specific workflow, none of the `lint`, `test-unit`, or `test-integration` jobs appear to require any write permissions. They just check out code, install dependencies, run tests, and upload artifacts. The single best fix without changing functionality is to add a workflow‑level `permissions` block right after the `name:` line, setting `contents: read`. This will apply to all jobs that do not define their own permissions and ensures the GITHUB_TOKEN cannot write to repository contents or other resources unless explicitly allowed.

Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `name: CI SurrealDB-ORM` and the `on:` block. No additional imports or methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
