### PR TITLE
Fixed CREATE and UPDATE behaving differently with regard to permissions

### DIFF
--- a/src/surreal_orm/model_base.py
+++ b/src/surreal_orm/model_base.py
@@ -35,6 +35,15 @@ class SurrealDbError(Exception):
 
 logger = logging.getLogger(__name__)
 
+# Raised when an update/merge affects no records. SurrealDB returns an empty
+# result both when the target row does not exist and when row-level
+# PERMISSIONS deny the write; in either case the update did not happen, so we
+# surface it instead of silently no-opping (mirrors the create-path guard).
+_UPDATE_NO_RECORD_MSG = (
+    "Can't update data, no record affected for {thing} "
+    "(record may not exist or the write was denied by permissions)."
+)
+
 # Global registry of all SurrealDB models for migration introspection
 _MODEL_REGISTRY: list[type["BaseSurrealModel"]] = []
 
@@ -931,8 +940,10 @@ class BaseSurrealModel(BaseModel):
                 )
             variables.update(extra_vars)
 
-        if self._db_persisted and id is not None:
-            thing = format_thing(table, id)
+        is_update = self._db_persisted and id is not None
+        thing: str | None = None
+        if is_update:
+            thing = format_thing(table, id)  # type: ignore[arg-type]
             query = f"UPDATE {thing} SET {set_clause};"
         elif id is not None:
             thing = format_thing(table, id)
@@ -949,6 +960,12 @@ class BaseSurrealModel(BaseModel):
             start = _start_timer()
             result = await client.query(query, variables)
             _log_query(query, variables, _elapsed_ms(start))
+
+        # A persisted UPDATE that affects no rows is a denied/missing write —
+        # surface it (skipped for deferred HTTP transactions). Mirrors the
+        # plain merge guard for the SurrealFunc / complex-nested-data paths.
+        if is_update:
+            self._raise_if_no_record_affected(result, thing or table, tx)
 
         if not self._db_persisted and result.all_records:
             record = result.all_records[0]
