### PR TITLE
ci(tag-release): take first version match so multi-commit release PRs tag correctly

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -41,7 +41,13 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           # Extract version: "chore(release): bump version to 0.31.2" → "0.31.2"
-          VERSION=$(echo "$COMMIT_MSG" | sed -n 's/.*bump version to \([0-9.]*\).*/\1/p')
+          # head -n1: a squash-merge concatenates every commit message, so the
+          # "bump version to" phrase can appear on multiple lines (e.g. the bump
+          # commit's own subject plus a CHANGELOG commit). Without head -n1, sed
+          # prints one match per line and $VERSION becomes multi-line, which
+          # makes `echo "version=$VERSION" >> "$GITHUB_OUTPUT"` fail with
+          # "Invalid format" and the release is never tagged.
+          VERSION=$(echo "$COMMIT_MSG" | sed -n 's/.*bump version to \([0-9.]*\).*/\1/p' | head -n1)
 
           if [[ -z "$VERSION" ]]; then
             echo "Could not extract version from commit message: $COMMIT_MSG"


### PR DESCRIPTION
## Problem

`tag-release.yml` extracts the release version with:

```bash
VERSION=$(echo "$COMMIT_MSG" | sed -n 's/.*bump version to \([0-9.]*\).*/\1/p')
```

`sed -n …p` prints **once per matching line**. When a `chore(release): bump version to X.Y.Z` PR is **squash-merged with more than one commit**, GitHub concatenates every commit message into `head_commit.message`, so the `bump version to X.Y.Z` phrase appears on multiple lines (the bump commit's own subject + any other commit, e.g. a CHANGELOG commit). `$VERSION` then becomes multi-line (`X.Y.Z\nX.Y.Z`), and:

```bash
echo "version=$VERSION" >> "$GITHUB_OUTPUT"
```

fails with `Invalid format 'X.Y.Z'` — the job dies **before** tagging, so no tag/release is created.

## Impact

Hit for real on **v2** with **0.21.2** (2026-07-20): the release-bump PR carried a CHANGELOG commit alongside the version bump, the version step failed, and `v0.21.2` had to be tagged/released manually. The same fragile step exists on `main`, so any multi-commit release-bump PR here would fail the same way.

## Fix

Append `| head -n1` so only the first match is used. Single-commit bumps are unaffected.

Verified locally:
- multi-line body `…0.21.2…\n…0.21.2…` → old: `0.21.2\n0.21.2` (breaks), new: `0.21.2`
- single-line body → unchanged (`0.31.13` → `0.31.13`)

The `$COMMIT_MSG` env-var pattern (no direct `${{ }}` interpolation in `run:`) is preserved.

_A matching backport PR targets `v2` (its copy of the workflow has the same bug)._