### PR TITLE
ci(security): harden workflow script-injection vectors (backport from main)

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -159,25 +159,44 @@ jobs:
       - name: Extract metadata from PR title (security sync)
         if: needs.check-pr-type.outputs.is-security-sync == 'true'
         id: sync-metadata
+        # The PR title is attacker-influenced under pull_request_target. Bind it
+        # to an env var and reference the shell variable so it is never expanded
+        # into the script text (prevents GitHub Actions script injection).
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          TITLE="${{ github.event.pull_request.title }}"
-          DEP_NAME=$(echo "$TITLE" | sed -n 's/.*bump \(.*\) from.*/\1/p')
-          NEW_VER=$(echo "$TITLE" | sed -n 's/.*from .* to \(.*\) (.*/\1/p')
-          PREV_VER=$(echo "$TITLE" | sed -n 's/.*from \(.*\) to.*/\1/p')
-          echo "dependency-names=$DEP_NAME" >> $GITHUB_OUTPUT
-          echo "new-version=$NEW_VER" >> $GITHUB_OUTPUT
-          echo "previous-version=$PREV_VER" >> $GITHUB_OUTPUT
-          echo "update-type=version-update:semver-patch" >> $GITHUB_OUTPUT
+          DEP_NAME=$(printf '%s' "$PR_TITLE" | sed -n 's/.*bump \(.*\) from.*/\1/p')
+          NEW_VER=$(printf '%s' "$PR_TITLE" | sed -n 's/.*from .* to \(.*\) (.*/\1/p')
+          PREV_VER=$(printf '%s' "$PR_TITLE" | sed -n 's/.*from \(.*\) to.*/\1/p')
+          # Validate the extracted dependency name against a strict allowlist
+          # before it flows into downstream outputs / commit messages.
+          if ! printf '%s' "$DEP_NAME" | grep -qE '^[A-Za-z0-9._-]+$'; then
+            echo "Refusing to process unexpected dependency name: '$DEP_NAME'" >&2
+            exit 1
+          fi
+          echo "dependency-names=$DEP_NAME" >> "$GITHUB_OUTPUT"
+          echo "new-version=$NEW_VER" >> "$GITHUB_OUTPUT"
+          echo "previous-version=$PREV_VER" >> "$GITHUB_OUTPUT"
+          echo "update-type=version-update:semver-patch" >> "$GITHUB_OUTPUT"
 
       - name: Resolve dependency info
         id: dep-info
+        # Values derived from the PR title (sync-metadata) are attacker-influenced
+        # under pull_request_target. Bind every ${{ }} expression to an env var and
+        # reference the shell variable so nothing is expanded into the script text.
+        env:
+          IS_DEPENDABOT: ${{ needs.check-pr-type.outputs.is-dependabot }}
+          DBM_DEP_NAMES: ${{ steps.dependabot-metadata.outputs.dependency-names }}
+          DBM_UPDATE_TYPE: ${{ steps.dependabot-metadata.outputs.update-type }}
+          SYNC_DEP_NAMES: ${{ steps.sync-metadata.outputs.dependency-names }}
+          SYNC_UPDATE_TYPE: ${{ steps.sync-metadata.outputs.update-type }}
         run: |
-          if [[ "${{ needs.check-pr-type.outputs.is-dependabot }}" == "true" ]]; then
-            echo "dep-names=${{ steps.dependabot-metadata.outputs.dependency-names }}" >> $GITHUB_OUTPUT
-            echo "update-type=${{ steps.dependabot-metadata.outputs.update-type }}" >> $GITHUB_OUTPUT
+          if [[ "$IS_DEPENDABOT" == "true" ]]; then
+            echo "dep-names=$DBM_DEP_NAMES" >> "$GITHUB_OUTPUT"
+            echo "update-type=$DBM_UPDATE_TYPE" >> "$GITHUB_OUTPUT"
           else
-            echo "dep-names=${{ steps.sync-metadata.outputs.dependency-names }}" >> $GITHUB_OUTPUT
-            echo "update-type=${{ steps.sync-metadata.outputs.update-type }}" >> $GITHUB_OUTPUT
+            echo "dep-names=$SYNC_DEP_NAMES" >> "$GITHUB_OUTPUT"
+            echo "update-type=$SYNC_UPDATE_TYPE" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Calculate next security patch version

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -15,8 +15,11 @@ permissions:
 jobs:
   tag-release:
     name: Create Tag & Release
