### PR TITLE
v0.5.5.3: Fix RecordId objects in non-id fields (Issue #10)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,25 @@ and adheres to [SemVer](https://semver.org/) versioning.
 
 ---
 
+## [0.5.5.3] - 2026-02-04
+
+### Fixed
+
+- **Issue #10: RecordId objects in non-id fields not converted to strings**
+  - When using CBOR protocol, foreign key fields (like `user_id`, `table_id`) returned `RecordId` objects instead of strings
+  - This caused Pydantic validation errors and application failures
+  - Fix: `_preprocess_db_record()` now converts RecordId objects in ANY field to strings
+  - For the `id` field: extracts just the id part (e.g., `"abc123"`)
+  - For other fields: converts to "table:id" format (e.g., `"users:abc123"`)
+
+### Changed
+
+- `_convert_record_id_to_string()` - New helper function for converting RecordId objects
+- `_update_from_db()` now also handles RecordId conversion in non-id fields
+- Version bump to 0.5.5.3
+
+---
+
 ## [0.5.5.2] - 2026-02-04
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,26 @@
 
 ---
 
-## Current Version: 0.5.5.2 (Alpha)
+## Current Version: 0.5.5.3 (Alpha)
+
+### What's New in 0.5.5.3
+
+- **Bug Fix: Issue #10 (RecordId objects in non-id fields)**
+
+  - **Fixed RecordId objects not converted to strings in foreign key fields** - When using CBOR protocol, fields like `user_id`, `table_id` returned `RecordId` objects instead of strings, causing Pydantic validation errors.
+
+    ```python
+    # Before (v0.5.5.2) - RecordId objects caused validation errors
+    record = await Model.objects().get("id")
+    print(record.user_id)  # RecordId(table='users', id='abc123')
+
+    # After (v0.5.5.3) - Converted to proper strings
+    print(record.user_id)  # "users:abc123"
+    ```
+
+  - **Fix**: `_preprocess_db_record()` now converts RecordId objects in ALL fields:
+    - For `id` field: extracts just the id part (e.g., `"abc123"`)
+    - For other fields: converts to "table:id" format (e.g., `"users:abc123"`)
 
 ### What's New in 0.5.5.2
 
@@ -18,23 +37,7 @@
 
   - **Fixed Pydantic validation error for datetime fields** - In v0.5.5.1, records containing datetime fields failed Pydantic validation when loaded from the database, causing `from_db()` to silently return dict values instead of model instances.
 
-  - **Root cause**: The `from_db()` method passed raw database data directly to Pydantic without preprocessing datetime fields. When SurrealDB returns datetime values (especially via CBOR protocol), they may be in formats that need normalization before Pydantic can validate them.
-
-  - **Fix**: Added `_preprocess_db_record()` method to handle datetime parsing and RecordId conversion before Pydantic validation. The `_parse_datetime()` function now handles all datetime formats:
-    - ISO 8601 strings (JSON protocol): `"2026-02-02T13:21:23.641315924Z"`
-    - Python datetime objects (CBOR protocol with proper decoding)
-    - CBOR timestamp arrays: `[seconds_since_epoch, nanoseconds]`
-
-    ```python
-    # Now works correctly - returns model instance, not dict
-    records = await GameTable.objects().exec()
-    assert isinstance(records[0], GameTable)  # True in 0.5.5.2, was False in 0.5.5.1
-
-    # Datetime fields are properly parsed
-    assert isinstance(records[0].created_at, datetime)
-    ```
-
-  - **Impact**: This fix restores proper ORM functionality that was broken in v0.5.5.1. Users who experienced "dict object has no attribute 'model_dump'" errors or similar issues should upgrade to 0.5.5.2.
+  - **Fix**: Added `_preprocess_db_record()` method to handle datetime parsing and RecordId conversion before Pydantic validation.
 
 ### What's New in 0.5.5.1
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
 
 ## What's New in 0.5.x
 
+### v0.5.5.3 - RecordId Conversion Fix
+
+- **Fixed RecordId objects in foreign key fields** - When using CBOR protocol, fields like `user_id`, `table_id` are now properly converted to `"table:id"` strings instead of raw RecordId objects, preventing Pydantic validation errors.
+
 ### v0.5.5.2 - Datetime Regression Fix
 
 - **Fixed datetime_type Pydantic validation error** - v0.5.5.1 introduced a regression where records with datetime fields failed validation, causing `from_db()` to return dicts instead of model instances

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surrealdb-orm"
-version = "0.5.5.2"
+version = "0.5.5.3"
 description = "SurrealDB ORM as 'DJango style' for Python with async support. Works with pydantic validation."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/surreal_orm/__init__.py
+++ b/src/surreal_orm/__init__.py
@@ -78,4 +78,4 @@ __all__ = [
     "AuthenticatedUserMixin",
 ]
 
-__version__ = "0.5.5.2"
+__version__ = "0.5.5.3"

--- a/src/surreal_sdk/__init__.py
+++ b/src/surreal_sdk/__init__.py
@@ -71,7 +71,7 @@ from .functions import (
     CryptoFunctions,
 )
 
-__version__ = "0.5.5.2"
+__version__ = "0.5.5.3"
 __all__ = [
     # Connections
     "BaseSurrealConnection",

--- a/uv.lock
+++ b/uv.lock
@@ -1527,7 +1527,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb-orm"
-version = "0.5.5.2"
+version = "0.5.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Bug Fixes:
- Issue #10: RecordId objects in foreign key fields (user_id, table_id, etc.) were not converted to strings when using CBOR protocol
- This caused Pydantic validation errors for models with foreign key fields
- Fix: _preprocess_db_record() now converts RecordId objects in ALL fields:
  - For 'id' field: extracts just the id part (e.g., "abc123")
  - For other fields: converts to "table:id" format (e.g., "users:abc123")

Added:
- _convert_recordid_to_string() helper function
- 5 new tests for RecordId conversion in TestRecordIdConversion class

Changed:
- _update_from_db() also handles RecordId conversion in non-id fields
- Version bump to 0.5.5.3