### PR TITLE
chore(release): bump version to 0.31.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ and adheres to [SemVer](https://semver.org/) versioning.
 
 ---
 
+## [0.31.13] - 2026-07-27
+
+**Bug-fix release.** Two correctness fixes.
+
+### Fixed
+
+- **Denied / missing `UPDATE` and `merge()` now raise instead of silently
+  no-opping (#135).** On a table protected by row-level `PERMISSIONS`, a write
+  the current user isn't allowed to make — or one targeting a row that no longer
+  exists — makes SurrealDB return an *empty* result (zero affected rows), not an
+  error. Previously `save()` on a persisted instance and `merge()` discarded
+  that result and returned `self`, so a denied update was indistinguishable from
+  a successful one and callers could silently lose data while reporting success.
+  A denied/missing update now raises `SurrealDbError`, mirroring the create-path
+  guard, across every non-deferred write path: plain `client.merge()`, the
+  `SurrealFunc` raw-`UPDATE` path, the complex-nested-data SET-clause path, and
+  WebSocket transactions. A new `BaseTransaction.defers_results` property keeps
+  HTTP-transaction behaviour unchanged (their per-statement results only exist
+  at `commit()`, so the guard is skipped there). Known limitation: denial
+  *inside* an HTTP transaction remains undetectable at statement time.
+- **`istartswith` / `iendswith` are now actually case-insensitive (#134).** They
+  previously compiled to the same SurrealQL as the case-sensitive `startswith` /
+  `endswith`, so e.g. `name__istartswith="ali"` did not match `"Alice"`. Both
+  the field and the value are now lowercased (mirroring `icontains`), and both
+  raise `TypeError` for non-string values.
+
+Thanks to [@rmortes](https://github.com/rmortes) for both fixes.
+
+### Changed
+
+- **Version bump to 0.31.13** — `pyproject.toml`, `surreal_orm/__init__.py`,
+  `surreal_sdk/__init__.py`, `surreal_sdk/pyproject.toml`.
+
+---
+
 ## [0.31.6] - 2026-06-09
 
 **CI / maintenance release.** No library code changes — runtime behaviour is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surrealdb-orm"
-version = "0.31.12"
+version = "0.31.13"
 description = "SurrealDB ORM as 'DJango style' for Python with async support. Works with pydantic validation."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/surreal_orm/__init__.py
+++ b/src/surreal_orm/__init__.py
@@ -191,4 +191,4 @@ __all__ = [
     "retry_on_conflict",
 ]
 
-__version__ = "0.31.12"
+__version__ = "0.31.13"

--- a/src/surreal_sdk/__init__.py
+++ b/src/surreal_sdk/__init__.py
@@ -75,7 +75,7 @@ from .types import (
     ResponseStatus,
 )
 
-__version__ = "0.31.12"
+__version__ = "0.31.13"
 __all__ = [
     # Connections
     "BaseSurrealConnection",

--- a/src/surreal_sdk/pyproject.toml
+++ b/src/surreal_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surreal-sdk"
-version = "0.31.12"
+version = "0.31.13"
 description = "Custom Python SDK for SurrealDB with HTTP and WebSocket support. No dependency on official surrealdb package."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1548,7 +1548,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb-orm"
-version = "0.31.12"
+version = "0.31.13"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Release 0.31.13

Bug-fix release shipping two correctness fixes already merged to `main`:

- **#135** — denied / missing `UPDATE` and `merge()` now raise `SurrealDbError` instead of silently no-opping (was indistinguishable from success on row-`PERMISSIONS` tables). Covers every non-deferred write path; a new `BaseTransaction.defers_results` keeps HTTP-transaction behaviour unchanged.
- **#134** — `istartswith` / `iendswith` are now actually case-insensitive (previously compiled identically to `startswith` / `endswith`).

Both by @rmortes.

Version bumped in `pyproject.toml`, `surreal_orm/__init__.py`, `surreal_sdk/__init__.py`, `surreal_sdk/pyproject.toml`, `uv.lock`; `CHANGELOG.md` entry added. Single commit so `tag-release.yml` parses the version cleanly.

Merging this triggers `tag-release.yml` → `v0.31.13` tag + GitHub Release → `publish.yml` → PyPI.