### PR TITLE
Fix istartswith / iendswith lookups being case-sensitive

### DIFF
--- a/src/surreal_orm/query_set.py
+++ b/src/surreal_orm/query_set.py
@@ -1006,13 +1006,29 @@ class QuerySet(Generic[T]):
             return f"{field_name} {op} {value}"
 
         # ── Function-based lookups (no SurrealQL operator equivalent) ─
-        # startswith / istartswith → string::starts_with()
-        if lookup_name in ("startswith", "istartswith"):
+        # startswith → string::starts_with(field, value)
+        if lookup_name == "startswith":
             return f"string::starts_with({field_name}, ${_bind(value)})"
 
-        # endswith / iendswith → string::ends_with()
-        if lookup_name in ("endswith", "iendswith"):
+        # istartswith → string::starts_with(lowercase(field), lowercase(value))
+        if lookup_name == "istartswith":
+            if not isinstance(value, str):
+                raise TypeError(
+                    f"Value for 'istartswith' lookup on '{field_name}' must be a string, got {type(value).__name__!r}."
+                )
+            return f"string::starts_with(string::lowercase({field_name}), ${_bind(value.lower())})"
+
+        # endswith → string::ends_with(field, value)
+        if lookup_name == "endswith":
             return f"string::ends_with({field_name}, ${_bind(value)})"
+
+        # iendswith → string::ends_with(lowercase(field), lowercase(value))
+        if lookup_name == "iendswith":
+            if not isinstance(value, str):
+                raise TypeError(
+                    f"Value for 'iendswith' lookup on '{field_name}' must be a string, got {type(value).__name__!r}."
+                )
+            return f"string::ends_with(string::lowercase({field_name}), ${_bind(value.lower())})"
 
         # like → string::matches(field, regex)  (LIKE pattern converted to regex)
         if lookup_name == "like":

--- a/tests/test_query_operators_integration.py
+++ b/tests/test_query_operators_integration.py
@@ -128,10 +128,34 @@ async def test_filter_startswith() -> None:
 
 
 @pytest.mark.integration
+async def test_filter_istartswith() -> None:
+    """istartswith → case-insensitive prefix match (lowercases both sides)."""
+    results = await Person.objects().filter(name__istartswith="al").exec()
+    assert len(results) == 1
+    assert results[0].name == "Alice Smith"
+
+    # A case-sensitive startswith with the same lowercase prefix matches nothing.
+    cs = await Person.objects().filter(name__startswith="al").exec()
+    assert cs == []
+
+
+@pytest.mark.integration
 async def test_filter_endswith() -> None:
     results = await Person.objects().filter(name__endswith="Jones").exec()
     assert len(results) == 1
     assert results[0].name == "Bob Jones"
+
+
+@pytest.mark.integration
+async def test_filter_iendswith() -> None:
+    """iendswith → case-insensitive suffix match (lowercases both sides)."""
+    results = await Person.objects().filter(name__iendswith="JONES").exec()
+    assert len(results) == 1
+    assert results[0].name == "Bob Jones"
+
+    # A case-sensitive endswith with the same uppercase suffix matches nothing.
+    cs = await Person.objects().filter(name__endswith="JONES").exec()
+    assert cs == []
 
 
 @pytest.mark.integration

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -168,12 +168,42 @@ def test_queryset_compile_startswith() -> None:
     assert qs._variables["_f0"] == "Al"
 
 
+def test_queryset_compile_istartswith() -> None:
+    """istartswith is case-insensitive: lowercases both field and value."""
+    qs = ModelTest.objects().filter(name__istartswith="ALI")
+    query = qs._compile_query()
+    assert "string::starts_with(string::lowercase(name), $_f0)" in query
+    assert qs._variables["_f0"] == "ali"
+
+
+def test_queryset_compile_istartswith_differs_from_startswith() -> None:
+    """istartswith must not compile to the same SurrealQL as startswith."""
+    qs_i = ModelTest.objects().filter(name__istartswith="ali")
+    qs_cs = ModelTest.objects().filter(name__startswith="ali")
+    assert qs_i._compile_query() != qs_cs._compile_query()
+
+
 def test_queryset_compile_endswith() -> None:
     """endswith generates string::ends_with() function call."""
     qs = ModelTest.objects().filter(name__endswith="ce")
     query = qs._compile_query()
     assert "string::ends_with(name, $_f0)" in query
     assert qs._variables["_f0"] == "ce"
+
+
+def test_queryset_compile_iendswith() -> None:
+    """iendswith is case-insensitive: lowercases both field and value."""
+    qs = ModelTest.objects().filter(name__iendswith="CE")
+    query = qs._compile_query()
+    assert "string::ends_with(string::lowercase(name), $_f0)" in query
+    assert qs._variables["_f0"] == "ce"
+
+
+def test_queryset_compile_iendswith_differs_from_endswith() -> None:
+    """iendswith must not compile to the same SurrealQL as endswith."""
+    qs_i = ModelTest.objects().filter(name__iendswith="ce")
+    qs_cs = ModelTest.objects().filter(name__endswith="ce")
+    assert qs_i._compile_query() != qs_cs._compile_query()
 
 
 def test_queryset_compile_like() -> None:


### PR DESCRIPTION
## Summary

The `istartswith` and `iendswith` field lookups were **case-sensitive**, compiling to exactly the same SurrealQL as their case-sensitive counterparts `startswith` / `endswith`. Neither the field nor the bound value was lowercased, which contradicts the `i`-prefix convention used elsewhere in the ORM (`icontains`, `iendswith`, `ilike`, `iregex`).

For example, `name__istartswith="ali"` did **not** match `"Alice"`, because it compiled to: string::starts_with(name, $_f0) -- with $_f0 = "ali"

## Fix
In `surreal_orm/query_set.py`, `_render_condition` split `istartswith` and `iendswith` out of their shared branches and now lowercases **both** sides, mirroring the existing `icontains` implementation:

```
string::starts_with(string::lowercase(name), $_f0) -- with $_f0 = "ali"
string::ends_with(string::lowercase(name), $_f0) -- with $_f0 = "ce"
```

Both now also raise `TypeError` for non-string values, consistent with the other
case-insensitive string lookups.

## Tests
Followed a red-green approach: added tests that failed against the old behavior, then
applied the fix:
- **Unit** (`tests/test_unit.py`): assert the compiled SurrealQL lowercases both sides and
  is no longer byte-for-byte identical to the case-sensitive variant.
- **Integration** (`tests/test_query_operators_integration.py`): verify against a live
  SurrealDB (`name__istartswith="al"` matches `"Alice Smith"`, `name__iendswith="JONES"`
  matches `"Bob Jones"`), and that the case-sensitive variant with the same casing matches
  nothing.

All 141 unit tests and 24 operator integration tests pass.