### PR TITLE
chore(release): bump version to 0.21.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,38 @@ and adheres to [SemVer](https://semver.org/) versioning.
 
 ---
 
+## [0.21.1] - 2026-06-09
+
+**Security maintenance release (V2 LTS).** No library code changes vs 0.21.0 —
+runtime behaviour is identical. Reaffirms the `cbor2 <6` pin and tags the CI/docs
+fixes that landed after 0.21.0.
+
+### Security
+
+- **`cbor2` stays pinned `<6` — rejected the 6.x widening.** Dependabot proposed
+  relaxing the requirement to `cbor2>=5.9.0,<7` (PR #117), which would re-allow
+  cbor2 **6.x** on this branch. 6.x changed the custom-tag encoding and breaks the
+  SurrealDB **2.x** CBOR RPC path the bundled SDK relies on; the 6.x compatibility
+  fix only landed on `main` (the 3.x line) and was **not** backported here. The
+  security floor (`cbor2>=5.9.0`, avoiding the vulnerable 5.6–5.8 range) is already
+  in place, so #117 added no security value and was closed.
+- **Dependabot now ignores `cbor2` `semver-major` updates on the `v2` target**
+  (config lives on the default branch). This stops the `<7` widening from being
+  re-proposed against this LTS branch.
+
+### Changed
+
+- **CI: v2 LTS releases are no longer marked GitHub "Latest" (#113)** — the
+  "Latest" badge belongs to the active 3.x `main` line; a v2 release must not
+  outrank a higher-versioned main release on the releases page.
+- **Docs: V2 retirement threshold clarified (#114)** — this branch is retired once
+  [SurrealDB-ORM-lite](https://github.com/EulogySnowfall/SurrealDB-ORM-lite)
+  reaches **v0.40.0 (beta)**.
+- **Version bump to 0.21.1** — `pyproject.toml`, `surreal_orm/__init__.py`,
+  `surreal_sdk/__init__.py`, `surreal_sdk/pyproject.toml`.
+
+---
+
 ## [0.21.0] - 2026-06-06
 
 ### Deprecated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,12 +19,19 @@
 
 ---
 
-## Current Version: 0.21.0 (Beta — V2 LTS, deprecated)
+## Current Version: 0.21.1 (Beta — V2 LTS, deprecated)
 
 > Maintenance line `0.2y.x` for SurrealDB 2.6.x. Tested against SurrealDB **v2.6.5**.
-> See the deprecation notice above and the [CHANGELOG](CHANGELOG) for the 0.21.0 details
-> (deprecation, security dependency upgrades, 401 clock-skew fix). The detailed "What's New"
-> history below predates the LTS split and is retained for reference.
+> See the deprecation notice above and the [CHANGELOG](CHANGELOG) for details.
+> The detailed "What's New" history below predates the LTS split and is retained for reference.
+>
+> **0.21.1** (security maintenance) — reaffirmed the `cbor2 <6` pin: rejected the Dependabot
+> proposal to widen it to `<7` (#117), which would re-allow cbor2 6.x (breaks SurrealDB 2.x
+> custom-tag CBOR; the 6.x fix only landed on `main`). Dependabot now ignores cbor2 major
+> bumps on `v2`. Also tagged the post-0.21.0 CI/docs fixes (#113 v2 releases not GitHub
+> "Latest", #114 retirement threshold = SurrealDB-ORM-lite v0.40.0 beta).
+>
+> **0.21.0** — deprecation, security dependency upgrades, 401 clock-skew fix.
 
 ### What's New in 0.14.4
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ Tested with SurrealDB: v2.6.5
 
 ---
 
+## What's New in 0.21.1
+
+> **Security maintenance release.** No library code changes vs 0.21.0.
+
+- **`cbor2` stays pinned `<6`** - Rejected the Dependabot proposal to widen the requirement to
+  `>=5.9.0,<7` (PR #117), which would re-allow cbor2 **6.x**. 6.x changed the custom-tag encoding and
+  breaks SurrealDB 2.x CBOR; the 6.x compatibility fix only landed on `main` (3.x) and was not backported
+  here. The security floor (`>=5.9.0`) is already in place. Dependabot now ignores cbor2 major bumps on `v2`.
+- **CI: v2 LTS releases are no longer marked GitHub "Latest" (#113)** and the **retirement threshold is
+  clarified as SurrealDB-ORM-lite v0.40.0 (beta) (#114)**.
+
+---
+
 ## What's New in 0.21.0
 
 > **Deprecation release.** This branch is now deprecated in favor of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surrealdb-orm"
-version = "0.21.0"
+version = "0.21.1"
 description = "SurrealDB ORM as 'DJango style' for Python with async support. Works with pydantic validation."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/surreal_orm/__init__.py
+++ b/src/surreal_orm/__init__.py
@@ -170,7 +170,7 @@ __all__ = [
     "retry_on_conflict",
 ]
 
-__version__ = "0.21.0"
+__version__ = "0.21.1"
 
 # ---------------------------------------------------------------------------
 # Deprecation notice (V2 LTS branch)

--- a/src/surreal_sdk/__init__.py
+++ b/src/surreal_sdk/__init__.py
@@ -74,7 +74,7 @@ from .types import (
     ResponseStatus,
 )
 
-__version__ = "0.21.0"
+__version__ = "0.21.1"
 __all__ = [
     # Connections
     "BaseSurrealConnection",

--- a/src/surreal_sdk/pyproject.toml
+++ b/src/surreal_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surreal-sdk"
-version = "0.21.0"
+version = "0.21.1"
 description = "Custom Python SDK for SurrealDB with HTTP and WebSocket support. No dependency on official surrealdb package."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1538,7 +1538,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb-orm"
-version = "0.21.0"
+version = "0.21.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Version Bump — 0.21.1 (V2 LTS)

**Security maintenance release.** No library code changes vs 0.21.0 — runtime behaviour is identical.

### Security
- **`cbor2` stays pinned `<6`** — rejected the Dependabot proposal to widen to `>=5.9.0,<7` (**#117**), which would re-allow cbor2 **6.x**. 6.x changed the custom-tag encoding and breaks the SurrealDB 2.x CBOR RPC path; the 6.x compatibility fix only landed on `main` (3.x) and was not backported here. The security floor (`>=5.9.0`) is already in place, so #117 added no value and was closed.
- Dependabot now ignores cbor2 `semver-major` on the `v2` target (config on the default branch).

### Changed
- CI: v2 LTS releases no longer marked GitHub "Latest" (#113).
- Docs: retirement threshold = SurrealDB-ORM-lite v0.40.0 (beta) (#114).

### Docs
- `CHANGELOG`, `README.md`, `CLAUDE.md` updated for 0.21.1.

---
Merging tags `v0.21.1`; v2's `publish.yml` then publishes to **PyPI** (trusted publishing) and creates a GitHub Release (`make_latest: false`). Tag will be pushed manually since `PAT_TOKEN` (used by `tag-release.yml` checkout) is expired.