### PR TITLE
v0.5.5: CBOR protocol (default), field aliases, sync unset_connection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,66 @@ and adheres to [SemVer](https://semver.org/) versioning.
 
 ---
 
+## [0.5.5] - 2026-02-03
+
+### Added
+
+- **CBOR Protocol Support** - Binary protocol for WebSocket connections (Issue #3)
+  - `cbor2` is now a **required dependency** (previously optional)
+  - CBOR is the **default protocol** for WebSocket connections
+  - Properly handles strings with `data:` prefix (no longer misinterpreted as record links)
+  - Custom CBOR tags for SurrealDB types: `RecordId`, `Table`, `Duration`, `DateTime`, `UUID`, `Decimal`
+  - `RPCRequest.to_cbor()` and `RPCResponse.from_cbor()` methods
+  - Aligns with official SurrealDB SDK protocol behavior
+
+- **`unset_connection_sync()` Method** (Issue #4)
+  - Synchronous version of `unset_connection()` for non-async contexts
+  - Useful in `atexit` handlers, `__del__` methods, and synchronous cleanup code
+  - Clears connection settings without async `close()` call
+
+- **Field Alias Support** (Issue #6)
+  - Map Python field names to different database column names
+  - Uses Pydantic `Field(alias="db_column_name")` syntax
+  - `populate_by_name=True` set by default in `BaseSurrealModel`
+  - All `model_dump()` calls use `by_alias=True` for database operations
+
+### Changed
+
+- **CBOR is now required** - `cbor2>=5.6.0` moved from optional to required dependency
+- **CBOR is the default protocol** - WebSocket connections use `protocol="cbor"` by default
+- Removed `[cbor]` optional extra from `pyproject.toml`
+- Updated `WebSocketConnection` docstring to reflect CBOR as recommended protocol
+- Version bump to 0.5.5
+
+### Fixed
+
+- **Issue #3** - Strings with `data:` prefix (like base64 images) no longer misinterpreted as record links
+  - JSON protocol interprets `data:xxx` as `record<data>` type
+  - CBOR protocol properly encodes strings without interpretation
+
+---
+
+## [0.5.4] - 2026-02-02
+
+### Added
+
+- **Record ID format handling** - `QuerySet.get()` now automatically handles both formats:
+  - Just the ID: `get("abc123")`
+  - Full SurrealDB format: `get("players:abc123")`
+
+- **`remove_relation()` accepts string IDs** - Now accepts both model instances and string IDs:
+  - Model instance: `await table.remove_relation("has_player", player_instance)`
+  - String ID (full format): `await table.remove_relation("has_player", "players:abc123")`
+  - String ID (just ID): `await table.remove_relation("has_player", "abc123")`
+
+- **`raw_query()` class method** - Execute arbitrary SurrealQL queries from model class
+
+### Changed
+
+- Version bump to 0.5.4
+
+---
+
 ## [0.5.3] - 2026-02-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,6 +15,22 @@
 
 ## What's New in 0.5.x
 
+### v0.5.5 - CBOR Protocol & Field Aliases
+
+- **CBOR Protocol (Default)** - Binary protocol for WebSocket connections
+  - `cbor2` is now a **required dependency**
+  - CBOR is the **default protocol** for WebSocket (fixes `data:` prefix string issues)
+  - Aligns with official SurrealDB SDK behavior
+- **`unset_connection_sync()`** - Synchronous version for non-async cleanup contexts
+- **Field Alias Support** - Map Python field names to different DB column names
+  - Use `Field(alias="db_column")` to store under a different name in DB
+
+### v0.5.4 - API Improvements
+
+- **Record ID format handling** - `QuerySet.get()` accepts both `"abc123"` and `"table:abc123"`
+- **`remove_relation()` accepts string IDs** - Pass string IDs instead of model instances
+- **`raw_query()` class method** - Execute arbitrary SurrealQL from model class
+
 ### v0.5.3.3 - Bug Fix
 
 - **`from_db()` fields_set fix** - Fixed bug where DB-loaded fields were incorrectly included in updates via `exclude_unset=True`
@@ -96,17 +112,16 @@
 ## Installation
 
 ```bash
-# Basic installation
+# Basic installation (includes CBOR support)
 pip install surrealdb-orm
 
 # With CLI support
 pip install surrealdb-orm[cli]
-
-# Full installation (CLI + CBOR)
-pip install surrealdb-orm[all]
 ```
 
 **Requirements:** Python 3.12+ | SurrealDB 2.6.0+
+
+**Included:** `pydantic`, `httpx`, `aiohttp`, `cbor2` (CBOR is the default protocol for WebSocket)
 
 ---
 
@@ -483,6 +498,28 @@ make db-dev            # Dev instance (port 8000)
 
 # Lint
 make ci-lint           # Run all linters
+```
+
+---
+
+## Related Projects
+
+### [SurrealDB-ORM-lite](https://github.com/EulogySnowfall/SurrealDB-ORM-lite)
+
+A lightweight Django-style ORM built on the **official SurrealDB Python SDK**.
+
+| Feature         | SurrealDB-ORM          | SurrealDB-ORM-lite   |
+| --------------- | ---------------------- | -------------------- |
+| SDK             | Custom (`surreal_sdk`) | Official `surrealdb` |
+| Live Queries    | Full support           | Limited              |
+| CBOR Protocol   | Default                | SDK-dependent        |
+| Transactions    | Full support           | Basic                |
+| Typed Functions | Yes                    | No                   |
+
+Choose **SurrealDB-ORM-lite** if you prefer to use the official SDK with basic ORM features.
+
+```bash
+pip install surreal-orm-lite
 ```
 
 ---

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -114,6 +114,9 @@ conn = HTTPConnection(
 
 Stateful connection for real-time features and Live Queries.
 
+**Protocol:** WebSocket connections use **CBOR** (binary) protocol by default (v0.5.5+).
+CBOR properly handles strings like `data:image/png;base64,...` that JSON would incorrectly interpret as record links.
+
 ```python
 from surreal_sdk import WebSocketConnection
 
@@ -124,6 +127,7 @@ conn = WebSocketConnection(
     auto_reconnect=True,
     reconnect_interval=1.0,
     max_reconnect_attempts=5,
+    protocol="cbor",  # Default. Use "json" only for debugging.
 )
 
 async with conn:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surrealdb-orm"
-version = "0.5.3.3"
+version = "0.5.5"
 description = "SurrealDB ORM as 'DJango style' for Python with async support. Works with pydantic validation."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -25,20 +25,18 @@ dependencies = [
     # SDK dependencies (bundled until surreal-sdk is published to PyPI)
     "httpx>=0.27.0",
     "aiohttp>=3.9.0",
+    # CBOR is required for proper binary protocol support
+    # (fixes data:xxx strings being interpreted as record links)
+    "cbor2>=5.6.0",
 ]
 
 [project.optional-dependencies]
-# CBOR support for binary protocol
-cbor = [
-    "cbor2>=5.6.0",
-]
 # CLI support
 cli = [
     "click>=8.1.0",
 ]
 # Full installation with all extras
 all = [
-    "cbor2>=5.6.0",
     "click>=8.1.0",
 ]
 

--- a/src/surreal_orm/__init__.py
+++ b/src/surreal_orm/__init__.py
@@ -78,4 +78,4 @@ __all__ = [
     "AuthenticatedUserMixin",
 ]
 
-__version__ = "0.5.4"
+__version__ = "0.5.5"

--- a/src/surreal_orm/connection_manager.py
+++ b/src/surreal_orm/connection_manager.py
@@ -61,9 +61,11 @@ class SurrealDBConnectionManager:
     @classmethod
     async def unset_connection(cls) -> None:
         """
-        Set the connection kwargs for the SurrealDB instance.
+        Unset the connection kwargs and close any active connection.
 
-        :param kwargs: The connection kwargs for the SurrealDB instance.
+        This is an async method that properly closes the connection before
+        clearing the settings. Use unset_connection_sync() if you need a
+        synchronous version (e.g., in atexit handlers or non-async contexts).
         """
         cls.__url = None
         cls.__user = None
@@ -71,6 +73,31 @@ class SurrealDBConnectionManager:
         cls.__namespace = None
         cls.__database = None
         await cls.close_connection()
+
+    @classmethod
+    def unset_connection_sync(cls) -> None:
+        """
+        Synchronously unset the connection kwargs without closing the connection.
+
+        This method clears all connection settings but does NOT close the active
+        connection (since close() is async). Use this in contexts where you cannot
+        use async/await, such as:
+        - atexit handlers
+        - __del__ methods
+        - synchronous cleanup code
+
+        For proper cleanup that closes the connection, use the async unset_connection().
+
+        Note: The underlying connection object will be garbage collected, but the
+        WebSocket/HTTP session may not be cleanly closed. If possible, prefer
+        calling unset_connection() in an async context.
+        """
+        cls.__url = None
+        cls.__user = None
+        cls.__password = None
+        cls.__namespace = None
+        cls.__database = None
+        cls.__client = None
 
     @classmethod
     def is_connection_set(cls) -> bool:

--- a/src/surreal_sdk/__init__.py
+++ b/src/surreal_sdk/__init__.py
@@ -29,6 +29,13 @@ from .streaming.live_select import (
     LiveSubscriptionParams,
 )
 from .protocol.rpc import RPCRequest, RPCResponse, RPCError
+from .protocol.cbor import (
+    CBOR_AVAILABLE,
+    RecordId,
+    Table,
+    Duration,
+    is_available as cbor_is_available,
+)
 from .types import (
     ResponseStatus,
     QueryResult,
@@ -86,6 +93,12 @@ __all__ = [
     "RPCRequest",
     "RPCResponse",
     "RPCError",
+    # CBOR Types
+    "CBOR_AVAILABLE",
+    "RecordId",
+    "Table",
+    "Duration",
+    "cbor_is_available",
     # Response Types
     "ResponseStatus",
     "QueryResult",
@@ -129,10 +142,17 @@ class SurrealDB:
             await db.signin("root", "root")
             result = await db.query("SELECT * FROM users")
 
-        # WebSocket connection (stateful)
+        # WebSocket connection (stateful, CBOR protocol - default)
+        # CBOR properly handles strings like 'data:image/png;base64,...' that
+        # JSON would incorrectly interpret as record links.
         async with SurrealDB.ws("ws://localhost:8000", "ns", "db") as db:
             await db.signin("root", "root")
             await db.live("users", callback=on_change)
+            # data:xxx values are handled correctly with CBOR
+
+        # WebSocket connection with JSON protocol (for debugging/compatibility)
+        async with SurrealDB.ws("ws://localhost:8000", "ns", "db", protocol="json") as db:
+            await db.signin("root", "root")
     """
 
     @staticmethod

--- a/src/surreal_sdk/protocol/__init__.py
+++ b/src/surreal_sdk/protocol/__init__.py
@@ -2,12 +2,31 @@
 SurrealDB SDK Protocol Module.
 
 Implements the RPC protocol for SurrealDB communication.
+Supports both JSON and CBOR serialization formats.
 """
 
 from .rpc import RPCRequest, RPCResponse, RPCError
+from .cbor import (
+    CBOR_AVAILABLE,
+    RecordId,
+    Table,
+    Duration,
+    encode as cbor_encode,
+    decode as cbor_decode,
+    is_available as cbor_is_available,
+)
 
 __all__ = [
+    # RPC
     "RPCRequest",
     "RPCResponse",
     "RPCError",
+    # CBOR
+    "CBOR_AVAILABLE",
+    "RecordId",
+    "Table",
+    "Duration",
+    "cbor_encode",
+    "cbor_decode",
+    "cbor_is_available",
 ]

--- a/src/surreal_sdk/protocol/cbor.py
+++ b/src/surreal_sdk/protocol/cbor.py
@@ -1,0 +1,189 @@
+"""
+CBOR Encoding/Decoding for SurrealDB Protocol.
+
+This module provides CBOR serialization support using SurrealDB's custom tags.
+CBOR (Concise Binary Object Representation) is the default protocol for
+SurrealDB as it properly handles binary data and avoids string interpretation
+issues that occur with JSON (e.g., 'data:xxx' being interpreted as record links).
+
+Custom CBOR Tags used by SurrealDB:
+- TAG_NONE (6): None/null value
+- TAG_TABLE (7): Table name
+- TAG_RECORDID (8): Record ID (table:id)
+- TAG_STRING_UUID (9): UUID as string
+- TAG_STRING_DECIMAL (10): Decimal as string
+- TAG_DATETIME (12): DateTime (ISO 8601)
+- TAG_STRING_DURATION (14): Duration as string
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+import cbor2
+from cbor2 import CBORTag
+
+
+# CBOR is always available (required dependency)
+CBOR_AVAILABLE = True
+
+
+# SurrealDB Custom CBOR Tags
+TAG_NONE = 6
+TAG_TABLE = 7
+TAG_RECORDID = 8
+TAG_STRING_UUID = 9
+TAG_STRING_DECIMAL = 10
+TAG_DATETIME = 12
+TAG_STRING_DURATION = 14
+
+
+@dataclass
+class RecordId:
+    """
+    Represents a SurrealDB Record ID (table:id format).
+
+    Attributes:
+        table: The table name
+        id: The record identifier (can be string, int, or complex object)
+    """
+
+    table: str
+    id: Any
+
+    def __str__(self) -> str:
+        """Return the full record ID string."""
+        return f"{self.table}:{self.id}"
+
+    @classmethod
+    def parse(cls, value: str) -> "RecordId":
+        """Parse a record ID string into a RecordId object."""
+        if ":" in value:
+            table, id_part = value.split(":", 1)
+            return cls(table=table, id=id_part)
+        raise ValueError(f"Invalid record ID format: {value}")
+
+
+@dataclass
+class Table:
+    """Represents a SurrealDB table reference."""
+
+    name: str
+
+    def __str__(self) -> str:
+        return self.name
+
+
+@dataclass
+class Duration:
+    """Represents a SurrealDB duration."""
+
+    value: str
+
+    def __str__(self) -> str:
+        return self.value
+
+
+def _cbor_default_encoder(encoder: Any, value: Any) -> None:
+    """
+    Custom CBOR encoder for SurrealDB types.
+
+    Handles encoding of Python types to SurrealDB CBOR format.
+    """
+    if isinstance(value, RecordId):
+        # Encode RecordId as tagged array [table, id]
+        encoder.encode(CBORTag(TAG_RECORDID, [value.table, value.id]))
+    elif isinstance(value, Table):
+        # Encode Table as tagged string
+        encoder.encode(CBORTag(TAG_TABLE, value.name))
+    elif isinstance(value, datetime):
+        # Encode datetime as tagged ISO 8601 string
+        # Ensure timezone-aware for consistency
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        encoder.encode(CBORTag(TAG_DATETIME, value.isoformat()))
+    elif isinstance(value, UUID):
+        # Encode UUID as tagged string
+        encoder.encode(CBORTag(TAG_STRING_UUID, str(value)))
+    elif isinstance(value, Decimal):
+        # Encode Decimal as tagged string to preserve precision
+        encoder.encode(CBORTag(TAG_STRING_DECIMAL, str(value)))
+    elif isinstance(value, Duration):
+        # Encode Duration as tagged string
+        encoder.encode(CBORTag(TAG_STRING_DURATION, value.value))
+    elif value is None:
+        # SurrealDB uses a special tag for None
+        encoder.encode(CBORTag(TAG_NONE, None))
+    else:
+        # Fall back to raising TypeError for unsupported types
+        raise TypeError(f"Cannot CBOR encode {type(value)}")
+
+
+def _cbor_tag_decoder(decoder: Any, tag: Any) -> Any:
+    """
+    Custom CBOR tag decoder for SurrealDB types.
+
+    Handles decoding of SurrealDB CBOR tags to Python types.
+    """
+    if tag.tag == TAG_NONE:
+        return None
+    elif tag.tag == TAG_TABLE:
+        return Table(name=tag.value)
+    elif tag.tag == TAG_RECORDID:
+        # RecordId is encoded as [table, id]
+        if isinstance(tag.value, list) and len(tag.value) == 2:
+            return RecordId(table=tag.value[0], id=tag.value[1])
+        # Some versions may encode as string
+        elif isinstance(tag.value, str):
+            return RecordId.parse(tag.value)
+        return tag.value
+    elif tag.tag == TAG_STRING_UUID:
+        return UUID(tag.value)
+    elif tag.tag == TAG_STRING_DECIMAL:
+        return Decimal(tag.value)
+    elif tag.tag == TAG_DATETIME:
+        # Parse ISO 8601 datetime string
+        if isinstance(tag.value, str):
+            return datetime.fromisoformat(tag.value.replace("Z", "+00:00"))
+        return tag.value
+    elif tag.tag == TAG_STRING_DURATION:
+        return Duration(value=tag.value)
+    else:
+        # Return raw tagged value for unknown tags
+        return tag.value
+
+
+def encode(data: Any) -> bytes:
+    """
+    Encode data to CBOR bytes using SurrealDB's custom tags.
+
+    Args:
+        data: Python object to encode
+
+    Returns:
+        CBOR-encoded bytes
+    """
+    result: bytes = cbor2.dumps(data, default=_cbor_default_encoder)
+    return result
+
+
+def decode(data: bytes) -> Any:
+    """
+    Decode CBOR bytes to Python objects using SurrealDB's custom tags.
+
+    Args:
+        data: CBOR-encoded bytes
+
+    Returns:
+        Decoded Python object
+    """
+    return cbor2.loads(data, tag_hook=_cbor_tag_decoder)
+
+
+def is_available() -> bool:
+    """Check if CBOR support is available. Always returns True (cbor2 is required)."""
+    return True

--- a/src/surreal_sdk/streaming/live_query.py
+++ b/src/surreal_sdk/streaming/live_query.py
@@ -143,6 +143,9 @@ class LiveQuery:
                         self._live_id = result_data
                     elif isinstance(result_data, dict) and "result" in result_data:
                         self._live_id = str(result_data["result"])
+                    elif hasattr(result_data, "__str__"):
+                        # Handle UUID objects from CBOR decoding
+                        self._live_id = str(result_data)
                     else:
                         raise LiveQueryError("Invalid live query response")
 

--- a/src/surreal_sdk/streaming/live_select.py
+++ b/src/surreal_sdk/streaming/live_select.py
@@ -190,6 +190,9 @@ class LiveSelectStream:
                         self._live_id = result_data
                     elif isinstance(result_data, dict) and "result" in result_data:
                         self._live_id = str(result_data["result"])
+                    elif hasattr(result_data, "__str__"):
+                        # Handle UUID objects from CBOR decoding
+                        self._live_id = str(result_data)
                     else:
                         raise LiveQueryError("Invalid live query response")
 

--- a/tests/sdk/test_protocol.py
+++ b/tests/sdk/test_protocol.py
@@ -1,6 +1,21 @@
 """Tests for the RPC protocol module."""
 
+from datetime import datetime, timezone
+from decimal import Decimal
+from uuid import UUID
+
+import pytest
+
 from src.surreal_sdk.protocol.rpc import RPCRequest, RPCResponse, RPCError, RPCMethod
+from src.surreal_sdk.protocol.cbor import (
+    CBOR_AVAILABLE,
+    RecordId,
+    Table,
+    Duration,
+    encode as cbor_encode,
+    decode as cbor_decode,
+    is_available as cbor_is_available,
+)
 
 
 class TestRPCRequest:
@@ -150,3 +165,204 @@ class TestRPCMethod:
         assert RPCMethod.DELETE == "delete"
         assert RPCMethod.LIVE == "live"
         assert RPCMethod.KILL == "kill"
+
+
+# =============================================================================
+# CBOR Protocol Tests
+# =============================================================================
+
+
+class TestCBORTypes:
+    """Tests for CBOR type classes."""
+
+    def test_record_id_str(self) -> None:
+        """Test RecordId string representation."""
+        record_id = RecordId(table="users", id="abc123")
+        assert str(record_id) == "users:abc123"
+
+    def test_record_id_parse(self) -> None:
+        """Test RecordId parsing from string."""
+        record_id = RecordId.parse("users:abc123")
+        assert record_id.table == "users"
+        assert record_id.id == "abc123"
+
+    def test_record_id_parse_with_colons_in_id(self) -> None:
+        """Test RecordId parsing with colons in the ID (like UUIDs)."""
+        record_id = RecordId.parse("users:550e8400-e29b-41d4-a716-446655440000")
+        assert record_id.table == "users"
+        assert record_id.id == "550e8400-e29b-41d4-a716-446655440000"
+
+    def test_record_id_parse_invalid(self) -> None:
+        """Test RecordId parsing with invalid format."""
+        with pytest.raises(ValueError, match="Invalid record ID format"):
+            RecordId.parse("invalid")
+
+    def test_table_str(self) -> None:
+        """Test Table string representation."""
+        table = Table(name="users")
+        assert str(table) == "users"
+
+    def test_duration_str(self) -> None:
+        """Test Duration string representation."""
+        duration = Duration(value="1h30m")
+        assert str(duration) == "1h30m"
+
+
+class TestCBORAvailability:
+    """Tests for CBOR availability checking."""
+
+    def test_cbor_is_available_function(self) -> None:
+        """Test cbor_is_available() function - always True since cbor2 is required."""
+        result = cbor_is_available()
+        assert result is True
+        assert CBOR_AVAILABLE is True
+
+
+class TestCBOREncodeDecode:
+    """Tests for CBOR encoding/decoding (requires cbor2)."""
+
+    def test_encode_decode_basic_types(self) -> None:
+        """Test encoding and decoding basic Python types."""
+        data = {
+            "string": "hello",
+            "number": 42,
+            "float": 3.14,
+            "bool": True,
+            "list": [1, 2, 3],
+        }
+        encoded = cbor_encode(data)
+        decoded = cbor_decode(encoded)
+
+        assert decoded == data
+
+    def test_encode_decode_datetime(self) -> None:
+        """Test encoding and decoding datetime."""
+        now = datetime.now(timezone.utc)
+        data = {"timestamp": now}
+
+        encoded = cbor_encode(data)
+        decoded = cbor_decode(encoded)
+
+        assert decoded["timestamp"] == now
+
+    def test_encode_decode_uuid(self) -> None:
+        """Test encoding and decoding UUID."""
+        uid = UUID("550e8400-e29b-41d4-a716-446655440000")
+        data = {"uuid": uid}
+
+        encoded = cbor_encode(data)
+        decoded = cbor_decode(encoded)
+
+        assert decoded["uuid"] == uid
+
+    def test_encode_decode_decimal(self) -> None:
+        """Test encoding and decoding Decimal."""
+        dec = Decimal("123.456789")
+        data = {"price": dec}
+
+        encoded = cbor_encode(data)
+        decoded = cbor_decode(encoded)
+
+        assert decoded["price"] == dec
+
+    def test_encode_decode_record_id(self) -> None:
+        """Test encoding and decoding RecordId."""
+        record_id = RecordId(table="users", id="abc123")
+        data = {"ref": record_id}
+
+        encoded = cbor_encode(data)
+        decoded = cbor_decode(encoded)
+
+        assert isinstance(decoded["ref"], RecordId)
+        assert decoded["ref"].table == "users"
+        assert decoded["ref"].id == "abc123"
+
+    def test_encode_decode_table(self) -> None:
+        """Test encoding and decoding Table."""
+        table = Table(name="users")
+        data = {"table": table}
+
+        encoded = cbor_encode(data)
+        decoded = cbor_decode(encoded)
+
+        assert isinstance(decoded["table"], Table)
+        assert decoded["table"].name == "users"
+
+    def test_encode_decode_duration(self) -> None:
+        """Test encoding and decoding Duration."""
+        duration = Duration(value="1h30m")
+        data = {"timeout": duration}
+
+        encoded = cbor_encode(data)
+        decoded = cbor_decode(encoded)
+
+        assert isinstance(decoded["timeout"], Duration)
+        assert decoded["timeout"].value == "1h30m"
+
+    def test_data_prefix_string_not_interpreted_as_record_link(self) -> None:
+        """
+        Test that strings with 'data:' prefix are NOT interpreted as record links.
+
+        This is the key fix for Issue #3: In JSON protocol, SurrealDB interprets
+        'data:xxx' as a record link. With CBOR, it's properly encoded as a string.
+        """
+        # This would be incorrectly interpreted as a record link in JSON
+        base64_image = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+        data = {
+            "content": base64_image,
+            "type": "image",
+        }
+
+        encoded = cbor_encode(data)
+        decoded = cbor_decode(encoded)
+
+        # The string should be preserved exactly as-is
+        assert decoded["content"] == base64_image
+        assert isinstance(decoded["content"], str)
+        # It should NOT be converted to a RecordId or any other type
+        assert not isinstance(decoded["content"], RecordId)
+
+    def test_multiple_data_prefix_strings(self) -> None:
+        """Test multiple data: prefix strings in same document."""
+        data = {
+            "avatar": "data:image/jpeg;base64,/9j/4AAQSkZJRg==",
+            "thumbnail": "data:image/png;base64,iVBORw0KGgo=",
+            "document": "data:application/pdf;base64,JVBERi0xLjQ=",
+        }
+
+        encoded = cbor_encode(data)
+        decoded = cbor_decode(encoded)
+
+        assert decoded["avatar"] == data["avatar"]
+        assert decoded["thumbnail"] == data["thumbnail"]
+        assert decoded["document"] == data["document"]
+
+    def test_rpc_request_to_cbor(self) -> None:
+        """Test RPCRequest.to_cbor() method."""
+        request = RPCRequest(
+            method="create",
+            params=["files", {"content": "data:image/png;base64,abc123"}],
+            id=42,
+        )
+
+        cbor_data = request.to_cbor()
+        decoded = cbor_decode(cbor_data)
+
+        assert decoded["id"] == 42
+        assert decoded["method"] == "create"
+        assert decoded["params"][0] == "files"
+        assert decoded["params"][1]["content"] == "data:image/png;base64,abc123"
+
+    def test_rpc_response_from_cbor(self) -> None:
+        """Test RPCResponse.from_cbor() method."""
+        response_data = {
+            "id": 42,
+            "result": [{"id": "files:1", "content": "data:image/png;base64,abc123"}],
+        }
+
+        cbor_data = cbor_encode(response_data)
+        response = RPCResponse.from_cbor(cbor_data)
+
+        assert response.id == 42
+        assert response.is_success
+        assert response.result[0]["content"] == "data:image/png;base64,abc123"

--- a/tests/test_features_0_5_5.py
+++ b/tests/test_features_0_5_5.py
@@ -1,0 +1,306 @@
+"""
+Tests for v0.5.5 features.
+
+Feature #1: CBOR protocol support for WebSocket connections
+Feature #2: Sync version of unset_connection()
+Feature #3: Field alias support (Python name vs DB column name)
+"""
+
+from typing import AsyncGenerator
+
+import pytest
+from pydantic import Field
+
+from src.surreal_orm import SurrealDBConnectionManager
+from src.surreal_orm.model_base import BaseSurrealModel
+
+
+# Test URLs - use same ports as other integration tests
+SURREALDB_URL = "http://localhost:8001"
+
+
+# =============================================================================
+# Test Models
+# =============================================================================
+
+
+class UserWithAlias(BaseSurrealModel):
+    """User model with field alias for password."""
+
+    id: str | None = None
+    email: str
+    # Python field 'password' maps to 'password_hash' in DB
+    password: str = Field(alias="password_hash")
+
+
+class ProfileWithAliases(BaseSurrealModel):
+    """Profile model with multiple field aliases."""
+
+    id: str | None = None
+    # Python 'full_name' maps to 'name' in DB
+    full_name: str = Field(alias="name")
+    # Python 'user_age' maps to 'age' in DB
+    user_age: int = Field(alias="age", default=0)
+
+
+# =============================================================================
+# Feature #1: CBOR Protocol (Unit Tests)
+# =============================================================================
+
+
+class TestCBORProtocol:
+    """Test CBOR protocol support."""
+
+    def test_cbor_available_check(self) -> None:
+        """Test that CBOR availability can be checked."""
+        from src.surreal_sdk.protocol.cbor import is_available
+
+        # Should return a boolean
+        result = is_available()
+        assert isinstance(result, bool)
+
+    def test_websocket_protocol_parameter(self) -> None:
+        """Test that WebSocketConnection accepts protocol parameter."""
+        from src.surreal_sdk.connection.websocket import WebSocketConnection
+
+        # Default protocol is cbor (required dependency)
+        conn = WebSocketConnection("ws://localhost:8000", "ns", "db")
+        assert conn.protocol == "cbor"
+
+        # Can explicitly set json for debugging/compatibility
+        conn_json = WebSocketConnection("ws://localhost:8000", "ns", "db", protocol="json")
+        assert conn_json.protocol == "json"
+
+        # Can explicitly set cbor
+        conn_cbor = WebSocketConnection("ws://localhost:8000", "ns", "db", protocol="cbor")
+        assert conn_cbor.protocol == "cbor"
+
+    def test_websocket_invalid_protocol_raises(self) -> None:
+        """Test that invalid protocol raises ValueError."""
+        from src.surreal_sdk.connection.websocket import WebSocketConnection
+
+        with pytest.raises(ValueError, match="Invalid protocol"):
+            WebSocketConnection("ws://localhost:8000", "ns", "db", protocol="invalid")
+
+
+# =============================================================================
+# Feature #2: Sync unset_connection()
+# =============================================================================
+
+
+class TestSyncUnsetConnection:
+    """Test synchronous unset_connection."""
+
+    def test_unset_connection_sync_clears_settings(self) -> None:
+        """unset_connection_sync() should clear all connection settings."""
+        # Setup with a different database to avoid affecting other tests
+        SurrealDBConnectionManager.set_connection(
+            SURREALDB_URL,
+            "root",
+            "root",
+            "test",
+            "test_sync_unset",
+        )
+        assert SurrealDBConnectionManager.is_connection_set() is True
+
+        # Test sync unset
+        SurrealDBConnectionManager.unset_connection_sync()
+        assert SurrealDBConnectionManager.is_connection_set() is False
+        assert SurrealDBConnectionManager.is_connected() is False
+
+        # Restore connection for subsequent tests in this module
+        SurrealDBConnectionManager.set_connection(
+            SURREALDB_URL,
+            "root",
+            "root",
+            "test",
+            "test_features_055",
+        )
+
+
+# =============================================================================
+# Feature #3: Field Alias Support (Unit Tests)
+# =============================================================================
+
+
+class TestFieldAliasSupport:
+    """Test that field aliases work correctly."""
+
+    def test_model_dump_uses_alias(self) -> None:
+        """model_dump(by_alias=True) should use alias names."""
+        user = UserWithAlias(email="test@example.com", password="secret123")
+
+        # Without by_alias, uses field names
+        data_no_alias = user.model_dump()
+        assert "password" in data_no_alias
+        assert "password_hash" not in data_no_alias
+
+        # With by_alias, uses alias names (as ORM does when saving)
+        data_with_alias = user.model_dump(by_alias=True)
+        assert "password_hash" in data_with_alias
+        assert "password" not in data_with_alias
+        assert data_with_alias["password_hash"] == "secret123"
+
+    def test_model_validates_both_names(self) -> None:
+        """Model should accept both field name and alias when loading."""
+        # Load using alias (as DB returns)
+        user1 = UserWithAlias.model_validate(
+            {
+                "email": "test@example.com",
+                "password_hash": "secret123",
+            }
+        )
+        assert user1.password == "secret123"
+
+        # Load using field name (also works with populate_by_name=True)
+        user2 = UserWithAlias.model_validate(
+            {
+                "email": "test@example.com",
+                "password": "secret456",
+            }
+        )
+        assert user2.password == "secret456"
+
+    def test_multiple_aliases(self) -> None:
+        """Test model with multiple field aliases."""
+        profile = ProfileWithAliases(full_name="John Doe", user_age=30)
+
+        # Dump with aliases (for DB)
+        data = profile.model_dump(by_alias=True)
+        assert data["name"] == "John Doe"
+        assert data["age"] == 30
+        assert "full_name" not in data
+        assert "user_age" not in data
+
+    def test_alias_with_exclude_fields(self) -> None:
+        """Test that alias works correctly with exclude fields."""
+        user = UserWithAlias(email="test@example.com", password="secret123")
+
+        # Simulate what save() does
+        exclude_fields = {"id"}
+        data = user.model_dump(exclude=exclude_fields, exclude_unset=True, by_alias=True)
+
+        # Should have alias names, not field names
+        assert "password_hash" in data
+        assert "password" not in data
+        assert "email" in data
+        assert "id" not in data
+
+
+# =============================================================================
+# Integration Tests
+# =============================================================================
+
+
+@pytest.fixture(scope="module", autouse=True)
+async def setup_connection() -> AsyncGenerator[None, None]:
+    """Setup connection for integration tests."""
+    SurrealDBConnectionManager.set_connection(
+        SURREALDB_URL,
+        "root",
+        "root",
+        "test",
+        "test_features_055",
+    )
+    yield
+    await SurrealDBConnectionManager.close_connection()
+    await SurrealDBConnectionManager.unset_connection()
+
+
+@pytest.fixture(autouse=True)
+async def cleanup_tables() -> AsyncGenerator[None, None]:
+    """Clean up test tables before and after each test."""
+    tables = ["UserWithAlias", "ProfileWithAliases"]
+    try:
+        client = await SurrealDBConnectionManager.get_client()
+        for table in tables:
+            try:
+                await client.query(f"DELETE {table};")
+            except Exception:
+                pass
+    except Exception:
+        pass
+    yield
+    try:
+        client = await SurrealDBConnectionManager.get_client()
+        for table in tables:
+            try:
+                await client.query(f"DELETE {table};")
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+
+@pytest.mark.integration
+class TestFieldAliasIntegration:
+    """Integration tests for field alias support."""
+
+    async def test_save_with_alias(self) -> None:
+        """save() should use alias names when writing to DB."""
+        user = UserWithAlias(id="alias_test_1", email="test@example.com", password="secret123")
+        await user.save()
+
+        # Query the DB directly to verify the column name
+        client = await SurrealDBConnectionManager.get_client()
+        result = await client.query("SELECT * FROM UserWithAlias:alias_test_1")
+
+        # The DB should have 'password_hash', not 'password'
+        records = result.all_records
+        assert len(records) == 1
+        assert "password_hash" in records[0]
+        assert records[0]["password_hash"] == "secret123"
+        # Field name 'password' should NOT be in DB
+        assert "password" not in records[0]
+
+    async def test_load_with_alias(self) -> None:
+        """Loading from DB should map alias back to field name."""
+        # Insert directly using alias
+        client = await SurrealDBConnectionManager.get_client()
+        await client.query("CREATE UserWithAlias:alias_test_2 SET email = 'load@example.com', password_hash = 'loaded123'")
+
+        # Fetch using ORM
+        user = await UserWithAlias.objects().get("alias_test_2")
+
+        # Should be accessible via Python field name
+        assert user.email == "load@example.com"
+        assert user.password == "loaded123"
+
+    async def test_save_and_reload_with_alias(self) -> None:
+        """Full round-trip: save with alias, reload, modify, save again."""
+        # Create and save
+        user = UserWithAlias(id="alias_test_3", email="roundtrip@example.com", password="initial")
+        await user.save()
+
+        # Reload
+        loaded = await UserWithAlias.objects().get("alias_test_3")
+        assert loaded.password == "initial"
+
+        # Modify and save again
+        loaded.password = "updated"
+        await loaded.save()
+
+        # Reload and verify
+        reloaded = await UserWithAlias.objects().get("alias_test_3")
+        assert reloaded.password == "updated"
+
+        # Verify DB has alias name
+        client = await SurrealDBConnectionManager.get_client()
+        result = await client.query("SELECT * FROM UserWithAlias:alias_test_3")
+        assert result.all_records[0]["password_hash"] == "updated"
+
+    async def test_multiple_aliases_save_and_load(self) -> None:
+        """Test model with multiple aliases saves and loads correctly."""
+        profile = ProfileWithAliases(id="multi_alias_1", full_name="Jane Doe", user_age=25)
+        await profile.save()
+
+        # Verify DB has alias names
+        client = await SurrealDBConnectionManager.get_client()
+        result = await client.query("SELECT * FROM ProfileWithAliases:multi_alias_1")
+        assert result.all_records[0]["name"] == "Jane Doe"
+        assert result.all_records[0]["age"] == 25
+
+        # Reload and verify
+        loaded = await ProfileWithAliases.objects().get("multi_alias_1")
+        assert loaded.full_name == "Jane Doe"
+        assert loaded.user_age == 25

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -278,6 +278,28 @@ async def test_unset(setup_connection_manager: AsyncGenerator[Any, Any]) -> None
     )
 
 
+def test_unset_connection_sync() -> None:
+    """Test synchronous unsetting of connection.
+
+    This tests the sync version of unset_connection which can be used
+    in non-async contexts like atexit handlers or __del__ methods.
+    """
+    # Setup: set connection
+    SurrealDBConnectionManager.set_connection(
+        SURREALDB_URL,
+        SURREALDB_USER,
+        SURREALDB_PASS,
+        SURREALDB_NAMESPACE,
+        SURREALDB_DATABASE,
+    )
+    assert SurrealDBConnectionManager.is_connection_set() is True
+
+    # Test: sync unset clears settings
+    SurrealDBConnectionManager.unset_connection_sync()
+    assert SurrealDBConnectionManager.is_connection_set() is False
+    assert SurrealDBConnectionManager.is_connected() is False
+
+
 @pytest.mark.integration
 async def test_reconnect(setup_connection_manager: AsyncGenerator[Any, Any]) -> None:
     await SurrealDBConnectionManager.close_connection()

--- a/uv.lock
+++ b/uv.lock
@@ -1527,21 +1527,18 @@ wheels = [
 
 [[package]]
 name = "surrealdb-orm"
-version = "0.5.3.3"
+version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "cbor2" },
     { name = "httpx" },
     { name = "pydantic" },
 ]
 
 [package.optional-dependencies]
 all = [
-    { name = "cbor2" },
     { name = "click" },
-]
-cbor = [
-    { name = "cbor2" },
 ]
 cli = [
     { name = "click" },
@@ -1568,14 +1565,13 @@ lint = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0" },
-    { name = "cbor2", marker = "extra == 'all'", specifier = ">=5.6.0" },
-    { name = "cbor2", marker = "extra == 'cbor'", specifier = ">=5.6.0" },
+    { name = "cbor2", specifier = ">=5.6.0" },
     { name = "click", marker = "extra == 'all'", specifier = ">=8.1.0" },
     { name = "click", marker = "extra == 'cli'", specifier = ">=8.1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]
-provides-extras = ["cbor", "cli", "all"]
+provides-extras = ["cli", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Features:
- CBOR protocol support for WebSocket connections (fixes Issue #3)
  - cbor2 is now a required dependency
  - CBOR is the default protocol (aligns with official SurrealDB SDK)
  - Fixes data: prefix strings being misinterpreted as record links
  - Custom CBOR tags for SurrealDB types (RecordId, Table, Duration, etc.)

- Field alias support (Issue #6)
  - Map Python field names to different DB column names
  - Use Field(alias="db_column") syntax
  - populate_by_name=True set by default in BaseSurrealModel

- unset_connection_sync() method (Issue #4)
  - Synchronous version for non-async cleanup contexts
  - Useful in atexit handlers and __del__ methods

- Related Projects section in README
  - Reference to SurrealDB-ORM-lite for official SDK users

Tests: 12 new tests for v0.5.5 features