@@ -990,6 +1007,29 @@ class BaseSurrealModel(BaseModel):
         """
         await self._execute_save_using_query(tx, table, id, data, extra_vars)
 
+    def _raise_if_no_record_affected(
+        self,
+        result: Any,
+        thing: str,
+        tx: "BaseTransaction | None" = None,
+    ) -> None:
+        """Raise ``SurrealDbError`` when an update/merge affected no records.
+
+        SurrealDB returns an empty result both when the target row is missing
+        and when row-level ``PERMISSIONS`` deny the write; in either case the
+        update did not happen, so we surface it instead of silently no-opping
+        (mirrors the create-path "no record returned" guard).
+
+        The check is skipped for transactions whose results are *deferred*:
+        HTTP transactions batch statements and return an empty placeholder from
+        each operation until ``commit()``, so an empty placeholder there is not
+        a denied write and must not be treated as one.
+        """
+        if tx is not None and tx.defers_results:
+            return
+        if result is None or result.is_empty:
+            raise SurrealDbError(_UPDATE_NO_RECORD_MSG.format(thing=thing))
+
     async def _execute_save(
         self,
         tx: "BaseTransaction | None",
@@ -1017,7 +1057,9 @@ class BaseSurrealModel(BaseModel):
             if self._db_persisted and id is not None:
                 # Already persisted: use merge for partial update
                 thing = format_thing(table, id)
-                await tx.merge(thing, data)
+                result = await tx.merge(thing, data)
+                # Surface a denied/missing update (skipped for deferred HTTP tx).
+                self._raise_if_no_record_affected(result, thing, tx)
             elif id is not None:
                 # New record with user-provided ID: use upsert
                 thing = format_thing(table, id)
@@ -1036,8 +1078,12 @@ class BaseSurrealModel(BaseModel):
             # Already persisted: use merge for partial update
             thing = format_thing(table, id)
             start = _start_timer()
-            await client.merge(thing, data)
+            result = await client.merge(thing, data)
             _log_query(f"MERGE {thing}", data, _elapsed_ms(start))
+            # Mirror the create guard: a permission-denied (or missing-record)
+            # update returns no affected records. Surface it instead of
+            # silently no-opping, so callers can distinguish denied from done.
+            self._raise_if_no_record_affected(result, thing)
             return
 
         if id is not None:
@@ -1197,6 +1243,7 @@ class BaseSurrealModel(BaseModel):
             update_fields=data_set,
             tx=tx,
         ):
+            result: Any
             if self._has_surreal_funcs(data_set):
                 # Use raw query path for SurrealFunc values
                 set_clause, variables = self._build_set_clause(data_set)
@@ -1212,19 +1259,22 @@ class BaseSurrealModel(BaseModel):
                 query = f"UPDATE {thing} SET {set_clause};"
                 if tx is not None:
                     start = _start_timer()
-                    await tx.query(query, variables)
+                    result = await tx.query(query, variables)
                     _log_query(query, variables, _elapsed_ms(start))
                 else:
                     client = await SurrealDBConnectionManager.get_client(self.get_connection_name())
                     start = _start_timer()
-                    await client.query(query, variables)
+                    result = await client.query(query, variables)
                     _log_query(query, variables, _elapsed_ms(start))
+                # Surface a denied/missing update (skipped for deferred HTTP tx).
+                self._raise_if_no_record_affected(result, thing, tx)
                 if refresh:
                     await self.refresh()
             elif tx is not None:
                 start = _start_timer()
-                await tx.merge(thing, data_set)
+                result = await tx.merge(thing, data_set)
                 _log_query(f"MERGE {thing}", data_set, _elapsed_ms(start))
+                self._raise_if_no_record_affected(result, thing, tx)
                 # Update local instance with merged data
                 for key, value in data_set.items():
                     if hasattr(self, key):
@@ -1232,8 +1282,12 @@ class BaseSurrealModel(BaseModel):
             else:
                 client = await SurrealDBConnectionManager.get_client(self.get_connection_name())
                 start = _start_timer()
-                await client.merge(thing, data_set)
+                result = await client.merge(thing, data_set)
                 _log_query(f"MERGE {thing}", data_set, _elapsed_ms(start))
+                # A permission-denied (or missing-record) merge affects no
+                # records. Raise rather than silently returning self, so a
+                # denied write is never mistaken for a successful one.
+                self._raise_if_no_record_affected(result, thing)
                 if refresh:
                     await self.refresh()
 

--- a/src/surreal_orm/model_base.py
+++ b/src/surreal_orm/model_base.py
@@ -40,8 +40,7 @@ logger = logging.getLogger(__name__)
 # PERMISSIONS deny the write; in either case the update did not happen, so we
 # surface it instead of silently no-opping (mirrors the create-path guard).
 _UPDATE_NO_RECORD_MSG = (
-    "Can't update data, no record affected for {thing} "
-    "(record may not exist or the write was denied by permissions)."
+    "Can't update data, no record affected for {thing} (record may not exist or the write was denied by permissions)."
 )
 
 # Global registry of all SurrealDB models for migration introspection

--- a/src/surreal_sdk/transaction.py
+++ b/src/surreal_sdk/transaction.py
@@ -76,6 +76,24 @@ class BaseTransaction(ABC):
         """Check if transaction was rolled back."""
         return self._rolled_back
 
+    @property
+    def defers_results(self) -> bool:
+        """Whether per-statement results are deferred until commit.
+
+        HTTP transactions batch statements and return an *empty placeholder*
+        response from each operation immediately; the real per-statement
+        results only exist once :meth:`commit` runs. WebSocket transactions
+        execute each statement on the server right away and return the real
+        result.
+
+        Callers that inspect a statement's result (e.g. to detect a
+        permission-denied no-op, where SurrealDB returns zero affected rows)
+        must skip that check when results are deferred — an empty placeholder
+        is indistinguishable from a genuinely empty result. Defaults to
+        ``False`` (immediate results); overridden by buffering transports.
+        """
+        return False
+
     async def __aenter__(self) -> Self:
         """Begin transaction on context entry."""
         await self._begin()
@@ -168,6 +186,11 @@ class HTTPTransaction(BaseTransaction):
     The statements are wrapped in BEGIN TRANSACTION / COMMIT TRANSACTION
     and sent as a single request.
     """
