### PR TITLE
v0.5.5.2: Fix datetime_type Pydantic validation regression (Issue #9)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,34 @@ and adheres to [SemVer](https://semver.org/) versioning.
 
 ---
 
+## [0.5.5.2] - 2026-02-04
+
+### Fixed
+
+- **Issue #9 (CRITICAL): datetime_type Pydantic validation regression**
+  - In v0.5.5.1, records with datetime fields failed Pydantic validation
+  - `from_db()` silently returned dicts instead of model instances
+  - Caused widespread application failures ("'dict' object has no attribute 'model_dump'")
+  - Root cause: `from_db()` passed raw database data directly to Pydantic without preprocessing
+  - Fix: Added `_preprocess_db_record()` method to handle datetime parsing and RecordId conversion
+
+### Added
+
+- **`BaseSurrealModel._preprocess_db_record()`** - New classmethod that preprocesses database records
+  - Parses datetime fields in all formats:
+    - ISO 8601 strings (JSON protocol)
+    - Python datetime objects (CBOR protocol)
+    - CBOR timestamp arrays `[seconds, nanoseconds]`
+  - Converts RecordId objects from CBOR responses to string IDs
+  - Called by `from_db()` before Pydantic validation
+
+### Changed
+
+- `from_db()` now uses `_preprocess_db_record()` for consistent handling with `_update_from_db()`
+- Version bump to 0.5.5.2
+
+---
+
 ## [0.5.5.1] - 2026-02-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@
 
 ## What's New in 0.5.x
 
+### v0.5.5.2 - Datetime Regression Fix
+
+- **Fixed datetime_type Pydantic validation error** - v0.5.5.1 introduced a regression where records with datetime fields failed validation, causing `from_db()` to return dicts instead of model instances
+- **New `_preprocess_db_record()` method** - Properly handles datetime parsing and RecordId conversion before Pydantic validation
+
 ### v0.5.5.1 - Critical Bug Fixes
 
 - **Record ID escaping** - IDs starting with digits (e.g., `7abc123`) now properly escaped with backticks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surrealdb-orm"
-version = "0.5.5.1"
+version = "0.5.5.2"
 description = "SurrealDB ORM as 'DJango style' for Python with async support. Works with pydantic validation."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/surreal_orm/__init__.py
+++ b/src/surreal_orm/__init__.py
@@ -78,4 +78,4 @@ __all__ = [
     "AuthenticatedUserMixin",
 ]
 
-__version__ = "0.5.5.1"
+__version__ = "0.5.5.2"

--- a/src/surreal_sdk/__init__.py
+++ b/src/surreal_sdk/__init__.py
@@ -71,7 +71,7 @@ from .functions import (
     CryptoFunctions,
 )
 
-__version__ = "0.5.5.1"
+__version__ = "0.5.5.2"
 __all__ = [
     # Connections
     "BaseSurrealConnection",

--- a/uv.lock
+++ b/uv.lock
@@ -1527,7 +1527,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb-orm"
-version = "0.5.5.1"
+version = "0.5.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Bug fixes:
- Fix Issue #9 (CRITICAL): datetime_type validation error in from_db()
- Records with datetime fields now correctly return model instances
- Previously returned dict values silently, breaking application

Root cause:
- from_db() passed raw database data directly to Pydantic
- Datetime fields from SurrealDB (especially via CBOR) need preprocessing
- _update_from_db() had this logic, but from_db() did not

Fix:
- Add _preprocess_db_record() classmethod for datetime/RecordId handling
- from_db() now uses preprocessing before Pydantic validation
- Consistent handling with _update_from_db()

Tests:
- Add 10 unit tests for Issue #9 datetime validation
- Test ISO strings, Python datetime objects, None values, lists
- Test _preprocess_db_record() and RecordId handling