### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI SurrealDB-ORM
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/EulogySnowfall/SurrealDB-ORM/security/code-scanning/4](https://github.com/EulogySnowfall/SurrealDB-ORM/security/code-scanning/4)

In general, the fix is to explicitly define a `permissions:` block either at the workflow root (to apply to all jobs) or for each job individually, granting only the minimal scopes required. Since no steps in this workflow need to write to the repository or GitHub resources, we can safely restrict permissions to read-only repository contents (`contents: read`). If later you add steps that need more (e.g., `pull-requests: write`), they can be granted on a per-job basis.

The single best way to fix this without changing existing functionality is to add a root-level `permissions:` block right after the `name:` (or immediately after `on:`), setting `contents: read`. This will apply to all jobs (`lint`, `test-unit`, `test-integration`, `coverage`, `ci-success`, etc.) that don’t override it. None of the shown jobs needs broader permissions: they perform code checkout (which uses the token but only needs read), install dependencies, run tests, manage Docker, and interact with Codecov and artifacts, which do not require repository write permissions. Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

near the top of the file (e.g., after `name: CI SurrealDB-ORM` and before `on:`). No imports or additional methods are needed, since this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