+
+    @property
+    def defers_results(self) -> bool:
+        """HTTP transactions buffer statements; results are known only at commit."""
+        return True
 
     async def _begin(self) -> None:
         """Mark transaction as active (no server call needed for HTTP)."""

--- a/tests/test_permission_denial_integration.py
+++ b/tests/test_permission_denial_integration.py
@@ -1,0 +1,263 @@
+"""
+Integration test pinning the CREATE vs UPDATE permission-denial bugfix.
+
+Against a real SurrealDB instance with row-level ``PERMISSIONS``, a write made
+by a non-owner record user is denied by the server (which returns an *empty*
+result, not an error). Before the fix, the merge / persisted-save paths
+swallowed that empty result and returned ``self`` silently — a denied update
+was indistinguishable from a successful one.
+
+This test signs in as a non-owner record user and asserts that:
+
+- A denied ``merge()`` raises ``SurrealDbError`` (was a silent no-op).
+- A denied persisted ``save()`` raises ``SurrealDbError`` (was a silent no-op).
+- The owner can still update their own row (the fix doesn't break the happy path).
+- The DB row is genuinely unchanged after a denied write.
+
+Run with: pytest -m integration tests/test_permission_denial_integration.py
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src import surreal_orm
+from src.surreal_orm.model_base import (
+    BaseSurrealModel,
+    SurrealConfigDict,
+    SurrealDbError,
+)
+from src.surreal_orm.surreal_function import SurrealFunc
+from tests.conftest import (
+    SURREALDB_NAMESPACE,
+    SURREALDB_PASS,
+    SURREALDB_URL,
+    SURREALDB_USER,
+)
+
+SURREALDB_DATABASE = "test_perm_denial"
+
+OWNER_EMAIL = "owner@example.com"
+OWNER_PASSWORD = "owner_secret"
+INTRUDER_EMAIL = "intruder@example.com"
+INTRUDER_PASSWORD = "intruder_secret"
+
+
+class Note(BaseSurrealModel):
+    """A note guarded by row-level PERMISSIONS (only the owner may write)."""
+
+    model_config = SurrealConfigDict(table_name="note")
+    id: str | None = None
+    title: str
+    owner: str | None = None
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_connection() -> None:
+    """Point the ORM at the dedicated permission-denial test database."""
+    surreal_orm.SurrealDBConnectionManager.set_connection(
+        SURREALDB_URL,
+        SURREALDB_USER,
+        SURREALDB_PASS,
+        SURREALDB_NAMESPACE,
+        SURREALDB_DATABASE,
+    )
+
+
+async def _root_client():
+    """Return a freshly root-authenticated client (drops any record-auth context)."""
+    client = await surreal_orm.SurrealDBConnectionManager.reconnect()
+    assert client is not None
+    return client
+
+
+NOTE_ID = "testnote"
+
+
+@pytest.fixture
+async def seeded_note():
+    """Create the schema, two record users, and one note owned by ``owner``.
+
+    Yields the bare record id (``str``) of the seeded note. Leaves the
+    connection authenticated as root. Cleans up before and after.
+    """
+
+    async def cleanup() -> None:
+        client = await _root_client()
+        await client.query("REMOVE ACCESS IF EXISTS note_user ON DATABASE;")
+        await client.query("REMOVE TABLE IF EXISTS note;")
+        await client.query("REMOVE TABLE IF EXISTS note_user;")
+
+    await cleanup()
+
+    client = await _root_client()
+    # Schema: a record-auth user table + a note table that only its owner may
+    # create/select/update/delete.
+    await client.query(
+        """
+        DEFINE TABLE note_user SCHEMAFULL;
+        DEFINE FIELD email ON note_user TYPE string;
+        DEFINE FIELD password ON note_user TYPE string;
+        DEFINE INDEX note_user_email ON note_user FIELDS email UNIQUE;
+
+        DEFINE ACCESS note_user ON DATABASE TYPE RECORD
+            SIGNUP (CREATE note_user SET
+                email = $email,
+                password = crypto::argon2::generate($password)
+            )
+            SIGNIN (SELECT * FROM note_user WHERE
+                email = $email AND
+                crypto::argon2::compare(password, $password)
+            )
+            DURATION FOR TOKEN 1h, FOR SESSION 24h;
+
+        DEFINE TABLE note SCHEMAFULL
+            PERMISSIONS
+                FOR create, select, update, delete
+                WHERE owner = $auth.id;
+        DEFINE FIELD title ON note TYPE string;
+        DEFINE FIELD owner ON note TYPE record<note_user>;
+        """
+    )
+
+    # Create both record users via record-auth signup.
+    await client.signup(
+        namespace=SURREALDB_NAMESPACE,
+        database=SURREALDB_DATABASE,
+        access="note_user",
+        email=OWNER_EMAIL,
+        password=OWNER_PASSWORD,
+    )
+    client = await _root_client()
+    await client.signup(
+        namespace=SURREALDB_NAMESPACE,
+        database=SURREALDB_DATABASE,
+        access="note_user",
+        email=INTRUDER_EMAIL,
+        password=INTRUDER_PASSWORD,
+    )
+
+    # As root (permissions bypassed), seed a note with a known id owned by OWNER.
+    client = await _root_client()
+    await client.query(
+        """
+        LET $owner = (SELECT VALUE id FROM note_user WHERE email = $email)[0];
+        CREATE type::record('note', $note_id) SET title = 'original', owner = $owner;
+        """,
+        {"email": OWNER_EMAIL, "note_id": NOTE_ID},
+    )
+
+    yield NOTE_ID
+
+    await cleanup()
+
+
+async def _signin(email: str, password: str) -> None:
+    """Sign the singleton ORM client in as a record user (changes auth context)."""
+    client = await surreal_orm.SurrealDBConnectionManager.get_client()
+    await client.signin(
+        namespace=SURREALDB_NAMESPACE,
+        database=SURREALDB_DATABASE,
+        access="note_user",
+        email=email,
+        password=password,
+    )
+
+
+@pytest.mark.integration
+class TestPermissionDenialRaises:
+    """The denied update/merge paths must raise, mirroring the create guard."""
+
+    async def test_denied_merge_raises(self, seeded_note: str) -> None:
+        """A non-owner merge is denied by the DB and must raise, not no-op."""
+        note_id = seeded_note
+
+        # Authenticate as the intruder (not the owner).
+        await _signin(INTRUDER_EMAIL, INTRUDER_PASSWORD)
+
+        note = Note(id=note_id, title="original", owner=None)
+        note._db_persisted = True
+
+        with pytest.raises(SurrealDbError):
+            await note.merge(title="hacked", refresh=False)
+
+        # Verify the row is genuinely unchanged (root bypasses permissions).
+        client = await _root_client()
+        rows = await client.query("SELECT title FROM note;")
+        assert rows.first["title"] == "original"
+
+    async def test_denied_persisted_save_raises(self, seeded_note: str) -> None:
+        """A non-owner save() on a persisted instance must also raise."""
+        note_id = seeded_note
+
+        await _signin(INTRUDER_EMAIL, INTRUDER_PASSWORD)
+
+        note = Note(id=note_id, title="original", owner=None)
+        note._db_persisted = True
+        note.title = "hacked-via-save"
+
+        with pytest.raises(SurrealDbError):
+            await note.save()
+
+        client = await _root_client()
+        rows = await client.query("SELECT title FROM note;")
+        assert rows.first["title"] == "original"
+
+    async def test_owner_merge_succeeds(self, seeded_note: str) -> None:
+        """The happy path is unaffected: the owner can update their own note."""
+        note_id = seeded_note
+
+        # Authenticate as the owner.
+        await _signin(OWNER_EMAIL, OWNER_PASSWORD)
+
+        note = Note(id=note_id, title="original", owner=None)
+        note._db_persisted = True
+
+        result = await note.merge(title="legitimately-updated", refresh=False)
+        assert result is note
+
+        # Verify the update actually landed.
+        client = await _root_client()
+        rows = await client.query("SELECT title FROM note;")
+        assert rows.first["title"] == "legitimately-updated"
+
+
+@pytest.mark.integration
+class TestPermissionDenialSurrealFunc:
+    """The SurrealFunc (raw UPDATE) merge path must also surface denial.
+
+    A SurrealFunc value routes through ``client.query("UPDATE ... SET ...")``,
+    a different code path from the plain ``client.merge()`` above. SurrealDB
+    returns an empty result for a denied update there too, so it must raise.
+    """
+
+    async def test_denied_surrealfunc_merge_raises(self, seeded_note: str) -> None:
+        note_id = seeded_note
+
+        await _signin(INTRUDER_EMAIL, INTRUDER_PASSWORD)
+
+        note = Note(id=note_id, title="original", owner=None)
+        note._db_persisted = True
+
+        with pytest.raises(SurrealDbError):
+            await note.merge(title=SurrealFunc("string::uppercase('hacked')"), refresh=False)
+
+        # Row unchanged.
+        client = await _root_client()
+        rows = await client.query("SELECT title FROM note;")
+        assert rows.first["title"] == "original"
+
+    async def test_owner_surrealfunc_merge_succeeds(self, seeded_note: str) -> None:
+        note_id = seeded_note
+
+        await _signin(OWNER_EMAIL, OWNER_PASSWORD)
+
+        note = Note(id=note_id, title="original", owner=None)
+        note._db_persisted = True
+
+        result = await note.merge(title=SurrealFunc("string::uppercase('legit')"), refresh=False)
+        assert result is note
+
+        client = await _root_client()
+        rows = await client.query("SELECT title FROM note;")
+        assert rows.first["title"] == "LEGIT"

--- a/tests/test_permission_denial_unit.py
+++ b/tests/test_permission_denial_unit.py
@@ -1,0 +1,303 @@
+"""
+Unit tests for the CREATE vs UPDATE permission-denial asymmetry bug.
+
+When SurrealDB denies a write because of row-level ``PERMISSIONS``, it returns
+an empty result (zero records affected) rather than an error. Historically:
+
+- A denied **create** raised ``SurrealDbError`` (the create path inspects the
+  returned record and raises when nothing comes back).
+- A denied **update / merge** was a *silent no-op* — it returned ``self`` with
+  no error and no indication that 0 rows were affected.
+
+These tests pin down the fixed behavior: the merge / persisted-save paths must
+also raise ``SurrealDbError`` when no record is affected, mirroring the create
+guard. The empty ``RecordsResponse`` returned by ``client.merge()`` simulates a
+permission-denied (or missing-record) write at the SDK boundary.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.surreal_orm.model_base import (
+    BaseSurrealModel,
+    SurrealConfigDict,
+    SurrealDbError,
+)
+from src.surreal_orm.surreal_function import SurrealFunc
+from src.surreal_sdk.types import QueryResponse, QueryResult, RecordResponse, RecordsResponse, ResponseStatus
+
+
+class Note(BaseSurrealModel):
+    model_config = SurrealConfigDict(table_name="note")
+    id: str | None = None
+    title: str
+    owner: str
+
+
+def _denied_merge_client() -> AsyncMock:
+    """A mock client whose merge() returns an empty result (write denied)."""
+    client = AsyncMock()
+    # Permission-denied / missing row → SurrealDB returns no affected records.
+    client.merge = AsyncMock(return_value=RecordsResponse(records=[], raw=[]))
+    return client
+
+
+def _allowed_merge_client() -> AsyncMock:
+    """A mock client whose merge() returns the updated record (write allowed)."""
+    client = AsyncMock()
+    client.merge = AsyncMock(
+        return_value=RecordsResponse(
+            records=[{"id": "note:mine", "title": "updated", "owner": "me"}],
+            raw=[{"id": "note:mine", "title": "updated", "owner": "me"}],
+        )
+    )
+    return client
+
+
+def _patch_client(client: AsyncMock):
+    return patch(
+        "src.surreal_orm.model_base.SurrealDBConnectionManager.get_client",
+        new_callable=AsyncMock,
+        return_value=client,
+    )
+
+
+# ── merge(): denied write must raise (was a silent no-op) ────────────────
+
+
+class TestMergeDeniedRaises:
+    async def test_merge_denied_raises(self) -> None:
+        """A denied merge (0 records affected) must raise, not silently no-op.
+
+        ``refresh`` is patched out so the *only* possible source of an exception
+        is the merge guard itself, not an incidental failure inside refresh().
+        """
+        note = Note(id="not_mine", title="original", owner="someone_else")
+        note._db_persisted = True
+
+        with _patch_client(_denied_merge_client()):
+            with patch.object(Note, "refresh", new_callable=AsyncMock):
+                with pytest.raises(SurrealDbError):
+                    await note.merge(title="hacked")
+
+    async def test_merge_denied_with_refresh_false_raises(self) -> None:
+        """Even fire-and-forget merges (refresh=False) must surface denial."""
+        note = Note(id="not_mine", title="original", owner="someone_else")
+        note._db_persisted = True
+
+        with _patch_client(_denied_merge_client()):
+            with pytest.raises(SurrealDbError):
+                await note.merge(title="hacked", refresh=False)
+
+    async def test_merge_allowed_returns_self(self) -> None:
+        """The happy path is unaffected: an allowed merge returns ``self``."""
+        note = Note(id="mine", title="original", owner="me")
+        note._db_persisted = True
+
+        with _patch_client(_allowed_merge_client()):
+            with patch.object(Note, "refresh", new_callable=AsyncMock):
+                result = await note.merge(title="updated")
+
+        assert result is note
+
+
+# ── save() on a persisted instance must raise when denied ────────────────
+
+
+class TestPersistedSaveDeniedRaises:
+    async def test_persisted_save_denied_raises(self) -> None:
+        """save() on a persisted instance is a merge; a denied merge must raise."""
+        note = Note(id="not_mine", title="original", owner="someone_else")
+        note._db_persisted = True
+        note.title = "hacked again"
+
+        with _patch_client(_denied_merge_client()):
+            with pytest.raises(SurrealDbError):
+                await note.save()
+
+    async def test_persisted_save_allowed_succeeds(self) -> None:
+        """The happy path is unaffected: an allowed persisted save returns self."""
+        note = Note(id="mine", title="original", owner="me")
+        note._db_persisted = True
+        note.title = "updated"
+
+        with _patch_client(_allowed_merge_client()):
+            result = await note.save()
+
+        assert result is note
+
+
+# ── Consistency: create and update both raise on denial ──────────────────
+
+
+class TestCreateUpdateConsistency:
+    async def test_create_denied_raises(self) -> None:
+        """Baseline: a denied create raises (the behavior update should match)."""
+        note = Note(title="x", owner="someone_else")
+        note._db_persisted = False
+
+        client = AsyncMock()
+        # create() returns an empty RecordResponse when the write is denied.
+        client.create = AsyncMock(return_value=RecordResponse(record=None, raw=[]))
+
+        with _patch_client(client):
+            with pytest.raises(SurrealDbError):
+                await note.save()
+
+
+# ── Helpers for the SurrealFunc (raw-query) and transaction paths ────────
+
+
+def _empty_query_response() -> QueryResponse:
+    """A QueryResponse with zero affected records (write denied / missing row)."""
+    return QueryResponse(results=[QueryResult(status=ResponseStatus.OK, result=[])], raw=[])
+
+
+def _nonempty_query_response() -> QueryResponse:
+    """A QueryResponse carrying one updated record (write allowed)."""
+    return QueryResponse(
+        results=[QueryResult(status=ResponseStatus.OK, result=[{"id": "note:mine", "title": "updated"}])],
+        raw=[{"id": "note:mine", "title": "updated"}],
+    )
+
+
+def _query_client(response: QueryResponse) -> AsyncMock:
+    """A mock client whose query() returns *response* (the SurrealFunc path)."""
+    client = AsyncMock()
+    client.query = AsyncMock(return_value=response)
+    return client
+
+
+def _fake_tx(
+    *,
+    defers_results: bool,
+    merge_result: RecordsResponse | None = None,
+    query_result: QueryResponse | None = None,
+) -> MagicMock:
+    """Build a fake transaction.
+
+    ``defers_results=True`` mimics an HTTP transaction (statements are
+    buffered and an *empty placeholder* is returned immediately — the real
+    result only exists after commit). ``defers_results=False`` mimics a
+    WebSocket transaction (each statement executes immediately, real result).
+    """
+    tx = MagicMock()
+    tx.defers_results = defers_results
+    tx.merge = AsyncMock(return_value=merge_result if merge_result is not None else RecordsResponse(records=[], raw=[]))
+    tx.query = AsyncMock(return_value=query_result if query_result is not None else _empty_query_response())
+    return tx
+
+
+# ── SurrealFunc (raw UPDATE query) path: denial must raise ───────────────
+
+
+class TestMergeSurrealFuncDeniedRaises:
+    """merge() with a SurrealFunc value runs a raw UPDATE via client.query()."""
+
+    async def test_surrealfunc_merge_denied_raises(self) -> None:
+        note = Note(id="not_mine", title="original", owner="someone_else")
+        note._db_persisted = True
+
+        with _patch_client(_query_client(_empty_query_response())):
+            with pytest.raises(SurrealDbError):
+                await note.merge(last_ping=SurrealFunc("time::now()"), refresh=False)
+
+    async def test_surrealfunc_merge_allowed_succeeds(self) -> None:
+        note = Note(id="mine", title="original", owner="me")
+        note._db_persisted = True
+
+        with _patch_client(_query_client(_nonempty_query_response())):
+            result = await note.merge(last_ping=SurrealFunc("time::now()"), refresh=False)
+
+        assert result is note
+
+    async def test_surrealfunc_save_denied_raises(self) -> None:
+        """save(server_values=SurrealFunc) on a persisted instance: denied must raise."""
+        note = Note(id="not_mine", title="original", owner="someone_else")
+        note._db_persisted = True
+
+        with _patch_client(_query_client(_empty_query_response())):
+            with pytest.raises(SurrealDbError):
+                await note.save(server_values={"last_ping": SurrealFunc("time::now()")})
+
+
+# ── Transaction paths: WebSocket-style (immediate) denial must raise ─────
+
+
+class TestTransactionDeniedRaises:
+    """A WS-style transaction returns the real result, so denial is detectable."""
+
+    async def test_tx_merge_denied_raises(self) -> None:
+        note = Note(id="not_mine", title="original", owner="someone_else")
+        note._db_persisted = True
+
+        tx = _fake_tx(defers_results=False)
+        with pytest.raises(SurrealDbError):
+            await note.merge(title="hacked", tx=tx)
+
+    async def test_tx_persisted_save_denied_raises(self) -> None:
+        note = Note(id="not_mine", title="original", owner="someone_else")
+        note._db_persisted = True
+        note.title = "hacked"
+
+        tx = _fake_tx(defers_results=False)
+        with pytest.raises(SurrealDbError):
+            await note.save(tx=tx)
+
+    async def test_tx_surrealfunc_merge_denied_raises(self) -> None:
+        note = Note(id="not_mine", title="original", owner="someone_else")
+        note._db_persisted = True
+
+        tx = _fake_tx(defers_results=False)
+        with pytest.raises(SurrealDbError):
+            await note.merge(last_ping=SurrealFunc("time::now()"), tx=tx, refresh=False)
+
+    async def test_tx_merge_allowed_succeeds(self) -> None:
+        note = Note(id="mine", title="original", owner="me")
+        note._db_persisted = True
+
+        tx = _fake_tx(
+            defers_results=False,
+            merge_result=RecordsResponse(records=[{"id": "note:mine", "title": "ok"}], raw=[]),
+        )
+        result = await note.merge(title="ok", tx=tx)
+        assert result is note
+
+
+# ── HTTP transactions buffer results: an empty placeholder is NOT denial ──
+
+
+class TestDeferredTransactionDoesNotFalselyRaise:
+    """HTTP transactions return empty placeholders before commit.
+
+    The guard must NOT treat that placeholder as a denied write, or every
+    transactional merge/save would wrongly raise.
+    """
+
+    async def test_deferred_tx_merge_does_not_raise(self) -> None:
+        note = Note(id="any", title="original", owner="me")
+        note._db_persisted = True
+
+        tx = _fake_tx(defers_results=True)  # empty placeholder, but deferred
+        result = await note.merge(title="queued", tx=tx)
+        assert result is note
+
+    async def test_deferred_tx_persisted_save_does_not_raise(self) -> None:
+        note = Note(id="any", title="original", owner="me")
+        note._db_persisted = True
+        note.title = "queued"
+
+        tx = _fake_tx(defers_results=True)
+        result = await note.save(tx=tx)
+        assert result is note
+
+    async def test_deferred_tx_surrealfunc_merge_does_not_raise(self) -> None:
+        note = Note(id="any", title="original", owner="me")
+        note._db_persisted = True
+
+        tx = _fake_tx(defers_results=True)
+        result = await note.merge(last_ping=SurrealFunc("time::now()"), tx=tx, refresh=False)
+        assert result is note


