### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
       - '*'
     paths:
       - 'src/**'
+
+permissions:
+  contents: read
+
       - 'tests/**'
       - 'devops/**'
       - 'pyproject.toml'


### PR DESCRIPTION
Potential fix for [https://github.com/EulogySnowfall/SurrealDB-ORM/security/code-scanning/6](https://github.com/EulogySnowfall/SurrealDB-ORM/security/code-scanning/6)

In general, the fix is to explicitly declare a `permissions` block in the workflow (either at the top level under the workflow root, or specifically for the `coverage` job) and restrict the GITHUB_TOKEN to the minimal scope required. This workflow uses `actions/checkout`, `actions/download-artifact`, and `codecov/codecov-action` with an explicit Codecov token; none of these require write access to repository contents, PRs, or other resources. Read-only access to repository contents is sufficient.

The single best fix without changing existing functionality is to add a top-level `permissions` block (just after the `on:` block and before `env:` or `jobs:`) that applies to all jobs, setting `contents: read`. This documents the workflow’s intent and ensures least privilege even if the repository’s default permissions are broader or change in the future. Since the other jobs (`lint`, `test-unit`, `test-integration`, `ci-success`) also only read code and run tests, `contents: read` is appropriate for all of them. No imports, methods, or additional definitions are needed; we only add YAML configuration.

Concretely, edit `.github/workflows/ci.yml` to insert:

```yaml
permissions:
  contents: read
```

at the root level, between the `on:` section and the subsequent `env:` / `jobs:` section.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
