### PR TITLE
ci: run CI (and report CI Success) on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,15 @@ on:
       - '.github/workflows/**'
       - '.surrealdb-version'
       - 'uv.lock'
+      # Docs paths: the `CI Success` job is a required status check, but a
+      # PR that only touches docs would otherwise never trigger this workflow,
+      # so the check stays "Expected" forever and the PR can't merge (the
+      # ruleset allows no bypass). Including docs makes CI run and report
+      # `CI Success` for docs-only PRs too (jobs pass trivially — no code changed).
+      - 'README.md'
+      - '**/*.md'
+      - 'docs/**'
+      - 'CHANGELOG'
 
 env:
   SURREALDB_URL: http://localhost:8000


### PR DESCRIPTION
## Problem

`CI Success` (the `ci-success` aggregator job in `ci.yml`) is a **required** status check on `main`, but `ci.yml`'s `pull_request` trigger is `paths`-filtered and excluded docs. A PR that only touches docs (e.g. README) therefore **never triggers the workflow**, so `CI Success` stays `Expected` indefinitely and the PR can't merge. The `protect merge` ruleset has an **empty bypass list**, so an admin merge is refused too.

Hit by #142 (README comparison-table refresh — pure docs, correct, but unmergeable).

## Fix

Add `README.md`, `**/*.md`, `docs/**`, and `CHANGELOG` to the `pull_request` `paths`. Docs-only PRs now trigger CI and report `CI Success` — the jobs pass trivially since no code changed. Permanent fix for all future docs PRs.

Tradeoff: docs PRs now spend a couple of CI minutes (lint/unit/integration run and pass). That's the cost of having `CI Success` reportable without weakening branch protection.

Docs/CI only — no library code touched.