### PR TITLE
ci: bump action-gh-release v2 → v3 (Node 24)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,7 +105,8 @@ jobs:
           path: dist/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        # v3 = same action, runtime moved Node 20 -> Node 24 (no input/behaviour changes)
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/*
           generate_release_notes: true

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -83,7 +83,8 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.check-tag.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v2
+        # v3 = same action, runtime moved Node 20 -> Node 24 (no input/behaviour changes)
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: "Release ${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
Bumps `softprops/action-gh-release@v2` → `@v3` in `tag-release.yml` and `publish.yml`.

**Why:** `@v2` runs on **Node 20**, which GitHub Actions deprecates — forced to Node 24 on 2026-06-16, removed 2026-09-16 — and which produced a warning annotation on every recent release (v0.31.4, v0.31.5).

**Safety:** [v3.0.0](https://github.com/softprops/action-gh-release/releases/tag/v3.0.0) is a **pure runtime bump (Node 20 → Node 24)** per its release notes — same inputs, same behaviour, same major-tag convention (`@v3`). Verified the `v3` tag resolves to `node24`. Every other action in the repo is already on a Node-24 generation (checkout@v6, setup-uv@v7, …).

CI-only change — no version bump, no release triggered.