### PR DESCRIPTION
## Summary

On a table protected by row-level `PERMISSIONS`, the write paths behaved inconsistently when SurrealDB denied a write:

- **CREATE** — `Model(**data).save()` on a new instance **raised** `SurrealDbError("Can't save data, no record returned.")`.
- **UPDATE / merge** — `.save()` on a persisted instance, or `.merge(...)`, on a row the user could not update was a **silent no-op**: it returned `self`, the row was unchanged, and no error was raised.

SurrealDB returns an *empty result* (zero affected rows) both when the target row is missing and when row-level permissions deny the write — it does not raise. The merge/update paths discarded that result, so a denied update was indistinguishable from a successful one. Application code relying on `merge()` / `save()` to enforce "the write happened" could silently lose data and report success.

## Fix

A denied/missing update now raises `SurrealDbError`, mirroring the create-path guard, across **every** non-deferred write path:

- plain `client.merge()` (persisted `save()` and `merge()`)
- the `SurrealFunc` raw-`UPDATE` path (`merge(field=SurrealFunc(...))`,
  `save(server_values=...)`)
- the complex-nested-data SET-clause path (`_execute_save_using_query`)
- WebSocket transactions (results are immediate)

The check is centralized in a single helper:

```python
def _raise_if_no_record_affected(self, result, thing, tx=None):
    if tx is not None and tx.defers_results:
        return
    if result is None or result.is_empty:
        raise SurrealDbError(_UPDATE_NO_RECORD_MSG.format(thing=thing))

```

## Transaction nuance (`defers_results`)

HTTPTransaction batches statements and returns an empty placeholder response from each operation until commit(). The real per-statement result only exists at commit time. A naïve is_empty check would therefore make every HTTP-transaction merge/save raise.

To distinguish a deferred placeholder from a genuinely empty (denied) result, a defers_results property was added to the transaction abstraction:

- BaseTransaction.defers_results → False (immediate results, default)
- HTTPTransaction.defers_results → True (buffered until commit)
- WebSocketTransaction inherits False
The guard skips deferred transactions, so HTTP-transaction behavior is unchanged.

## Known limitation

Denial inside an HTTP transaction remains undetectable at statement time: the real result is not known until commit(), and a denied UPDATE returns an empty result without error even there. Detecting it would require inspecting the commit() QueryResponse in the transaction layer, which is out of scope here. This is why the WS-transaction case is covered by unit tests rather than integration tests (the ORM uses an HTTP connection by default).

### Verification

Full suite: 2243 passed, 27 skipped, 0 failed
mypy (strict): 66 source files, 0 errors