### PR TITLE
ci: don't mark v2 LTS releases as GitHub 'Latest'

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,7 +75,7 @@ jobs:
           path: dist/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/*
           generate_release_notes: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,3 +79,8 @@ jobs:
         with:
           files: dist/*
           generate_release_notes: true
+          # V2 is the deprecated LTS line — never claim the repo's "Latest"
+          # release (that belongs to the active 3.x `main` line). Without this,
+          # softprops defaults to make_latest=true and a v2 release would
+          # outrank higher-versioned main releases on the GitHub releases page.
+          make_latest: false

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.check-tag.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: "Release ${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
## Why

The `v2` branch is the deprecated SurrealDB 2.x LTS line. Its `publish.yml`
`github-release` job uses `softprops/action-gh-release@v2`, which defaults to
`make_latest=true`. As a result, the **v0.21.0** release just claimed the repo's
**"Latest"** flag over the active 3.x `main` release **v0.31.5** (already corrected
manually with `gh release edit v0.31.5 --latest`).

Without this fix, every future v2 release (e.g. security patches v0.21.1, v0.21.2…)
would grab "Latest" again.

## Change

Add `make_latest: false` to the `Create GitHub Release` step in v2's `publish.yml`.
v2 releases still publish to PyPI and still create a GitHub Release with notes — they
just no longer claim the repo-wide "Latest" flag, which stays with the active `main` line.

No change to `main` (its releases should remain "Latest").