### PR TITLE
fix: sync __version__ to 0.5.5.1 in both modules

### DIFF
--- a/src/surreal_orm/__init__.py
+++ b/src/surreal_orm/__init__.py
@@ -78,4 +78,4 @@ __all__ = [
     "AuthenticatedUserMixin",
 ]
 
-__version__ = "0.5.5"
+__version__ = "0.5.5.1"

--- a/src/surreal_sdk/__init__.py
+++ b/src/surreal_sdk/__init__.py
@@ -71,7 +71,7 @@ from .functions import (
     CryptoFunctions,
 )
 
-__version__ = "0.5.2"
+__version__ = "0.5.5.1"
 __all__ = [
     # Connections
     "BaseSurrealConnection",


### PR DESCRIPTION
Both surreal_orm and surreal_sdk now report version 0.5.5.1