### PR TITLE
chore(release): bump version to 0.31.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,86 @@ and adheres to [SemVer](https://semver.org/) versioning.
 
 ---
 
+## [0.31.5] - 2026-06-06
+
+**Documentation & maintenance release.** Brings the changelog and README up to
+date through 0.31.4, adds a consolidated summary of the 0.31.x line, and corrects
+stale "last updated" dates. No library code changes — runtime behaviour is
+identical to 0.31.4.
+
+### Changed
+
+- Documented the previously-unreleased 0.31.1–0.31.4 entries in this changelog and in the README "What's New" history.
+- Renamed `CHANGELOG` → `CHANGELOG.md` so the README link resolves and the file follows convention.
+- Refreshed the "last updated" date in `CLAUDE.md` (was stuck at "March 2026").
+
+### 0.31.x at a glance
+
+- **0.31.0** — First PyPI release for SurrealDB 3.0: `RebuildIndex`, `DefineGraphQLConfig` / `RemoveGraphQLConfig`, `DefineBearerAccess`, and `QuerySet.upsert()` / `bulk_upsert()` with `ON DUPLICATE KEY UPDATE`.
+- **0.31.1** — Security: bumped `cbor2` 5.8.0 → 5.9.0; CI / release-automation fixes.
+- **0.31.2** — Critical: fixed the cbor2 6.x incompatibility that produced 401 auth failures on every CBOR RPC; raised security dependency floors.
+- **0.31.3** — Validated against SurrealDB 3.1.3 (test/CI target + Docker image).
+- **0.31.4** — Fixed intermittent integration-suite 401s caused by JWT `nbf` clock skew (WSL2 backward clock jumps); upgraded locked dependencies, clearing the Pygments ReDoS advisory.
+
+---
+
+## [0.31.4] - 2026-06-06
+
+**Fixes non-deterministic `401 Unauthorized` failures in the integration suite
+(issue #101) and refreshes dependencies.**
+
+### Fixed
+
+- **Transient JWT `nbf` clock-skew 401s (#101 / #106)** — A freshly-minted SurrealDB JWT carries `iat == nbf == now`. When the server clock jumps *backwards* between minting and verifying a token (notably on WSL2, whose VM clock can jump back), the token's `nbf` claim is momentarily in the future and SurrealDB rejects the request with a transient `401` ("Token verification failed due to the 'nbf' claim containing a future time"). Under load this surfaced as non-deterministic, disjoint failure sets per run. `HTTPConnection` now retains its last signin arguments and `_send_rpc()` recovers by re-minting the token (a fresh `nbf` aligned with the current clock) and retrying with a short bounded backoff. The earlier "shared singleton auth-leak" hypothesis was disproven — every rejected token was a valid, unexpired root token.
+
+### Changed
+
+- **Dependency upgrade (#107)** — Refreshed `uv.lock` to the latest compatible versions: **pygments 2.19.2 → 2.20.0** (see Security below), plus mypy 2.1.0, pydantic 2.13.4, ruff 0.15.16 and assorted transitive bumps. Runtime floor pins in `pyproject.toml` are unchanged.
+
+### Security
+
+- **Pygments 2.19.2 → 2.20.0** — Resolves Dependabot alert #6 (GHSA-5239-wwwm-4pmq / CVE-2026-4539), a low-severity ReDoS in GUID matching (transitive dev dependency).
+
+---
+
+## [0.31.3] - 2026-06-06
+
+**SurrealDB 3.1.3 support.**
+
+### Changed
+
+- Bumped the integration-test / CI target and Docker Compose image to `surrealdb/surrealdb:v3.1.3` (#104). No source changes — the SDK and ORM are compatible as-is.
+
+---
+
+## [0.31.2] - 2026-06-06
+
+**Critical cbor2 6.x compatibility fix.**
+
+### Fixed
+
+- **cbor2 6+ compatibility (CRITICAL — fixes 401 auth failures)** — Under cbor2 6.x the decoder's `tag_hook` callback signature changed from `(decoder, tag)` to `(tag, immutable)`. Run with cbor2 6.x, the old code raised `CBORDecodeError: error decoding semantic tag 6` on every SurrealDB response containing a `NONE` value (i.e. virtually all of them), breaking all CBOR RPC operations — including authentication — and surfacing as 401 Unauthorized in applications (the workaround was pinning `cbor2<6`). `_cbor_tag_decoder(tag, immutable)` in `src/surreal_sdk/protocol/cbor.py` is fixed for cbor2 6.x, and the RecordId tag branch now accepts `list | tuple` (cbor2 6.x exposes a `CBORTag` array value as a `tuple` rather than a `list`).
+
+### Security
+
+- Raised dependency floors and pinned `cbor2>=6.1.2` (avoids the data-corruption bugs in 6.0.x / 6.1.0, fixed in 6.1.1 / 6.1.2): `aiohttp>=3.12` (drops CVE-affected 3.9.x), `pydantic>=2.11`, `httpx>=0.28`, `click>=8.1.8`.
+
+---
+
+## [0.31.1] - 2026-03-28
+
+**Automated security-patch release.**
+
+### Security
+
+- Bumped `cbor2` 5.8.0 → 5.9.0 (Dependabot auto-merge).
+
+### Changed
+
+- CI / release automation: `tag-release` now uses `PAT_TOKEN` so tag pushes trigger the publish workflow; Dependabot v2 sync and version-bump PR flow; PyPI scoping fixes; version tests made dynamic instead of hardcoded.
+
+---
+
 ## [0.31.0] - 2026-03-22
 
 **First PyPI release for SurrealDB 3.0.** Previous 0.30.x versions were

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # SurrealDB-ORM - Development Context
 
-> Context document for Claude AI - Last updated: March 2026
+> Context document for Claude AI - Last updated: June 2026
 
 ## Project Vision
 
@@ -10,7 +10,7 @@
 
 ---
 
-## Current Version: 0.31.4 (Beta) — First PyPI release for SurrealDB 3.0
+## Current Version: 0.31.5 (Beta) — First PyPI release for SurrealDB 3.0
 
 ### Branch Strategy
 
@@ -18,6 +18,17 @@
 | ------ | --------- | ----------- | ------------------------------- |
 | `main` | 3.X       | 0.31.x      | Active development              |
 | `v2`   | 2.X       | 0.20.x      | LTS (security & bug fixes only) |
+
+### What's New in 0.31.5
+
+- **Documentation & maintenance release** — no library code changes vs 0.31.4. Brought `CHANGELOG.md`
+  and the README "What's New" history up to date through the whole 0.31.x line (0.31.1–0.31.4 were
+  released but undocumented), added a consolidated 0.31.0 → 0.31.4 summary, renamed `CHANGELOG` →
+  `CHANGELOG.md` (so the README link resolves), and corrected stale "last updated" dates.
+
+  **0.31.x recap:** 0.31.0 (SurrealDB 3.0 migration ops) → 0.31.1 (cbor2 5.9.0 security bump) →
+  0.31.2 (critical cbor2 6.x 401 fix + floor bumps) → 0.31.3 (SurrealDB 3.1.3 support) →
+  0.31.4 (JWT `nbf` clock-skew 401 fix + dependency refresh / Pygments ReDoS).
 
 ### What's New in 0.31.4
 
@@ -60,6 +71,12 @@
   bugs in 6.0.x/6.1.0 (fixed in 6.1.1/6.1.2).
 - **Security dependency-floor bumps** — `aiohttp>=3.12` (CVE-affected 3.9.x dropped),
   `pydantic>=2.11`, `httpx>=0.28`, `click>=8.1.8`.
+
+### What's New in 0.31.1
+
+- **Automated security patch** — `cbor2` 5.8.0 → 5.9.0 (Dependabot auto-merge). CI / release-automation
+  fixes: `tag-release` uses `PAT_TOKEN` so tag pushes trigger publishing; Dependabot v2 sync + version-bump
+  PR flow; version tests made dynamic instead of hardcoded.
 
 ### What's New in 0.31.0
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,26 @@ Both branches receive automated daily security monitoring from `main` (GitHub Ac
 
 ---
 
+## What's New in 0.31.5
+
+**Documentation & maintenance release** — no library code changes vs 0.31.4. It
+brings the changelog and this README up to date across the whole 0.31.x line and
+corrects stale dates. See [CHANGELOG.md](CHANGELOG.md) for the full detail.
+
+### 0.31.x at a glance (0.31.0 → 0.31.4)
+
+| Version | Highlights |
+| ------- | ---------- |
+| **0.31.0** | First PyPI release for SurrealDB 3.0 — `RebuildIndex`, GraphQL config (`DefineGraphQLConfig` / `RemoveGraphQLConfig`), bearer access (`DefineBearerAccess`), and `QuerySet.upsert()` / `bulk_upsert()` with `ON DUPLICATE KEY UPDATE`. |
+| **0.31.1** | Security: `cbor2` 5.8.0 → 5.9.0; CI / release-automation fixes. |
+| **0.31.2** | **Critical** — fixed a cbor2 6.x incompatibility that broke every CBOR RPC (surfaced as `401 Unauthorized`); raised security dependency floors (`aiohttp>=3.12`, `pydantic>=2.11`, `httpx>=0.28`, `cbor2>=6.1.2`). |
+| **0.31.3** | Validated against **SurrealDB 3.1.3** (test/CI target + Docker image). |
+| **0.31.4** | Fixed intermittent integration-suite **401s caused by JWT `nbf` clock skew** (issue #101); dependency refresh that also cleared the Pygments ReDoS advisory. |
+
+> **Upgrading from 0.31.0 / 0.31.1?** 0.31.2 is an important fix: under `cbor2>=6`, earlier versions fail **all** authenticated CBOR operations with `401 Unauthorized`. Move to ≥ 0.31.2 (ideally the latest 0.31.x).
+
+---
+
 ## What's New in 0.31.0
 
 ### REBUILD INDEX Migration Operation
@@ -975,7 +995,7 @@ pip install surrealdb-orm[cli]
 | **0.30.x+** | >= 3.0    | `main` | Active development  |
 | **0.20.x**  | 2.6.x     | `v2`   | Security fixes only |
 
-- **SurrealDB 3.0+** — Use `surrealdb-orm >= 0.30.0` (this branch).
+- **SurrealDB 3.0+** — Use `surrealdb-orm >= 0.30.0` (this branch). Tested through SurrealDB **3.1.3**.
 - **SurrealDB 2.6.x** — Use the [`v2` branch](https://github.com/EulogySnowfall/SurrealDB-ORM/tree/v2) (`surrealdb-orm 0.20.x`). This branch receives security patches but no new features.
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surrealdb-orm"
-version = "0.31.4"
+version = "0.31.5"
 description = "SurrealDB ORM as 'DJango style' for Python with async support. Works with pydantic validation."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/surreal_orm/__init__.py
+++ b/src/surreal_orm/__init__.py
@@ -191,4 +191,4 @@ __all__ = [
     "retry_on_conflict",
 ]
 
-__version__ = "0.31.4"
+__version__ = "0.31.5"

--- a/src/surreal_sdk/__init__.py
+++ b/src/surreal_sdk/__init__.py
@@ -75,7 +75,7 @@ from .types import (
     ResponseStatus,
 )
 
-__version__ = "0.31.4"
+__version__ = "0.31.5"
 __all__ = [
     # Connections
     "BaseSurrealConnection",

--- a/src/surreal_sdk/pyproject.toml
+++ b/src/surreal_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surreal-sdk"
-version = "0.31.4"
+version = "0.31.5"
 description = "Custom Python SDK for SurrealDB with HTTP and WebSocket support. No dependency on official surrealdb package."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1548,7 +1548,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb-orm"
-version = "0.31.4"
+version = "0.31.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
**Documentation & maintenance release** — no library code changes vs 0.31.4.

### What this does
- **CHANGELOG** — documents the previously-unreleased **0.31.1, 0.31.2, 0.31.3, 0.31.4** entries, adds a **0.31.5** consolidation entry, and renames `CHANGELOG` → `CHANGELOG.md` (fixes the README link + follows convention).
- **README** — adds a consolidated **"What's New in 0.31.5"** recap of the whole 0.31.0 → 0.31.4 line, and notes SurrealDB is tested through **3.1.3**.
- **CLAUDE.md** — corrects the stale "Last updated" date (**March → June 2026**), sets Current Version to **0.31.5**, and backfills the missing 0.31.1 entry.
- Bumps version **0.31.4 → 0.31.5**.

### 0.31.x recap (the summary that lands in 0.31.5)
| Version | Highlights |
| --- | --- |
| 0.31.0 | First PyPI release for SurrealDB 3.0 (RebuildIndex, GraphQL config, bearer access, upsert/bulk_upsert) |
| 0.31.1 | Security: cbor2 5.8→5.9; CI/release fixes |
| 0.31.2 | **Critical** cbor2 6.x 401 fix + security floor bumps |
| 0.31.3 | SurrealDB 3.1.3 support |
| 0.31.4 | JWT `nbf` clock-skew 401 fix (#101) + deps refresh / Pygments ReDoS (#6) |

On merge, the `chore(release): bump version to 0.31.5` squash commit triggers `tag-release.yml` → tag **v0.31.5** → `publish.yml` → PyPI + GitHub Release.