### PR TITLE
chore(release): bump version to 0.31.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ and adheres to [SemVer](https://semver.org/) versioning.
 
 ---
 
+## [0.31.6] - 2026-06-09
+
+**CI / maintenance release.** No library code changes — runtime behaviour is
+identical to 0.31.5. Integrates the open Dependabot PRs and fixes the
+release-automation deadlock that was preventing them from auto-merging.
+
+### Fixed
+
+- **Dependabot auto-merge self-watch deadlock (#118)** — The `Auto-merge & Tag` job in `dependabot-automerge.yml` began with `gh pr checks --watch`, which waits for *all* of the PR's checks to finish — including this job's own check run. The job therefore waited on itself until the 6-hour max-job timeout and was cancelled, so no Dependabot PR ever auto-merged. The full test suite (lint, mypy, unit, integration, CodeQL) was green throughout — this was never a test or version-bump failure. Removed the self-referential gate; merging is delegated to `gh pr merge --auto`, which merges only once the branch's required `CI Success` check passes. Because `pull_request_target` always runs the workflow from the default branch, the already-fixed copy on `v2` never executed — the broken `main` copy ran for every PR.
+
+### Changed
+
+- **`dependabot/fetch-metadata` 2 → 3 (#115).**
+- **`codecov/codecov-action` 5 → 7 (#116).**
+- **Dependabot config** — Ignore `cbor2` `semver-major` updates on the **v2** target branch. v2 is intentionally pinned to `cbor2 <6`; 6.x changed the custom-tag encoding and breaks SurrealDB 2.x CBOR RPC (the 6.x compatibility fix only landed on the `main` / 3.x line in 0.31.2). This stops Dependabot from re-proposing the `<7` widening on v2.
+
+---
+
 ## [0.31.5] - 2026-06-06
 
 **Documentation & maintenance release.** Brings the changelog and README up to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # SurrealDB-ORM - Development Context
 
-> Context document for Claude AI - Last updated: June 2026
+> Context document for Claude AI - Last updated: June 2026 (0.31.6)
 
 ## Project Vision
 
@@ -10,7 +10,7 @@
 
 ---
 
-## Current Version: 0.31.5 (Beta) — First PyPI release for SurrealDB 3.0
+## Current Version: 0.31.6 (Beta) — SurrealDB 3.0 line
 
 ### Branch Strategy
 
@@ -18,6 +18,16 @@
 | ------ | --------- | ----------- | ------------------------------- |
 | `main` | 3.X       | 0.31.x      | Active development              |
 | `v2`   | 2.X       | 0.20.x      | LTS (security & bug fixes only) |
+
+### What's New in 0.31.6
+
+- **CI / maintenance release** — no library code changes vs 0.31.5. Integrated the open Dependabot
+  PRs (`dependabot/fetch-metadata` 2→3 #115, `codecov/codecov-action` 5→7 #116) and fixed the
+  Dependabot auto-merge **self-watch deadlock** (#118): the `Auto-merge & Tag` job ran
+  `gh pr checks --watch`, which includes its own check, so it waited on itself until the 6h job
+  timeout — no Dependabot PR ever merged (tests were green throughout). Gating now relies on
+  `gh pr merge --auto`. Also told Dependabot to ignore `cbor2` major bumps on `v2` (pinned `<6`
+  because 6.x breaks SurrealDB 2.x CBOR).
 
 ### What's New in 0.31.5
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ Both branches receive automated daily security monitoring from `main` (GitHub Ac
 
 ---
 
+## What's New in 0.31.6
+
+**CI / maintenance release** — no library code changes vs 0.31.5. Integrates the
+open Dependabot updates and fixes the release-automation deadlock that kept them
+from auto-merging. See [CHANGELOG.md](CHANGELOG.md) for the full detail.
+
+- **Fixed the Dependabot auto-merge deadlock** — the `Auto-merge & Tag` job waited on `gh pr checks --watch`, which includes the job's *own* check, so it waited on itself until the 6h job timeout and never merged. Tests were green the whole time; this was never a test or version-bump failure. Gating now relies on `gh pr merge --auto`.
+- **Dependency bumps** — `dependabot/fetch-metadata` 2 → 3 (#115), `codecov/codecov-action` 5 → 7 (#116).
+- **Dependabot now ignores `cbor2` major bumps on `v2`** — that LTS branch is pinned `<6` on purpose (6.x breaks SurrealDB 2.x CBOR).
+
+---
+
 ## What's New in 0.31.5
 
 **Documentation & maintenance release** — no library code changes vs 0.31.4. It

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surrealdb-orm"
-version = "0.31.5"
+version = "0.31.6"
 description = "SurrealDB ORM as 'DJango style' for Python with async support. Works with pydantic validation."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/surreal_orm/__init__.py
+++ b/src/surreal_orm/__init__.py
@@ -191,4 +191,4 @@ __all__ = [
     "retry_on_conflict",
 ]
 
-__version__ = "0.31.5"
+__version__ = "0.31.6"

--- a/src/surreal_sdk/__init__.py
+++ b/src/surreal_sdk/__init__.py
@@ -75,7 +75,7 @@ from .types import (
     ResponseStatus,
 )
 
-__version__ = "0.31.5"
+__version__ = "0.31.6"
 __all__ = [
     # Connections
     "BaseSurrealConnection",

--- a/src/surreal_sdk/pyproject.toml
+++ b/src/surreal_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surreal-sdk"
-version = "0.31.5"
+version = "0.31.6"
 description = "Custom Python SDK for SurrealDB with HTTP and WebSocket support. No dependency on official surrealdb package."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1548,7 +1548,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb-orm"
-version = "0.31.5"
+version = "0.31.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Version Bump — 0.31.6

CI / maintenance release. **No library code changes vs 0.31.5** — runtime behaviour is identical.

Integrates the open Dependabot PRs and fixes the release-automation deadlock that prevented them from auto-merging.

### Included
- **#118** — ci: fix Dependabot auto-merge self-watch deadlock (+ pin cbor2 `<6` on v2 in `dependabot.yml`)
- **#115** — chore(actions): `dependabot/fetch-metadata` 2 → 3
- **#116** — chore(actions): `codecov/codecov-action` 5 → 7

### Docs
- `CHANGELOG.md`, `README.md`, `CLAUDE.md` updated for 0.31.6.

---
Merging this triggers `tag-release.yml` (tag `v0.31.6` + GitHub Release) and `publish.yml` (PyPI).