### PR TITLE
fix(ci): repair tag-release.yml (invalid YAML since #86) and harden run blocks

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -15,8 +15,11 @@ permissions:
 jobs:
   tag-release:
     name: Create Tag & Release
-    # Only run on version bump commits from the automerge workflow
-    if: startsWith(github.event.head_commit.message, 'chore(release): bump version to')
+    # Only run on version bump commits from the automerge workflow.
+    # NOTE: the whole expression MUST be quoted — the ': ' inside the string
+    # literal otherwise makes YAML parse this as a mapping and the entire
+    # workflow fails to load ("mapping values are not allowed here").
+    if: "${{ startsWith(github.event.head_commit.message, 'chore(release): bump version to') }}"
     runs-on: ubuntu-latest
 
     steps:
@@ -31,41 +34,45 @@ jobs:
 
       - name: Extract version from commit message
         id: version
+        # Commit message is attacker-influenceable — bind to env vars and never
+        # expand context expressions directly into the shell script.
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          MSG="${{ github.event.head_commit.message }}"
           # Extract version: "chore(release): bump version to 0.31.2" → "0.31.2"
-          VERSION=$(echo "$MSG" | sed -n 's/.*bump version to \([0-9.]*\).*/\1/p')
+          VERSION=$(echo "$COMMIT_MSG" | sed -n 's/.*bump version to \([0-9.]*\).*/\1/p')
 
           if [[ -z "$VERSION" ]]; then
-            echo "Could not extract version from commit message: $MSG"
+            echo "Could not extract version from commit message: $COMMIT_MSG"
             exit 1
           fi
 
           TAG="v${VERSION}"
-          BRANCH="${{ github.ref_name }}"
 
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
-          echo "Version: $VERSION, Tag: $TAG, Branch: $BRANCH"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "branch=$REF_NAME" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION, Tag: $TAG, Branch: $REF_NAME"
 
       - name: Check if tag already exists
         id: check-tag
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          TAG="${{ steps.version.outputs.tag }}"
           if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "Tag $TAG already exists — skipping"
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create and push tag
         if: steps.check-tag.outputs.exists == 'false'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          VERSION="${{ steps.version.outputs.version }}"
-
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 


### PR DESCRIPTION
## Problem

`tag-release.yml` has failed to load on **every** push since #86 (2026-03-28) with *"This run likely failed because of a workflow file issue"*. Root cause: the job-level `if:` expression was unquoted, and the `': '` inside the string literal `'chore(release): bump version to'` made YAML parse it as a mapping → *"mapping values are not allowed here"* (line 19, col 69). The workflow never ran, so **automated tag + GitHub Release on version bumps has been silently broken for ~2 months**.

This is the workflow that reacts to the `chore(release): bump version to X.Y.Z` commit produced by the Dependabot auto-merge pipeline (hardened in #102), so it's the missing last step of that release automation.

## Fix

1. **Quote the `if:` expression** so YAML parses it:
   `if: "${{ startsWith(github.event.head_commit.message, 'chore(release): bump version to') }}"`
2. **Harden run blocks** — once the file parses, CodeQL analyzes it. `github.event.head_commit.message` (and the `steps.version.outputs.*` values derived from it) are attacker-influenceable, so every such value is now bound to an `env:` var and referenced as a shell variable instead of being expanded into the script text. This prevents code-injection alerts (same pattern applied in #102). Action `with:` inputs are not shell-evaluated and are left as-is.

## Verification

- `yaml.safe_load` parses the file (previously errored).
- No attacker-influenceable `${{ }}` remains inside any `run:` block — all routed through `env:`.

Discovered while resolving the CodeQL check on #102. Independent of the security-alert fixes (this bug predates them).