### PR TITLE
v0.5.6: Fix ID escaping in relation queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ dmypy.json
 
 # Claude
 .claude/
+
+# Interne
+features/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,29 @@
 
 ---
 
-## Current Version: 0.5.5.3 (Alpha)
+## Current Version: 0.5.6 (Alpha)
+
+### What's New in 0.5.6
+
+- **Bug Fix: Issue #8 bis (Numeric ID escaping in relation queries)**
+
+  - **Fixed missing ID escaping in graph traversal queries** - When using `get_related()`, `RelationQuerySet`, or `RelationInfo.get_traversal_query()` with IDs starting with digits, the queries would fail with parse errors.
+
+    ```python
+    # Before (v0.5.5.3) - Parse error for numeric IDs in relations
+    table = GameTable(id="7qvdzsc14e5clo8sg064", ...)
+    await table.save()
+    players = await table.get_related("has_player", direction="out", model_class=Player)
+    # Parse error: Failed to parse query - expected identifier, found '7qvdzsc'
+
+    # After (v0.5.6) - Properly escaped
+    players = await table.get_related("has_player", direction="out", model_class=Player)
+    # Generates: SELECT VALUE out.* FROM has_player WHERE in = game_tables:`7qvdzsc14e5clo8sg064`;
+    ```
+
+  - **Files Fixed**:
+    - `fields/relation.py` - `RelationInfo.get_traversal_query()` now uses `escape_record_id()`
+    - `relations.py` - `RelationQuerySet._build_traversal_query()` now uses `escape_record_id()`
 
 ### What's New in 0.5.5.3
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
 
 ## What's New in 0.5.x
 
+### v0.5.6 - Relation Query ID Escaping Fix
+
+- **Fixed ID escaping in relation queries** - When using `get_related()`, `RelationQuerySet`, or graph traversal with IDs starting with digits, queries now properly escape the IDs with backticks, preventing parse errors.
+
 ### v0.5.5.3 - RecordId Conversion Fix
 
 - **Fixed RecordId objects in foreign key fields** - When using CBOR protocol, fields like `user_id`, `table_id` are now properly converted to `"table:id"` strings instead of raw RecordId objects, preventing Pydantic validation errors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surrealdb-orm"
-version = "0.5.5.3"
+version = "0.5.6"
 description = "SurrealDB ORM as 'DJango style' for Python with async support. Works with pydantic validation."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/surreal_orm/__init__.py
+++ b/src/surreal_orm/__init__.py
@@ -78,4 +78,4 @@ __all__ = [
     "AuthenticatedUserMixin",
 ]
 
-__version__ = "0.5.5.3"
+__version__ = "0.5.6"

--- a/src/surreal_orm/relations.py
+++ b/src/surreal_orm/relations.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from .connection_manager import SurrealDBConnectionManager
 from .fields.relation import RelationInfo
+from .utils import escape_record_id
 
 if TYPE_CHECKING:
     from .model_base import BaseSurrealModel
@@ -143,8 +144,9 @@ class RelationQuerySet:
         if not source_id:
             raise ValueError("Cannot traverse relations from unsaved instance")
 
-        # Build the traversal path
-        path_parts = [f"{source_table}:{source_id}"]
+        # Build the traversal path with properly escaped ID
+        escaped_id = escape_record_id(source_id)
+        path_parts = [f"{source_table}:{escaped_id}"]
         variables: dict[str, Any] = {}
         where_clauses: list[str] = []
         var_counter = 0

--- a/src/surreal_sdk/__init__.py
+++ b/src/surreal_sdk/__init__.py
@@ -71,7 +71,7 @@ from .functions import (
     CryptoFunctions,
 )
 
-__version__ = "0.5.5.3"
+__version__ = "0.5.6"
 __all__ = [
     # Connections
     "BaseSurrealConnection",

--- a/uv.lock
+++ b/uv.lock
@@ -1527,7 +1527,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb-orm"
-version = "0.5.5.3"
+version = "0.5.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- **Fix Issue #8 bis**: ID escaping was missing in relation traversal queries
  - `RelationInfo.get_traversal_query()` now escapes IDs starting with digits
  - `RelationQuerySet._build_traversal_query()` now escapes numeric source IDs
- Added 7 comprehensive tests for numeric ID escaping in relations
- Updated documentation (CLAUDE.md, README.md)
- Created migration guide for Gamesncards users

## Bug Fixed

When using `get_related()` or `RelationQuerySet` with record IDs starting with digits (e.g., `22aenw...`), SurrealDB returned a parse error:

```
Parse error: Failed to parse query - expected identifier, found '22aenw'
```

The fix adds proper backtick escaping using `escape_record_id()` in both relation query builders.

## Test plan

- [x] All unit tests pass (401 passed)
- [x] All integration tests pass (175 passed)
- [x] Mypy type checking passes
- [x] Ruff linting passes
- [ ] Gamesncards to validate with their E2E test suite