-    # Only run on version bump commits from the automerge workflow
-    if: startsWith(github.event.head_commit.message, 'chore(release): bump version to')
+    # Only run on version bump commits from the automerge workflow.
+    # NOTE: the whole expression MUST be quoted — the ': ' inside the string
+    # literal otherwise makes YAML parse this as a mapping and the entire
+    # workflow fails to load ("mapping values are not allowed here").
+    if: "${{ startsWith(github.event.head_commit.message, 'chore(release): bump version to') }}"
     runs-on: ubuntu-latest
 
     steps:
@@ -31,41 +34,47 @@ jobs:
 
       - name: Extract version from commit message
         id: version
+        # The commit message is attacker-influenced input. Bind it (and ref_name)
+        # to env vars and reference the shell variables so nothing is expanded
+        # into the script text (prevents GitHub Actions script injection).
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          MSG="${{ github.event.head_commit.message }}"
           # Extract version: "chore(release): bump version to 0.31.2" → "0.31.2"
-          VERSION=$(echo "$MSG" | sed -n 's/.*bump version to \([0-9.]*\).*/\1/p')
+          VERSION=$(printf '%s' "$COMMIT_MSG" | sed -n 's/.*bump version to \([0-9.]*\).*/\1/p')
 
           if [[ -z "$VERSION" ]]; then
-            echo "Could not extract version from commit message: $MSG"
+            echo "Could not extract version from commit message: $COMMIT_MSG"
             exit 1
           fi
 
           TAG="v${VERSION}"
-          BRANCH="${{ github.ref_name }}"
+          BRANCH="$REF_NAME"
 
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           echo "Version: $VERSION, Tag: $TAG, Branch: $BRANCH"
 
       - name: Check if tag already exists
         id: check-tag
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          TAG="${{ steps.version.outputs.tag }}"
           if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "Tag $TAG already exists — skipping"
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create and push tag
         if: steps.check-tag.outputs.exists == 'false'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          VERSION="${{ steps.version.outputs.version }}"
-
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 


### PR DESCRIPTION
## Summary

Backports the **GitHub Actions script-injection hardening** already present on `main` to the `v2` branch. Addresses the CRITICAL finding from the automated push security review (PR-title interpolation in a `run:` block under `pull_request_target`) and the same vulnerability class found in `tag-release.yml`.

**Scope: script-injection hardening only.** No behavior change. The `pull_request_target` trigger and `PAT_TOKEN` usage are intentional design and left untouched.

## Changes

### `dependabot-automerge.yml`
- **PR title → `env: PR_TITLE`** in *Extract metadata from PR title* (was `TITLE="${{ github.event.pull_request.title }}"` inlined in the `run:` block — the actual injection vector).
- **Context/step outputs → env vars** in *Resolve dependency info* (`needs.*`, `steps.*.outputs.*` no longer interpolated into the shell).
- **Allowlist validation**: extracted dependency name must match `^[A-Za-z0-9._-]+$` before flowing downstream.
- Quote `"$GITHUB_OUTPUT"` redirects.

### `tag-release.yml`
- **Commit message + `ref_name` → env vars** in *Extract version from commit message* (`github.event.head_commit.message` is on the injection list).
- **Quote the `if:` expression** — the `': '` inside the string literal otherwise makes YAML parse it as a mapping (latent workflow-load bug).
- Bind sanitized step outputs to env; quote `"$GITHUB_OUTPUT"`.

## Deliberately NOT ported (branch-specific, from the main↔v2 audit)
- `ci.yml` branch-guard job (main-only merge gate)
- `dependabot-automerge.yml` test-job removal + `sync-v2` job (main-only)
- `publish.yml` `check-main` PyPI gate (main-only)
- `surrealdb-security.yml` 3.x refactor / `surrealdb-v2-security.yml` (cron monitors run from the default branch)
- All hardcoded `v2` branch refs and the `0.2y.x` version scheme are preserved.

## Verification
- Both workflows parse cleanly (PyYAML `safe_load`).
- No attacker-controllable **string** remains interpolated in any `run:` shell. Residual `${{ }}` are `env:`-bound values, integer `pull_request.number`, or the `ref:` checkout input (the `pull_request_target` checkout — out of scope here).