### PR TITLE
chore(release): bump version to 0.31.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surrealdb-orm"
-version = "0.31.3"
+version = "0.31.4"
 description = "SurrealDB ORM as 'DJango style' for Python with async support. Works with pydantic validation."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/surreal_orm/__init__.py
+++ b/src/surreal_orm/__init__.py
@@ -191,4 +191,4 @@ __all__ = [
     "retry_on_conflict",
 ]
 
-__version__ = "0.31.3"
+__version__ = "0.31.4"

--- a/src/surreal_sdk/__init__.py
+++ b/src/surreal_sdk/__init__.py
@@ -75,7 +75,7 @@ from .types import (
     ResponseStatus,
 )
 
-__version__ = "0.31.3"
+__version__ = "0.31.4"
 __all__ = [
     # Connections
     "BaseSurrealConnection",

--- a/src/surreal_sdk/pyproject.toml
+++ b/src/surreal_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surreal-sdk"
-version = "0.31.3"
+version = "0.31.4"
 description = "Custom Python SDK for SurrealDB with HTTP and WebSocket support. No dependency on official surrealdb package."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1548,7 +1548,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb-orm"
-version = "0.31.3"
+version = "0.31.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release **0.31.4** — bundles the two changes merged since 0.31.3:

- **#106** — fix(sdk): recover from transient JWT `nbf` clock-skew 401s (closes #101). Makes `make test-integration` deterministic.
- **#107** — chore(deps): upgrade locked dependencies to latest, fixing Dependabot alert #6 (Pygments ReDoS, CVE-2026-4539).

Version bump only (`pyproject.toml`, both `__init__.py`, the SDK `pyproject.toml`, `uv.lock`). The `CLAUDE.md` changelog entry for 0.31.4 already landed in #106.

On merge, the `chore(release): bump version to 0.31.4` squash commit triggers `tag-release.yml` → tag **v0.31.4** → `publish.yml` → PyPI + GitHub Release.