### PR TITLE
docs: V2 retirement threshold is lite v0.40.0 (beta)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,7 +13,7 @@ and adheres to [SemVer](https://semver.org/) versioning.
 - **V2 LTS branch deprecated in favor of [SurrealDB-ORM-lite](https://github.com/EulogySnowfall/SurrealDB-ORM-lite).**
   The official SurrealDB Python SDK v2 has matured, so the bundled custom SDK is no longer needed for the
   SurrealDB 2.x line. SurrealDB-ORM-lite continues to support SurrealDB 2.x on top of that official SDK.
-  This branch will only receive **security and bug fixes** until SurrealDB-ORM-lite reaches **v0.20.0**,
+  This branch will only receive **security and bug fixes** until SurrealDB-ORM-lite reaches **v0.40.0 (beta)**,
   after which it will be retired.
   - Importing `surreal_orm` now emits a `DeprecationWarning` pointing to SurrealDB-ORM-lite.
   - README carries a deprecation banner; the package stays `Development Status :: 4 - Beta` while still maintained.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 > **This is the deprecated `v2` LTS branch** (SurrealDB 2.x), superseded since 0.21.0 by
 > [SurrealDB-ORM-lite](https://github.com/EulogySnowfall/SurrealDB-ORM-lite), which targets
 > SurrealDB 2.x on the official SurrealDB Python SDK v2. The `v2` branch receives security and
-> bug fixes only until SurrealDB-ORM-lite reaches v0.20.0, then it is retired. The `main` branch
+> bug fixes only until SurrealDB-ORM-lite reaches v0.40.0 (beta), then it is retired. The `main` branch
 > targets SurrealDB 3.x. Do not develop new features here.
 
 ## Project Vision

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 > continues to support **SurrealDB 2.x** on top of the now-matured **official SurrealDB
 > Python SDK v2** — the SDK improvements are what make a bundled custom SDK unnecessary
 > for the 2.x line. This branch will only receive **security and bug fixes** until
-> SurrealDB-ORM-lite reaches **v0.20.0**, after which it will be retired. New projects
+> SurrealDB-ORM-lite reaches **v0.40.0 (beta)**, after which it will be retired. New projects
 > targeting SurrealDB 2.x should adopt SurrealDB-ORM-lite.
 
 **SurrealDB-ORM** is a Django-style ORM for [SurrealDB](https://surrealdb.com/) with async support, Pydantic validation, and JWT authentication.
@@ -51,7 +51,7 @@ Tested with SurrealDB: v2.6.5
 
 > **Deprecation release.** This branch is now deprecated in favor of
 > [SurrealDB-ORM-lite](https://github.com/EulogySnowfall/SurrealDB-ORM-lite). It remains
-> under security/bug-fix maintenance until SurrealDB-ORM-lite reaches v0.20.0.
+> under security/bug-fix maintenance until SurrealDB-ORM-lite reaches v0.40.0 (beta).
 
 - **Deprecation notice** - README banner + a runtime `DeprecationWarning` on `import surreal_orm`,
   pointing to SurrealDB-ORM-lite (which supports SurrealDB 2.x via the official SurrealDB Python SDK v2).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Two release lines are maintained, one per SurrealDB major version:
 > :warning: The `v2` branch is **deprecated** (security & bug fixes only) in favor of
 > [SurrealDB-ORM-lite](https://github.com/EulogySnowfall/SurrealDB-ORM-lite), which supports
 > SurrealDB 2.x via the official SurrealDB Python SDK v2. The `v2` branch receives **security and
-> bug fixes only** until SurrealDB-ORM-lite reaches **v0.20.0**, after which it will be retired.
+> bug fixes only** until SurrealDB-ORM-lite reaches **v0.40.0 (beta)**, after which it will be retired.
 
 ## Versioning Scheme
 

--- a/src/surreal_orm/__init__.py
+++ b/src/surreal_orm/__init__.py
@@ -178,8 +178,8 @@ __version__ = "0.21.0"
 # The V2 LTS branch is deprecated in favor of SurrealDB-ORM-lite, which
 # continues to support SurrealDB 2.x on top of the now-matured official
 # SurrealDB Python SDK (v2). This branch remains under security/bug-fix
-# maintenance until SurrealDB-ORM-lite reaches v0.20.0, after which it will
-# be retired.
+# maintenance until SurrealDB-ORM-lite reaches v0.40.0 (beta), after which it
+# will be retired.
 #
 #   https://github.com/EulogySnowfall/SurrealDB-ORM-lite
 warnings.warn(
@@ -187,7 +187,7 @@ warnings.warn(
     "SurrealDB-ORM-lite (https://github.com/EulogySnowfall/SurrealDB-ORM-lite), "
     "which supports SurrealDB 2.x via the official SurrealDB Python SDK v2. "
     "This branch will only receive security and bug fixes until SurrealDB-ORM-lite "
-    "reaches v0.20.0, after which it will be retired.",
+    "reaches v0.40.0 (beta), after which it will be retired.",
     DeprecationWarning,
     stacklevel=2,
 )


### PR DESCRIPTION
## Summary

Updates the V2 LTS **retirement threshold** from SurrealDB-ORM-lite **v0.20.0** to **v0.40.0 (beta)**, per the revised plan. The original 0.20.0 figure (introduced in 0.21.0) was a placeholder; the branch will now be retired when SurrealDB-ORM-lite reaches **v0.40.0 (beta)**.

Updated everywhere the threshold appears (7 references):
- `src/surreal_orm/__init__.py` — runtime `DeprecationWarning` message + the explanatory comment
- `README.md` — deprecation banner + "What's New in 0.21.0"
- `SECURITY.md` — deprecation warning note
- `CHANGELOG` — `[0.21.0]` Deprecated section
- `CLAUDE.md` — deprecation banner

## Scope
- **No version bump / re-release.** This corrects the stated policy in-repo; the corrected `DeprecationWarning` will ship with the next v2 patch (the published 0.21.0 keeps the old text until then).
- **V2's own `0.2y.x` version scheme is untouched** — only the lite-version threshold changed.

## Verification
- `ruff format --check` + `ruff check`: clean
- `mypy` strict: clean (64 files)
- Runtime warning confirmed: `…reaches v0.40.0 (beta), after which it will be retired.`