### PR TITLE
ci: fix Dependabot auto-merge self-watch deadlock + pin cbor2 <6 on v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,12 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
+    ignore:
+      # The V2 LTS branch is pinned to cbor2 <6 on purpose: cbor2 6.x changed the
+      # custom-tag encoding and breaks SurrealDB 2.x CBOR RPC on this branch (the
+      # 6.x compatibility fix only landed on main / the 3.x line). Stay on 5.x.
+      - dependency-name: "cbor2"
+        update-types: ["version-update:semver-major"]
     groups:
       python-patch:
         patterns:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -76,11 +76,12 @@ jobs:
       new-version-dep: ${{ steps.dep-info.outputs.new-ver }}
 
     steps:
-      - name: Wait for CI checks to pass
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr checks "${{ github.event.pull_request.number }}" --watch --fail-fast --repo "${{ github.repository }}"
-
+      # NOTE: do NOT add a `gh pr checks --watch` gate here. This job is itself
+      # reported as the "Auto-merge & Tag" check on the PR, so watching *all*
+      # PR checks waits on this job too — a self-referential deadlock that ran
+      # until the 6h max-job timeout and never merged. Gating is delegated to
+      # `gh pr merge --auto` below, which merges only once the branch's required
+      # status checks (CI) pass.
       - name: Checkout code
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Why Dependabot auto-merges were failing

The `Auto-merge & Tag` job in `dependabot-automerge.yml` started with:

```yaml
- name: Wait for CI checks to pass
  run: gh pr checks "$PR" --watch --fail-fast
```

`gh pr checks --watch` waits for **all** of the PR's checks to reach a terminal
state — but `Auto-merge & Tag` is *itself* one of those checks. The job waited
on itself, hit the **6h max-job timeout**, and got cancelled, so no Dependabot
PR ever merged. The actual test suite (Lint, mypy, Unit 3.12/3.13/3.14,
Integration, CodeQL) was **green the whole time** — this was never a test or
`bump` failure.

Evidence (PR #117 job timing): step `Wait for CI checks to pass` ran
`10:35:15 → 16:35:26` (exactly 6h) then `cancelled`; all later steps skipped.

Since `pull_request_target` always runs the workflow from the **default branch
(main)**, the already-fixed copy on `v2` never executed — the broken main copy
ran for every PR, including those targeting v2.

### Fix
- Remove the self-referential wait step. Gating is delegated to
  `gh pr merge --auto`, which merges only once the branch's required checks pass.
- `dependabot.yml`: ignore cbor2 `semver-major` on the **v2** target so Dependabot
  stops re-proposing 6.x (v2 is pinned `<6` — 6.x breaks SurrealDB 2.x CBOR).