### PR TITLE
ci(tag-release): take first version match so multi-commit release PRs tag correctly (v2)

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -42,7 +42,13 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           # Extract version: "chore(release): bump version to 0.31.2" → "0.31.2"
-          VERSION=$(printf '%s' "$COMMIT_MSG" | sed -n 's/.*bump version to \([0-9.]*\).*/\1/p')
+          # head -n1: a squash-merge concatenates every commit message, so the
+          # "bump version to" phrase can appear on multiple lines (e.g. the bump
+          # commit's own subject plus a CHANGELOG commit). Without head -n1, sed
+          # prints one match per line and $VERSION becomes multi-line, which
+          # makes `echo "version=$VERSION" >> "$GITHUB_OUTPUT"` fail with
+          # "Invalid format" and the release is never tagged (hit on 0.21.2).
+          VERSION=$(printf '%s' "$COMMIT_MSG" | sed -n 's/.*bump version to \([0-9.]*\).*/\1/p' | head -n1)
 
           if [[ -z "$VERSION" ]]; then
             echo "Could not extract version from commit message: $COMMIT_MSG"


### PR DESCRIPTION
## Problem

Backport of #140 to the **v2 LTS** branch — this branch's `tag-release.yml` has the same bug.

The version step uses `sed -n …p`, which prints **once per matching line**. When a `chore(release): bump version to X.Y.Z` PR is **squash-merged with more than one commit**, GitHub concatenates all commit messages, so `bump version to X.Y.Z` appears on multiple lines, `$VERSION` becomes multi-line, and `echo "version=$VERSION" >> "$GITHUB_OUTPUT"` fails with `Invalid format` — the job dies before tagging.

## This actually happened

**0.21.2** (this branch, 2026-07-20): the release-bump PR carried a CHANGELOG commit alongside the bump, tag-release failed, and `v0.21.2` was tagged + released manually as a workaround.

## Fix

Append `| head -n1` so only the first match is used. Single-commit bumps are unaffected. The `$COMMIT_MSG` env-var / no-interpolation injection guard is preserved.

Verified locally against both the multi-line body (old `0.21.2\n0.21.2` → new `0.21.2`) and a normal single-line body (unchanged).