### PR TITLE
docs: backfill CHANGELOG + README for 0.31.7–0.31.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,76 @@ Thanks to [@rmortes](https://github.com/rmortes) for both fixes.
 
 ---
 
+## [0.31.12] - 2026-07-20
+
+**CI maintenance release.** No library code changes — runtime behaviour is
+identical to 0.31.11.
+
+### Changed
+
+- **CI: `actions/setup-python` 6 → 7 (#136).**
+
+---
+
+## [0.31.11] - 2026-06-22
+
+**CI maintenance release.** No library code changes — runtime behaviour is
+identical to 0.31.10.
+
+### Changed
+
+- **CI: `actions/checkout` 6 → 7 (#132).**
+
+---
+
+## [0.31.10] - 2026-06-20
+
+**Maintenance release.** No library code changes — runtime behaviour is
+identical to 0.31.9.
+
+### Changed
+
+- **Dependency: `tornado` 6.5.6 → 6.5.7 (#127)** — transitive dev-group
+  dependency; not part of the runtime install.
+
+---
+
+## [0.31.9] - 2026-06-20
+
+**Maintenance release.** No library code changes — the SDK and ORM are
+compatible as-is.
+
+### Changed
+
+- **Validated against SurrealDB 3.1.5 (#128)** — bumped the test/CI target and
+  Docker Compose image `surrealdb/surrealdb:v3.1.4` → `v3.1.5`.
+
+---
+
+## [0.31.8] - 2026-06-17
+
+**Maintenance release.** No library code changes — runtime behaviour is
+identical to 0.31.7.
+
+### Changed
+
+- **Dependency: `aiohttp` 3.14.0 → 3.14.1 (#123)** — the WebSocket transport's
+  runtime dependency (Dependabot).
+
+---
+
+## [0.31.7] - 2026-06-11
+
+**Maintenance release.** No library code changes — the SDK and ORM are
+compatible as-is.
+
+### Changed
+
+- **Validated against SurrealDB 3.1.4 (#121)** — bumped the test/CI target and
+  Docker Compose image `surrealdb/surrealdb:v3.1.3` → `v3.1.4`.
+
+---
+
 ## [0.31.6] - 2026-06-09
 
 **CI / maintenance release.** No library code changes — runtime behaviour is

--- a/README.md
+++ b/README.md
@@ -24,6 +24,28 @@ Both branches receive automated daily security monitoring from `main` (GitHub Ac
 
 ---
 
+## What's New in 0.31.13
+
+**Bug-fix release** — two correctness fixes (thanks [@rmortes](https://github.com/rmortes)).
+See [CHANGELOG.md](CHANGELOG.md) for the full detail.
+
+- **Denied / missing `UPDATE` and `merge()` now raise instead of silently no-opping (#135)** — on a table with row-level `PERMISSIONS`, a write the current user isn't allowed to make (or one targeting a row that no longer exists) makes SurrealDB return an *empty* result, not an error. `save()` on a persisted instance and `merge()` previously discarded that and returned `self`, so a denied update looked identical to success. All non-deferred write paths now raise `SurrealDbError`; a new `BaseTransaction.defers_results` keeps HTTP-transaction behaviour unchanged.
+- **`istartswith` / `iendswith` are now actually case-insensitive (#134)** — they previously compiled to the same SurrealQL as `startswith` / `endswith`, so `name__istartswith="ali"` did not match `"Alice"`. Both sides are now lowercased (mirroring `icontains`).
+
+## What's New in 0.31.7 → 0.31.12
+
+**Maintenance / dependency releases** — no library code changes; runtime behaviour
+is identical across this range. See [CHANGELOG.md](CHANGELOG.md) for the full detail.
+
+| Version | Change |
+| ------- | ------ |
+| **0.31.7** | Validated against **SurrealDB 3.1.4** (test/CI target + Docker image) (#121). |
+| **0.31.8** | Dependency: `aiohttp` 3.14.0 → 3.14.1 (WebSocket transport runtime dep) (#123). |
+| **0.31.9** | Validated against **SurrealDB 3.1.5** (test/CI target + Docker image) (#128). |
+| **0.31.10** | Dependency: `tornado` 6.5.6 → 6.5.7 (transitive dev-group dep) (#127). |
+| **0.31.11** | CI: `actions/checkout` 6 → 7 (#132). |
+| **0.31.12** | CI: `actions/setup-python` 6 → 7 (#136). |
+
 ## What's New in 0.31.6
 
 **CI / maintenance release** — no library code changes vs 0.31.5. Integrates the


### PR DESCRIPTION
## Problem

The `CHANGELOG.md` jumped from **0.31.6** straight to **0.31.13**, and the README "What's New" history stopped at **0.31.6** — leaving **0.31.7 → 0.31.12** undocumented. All six were maintenance / dependency releases (no library code changes), but the gap made the history look broken.

## Change (docs only)

Backfill both files with accurate per-version entries reconstructed from git history:

| Version | Change |
| --- | --- |
| 0.31.7 | SurrealDB test/CI target 3.1.3 → **3.1.4** (#121) |
| 0.31.8 | `aiohttp` 3.14.0 → 3.14.1 — WebSocket transport runtime dep (#123) |
| 0.31.9 | SurrealDB test/CI target 3.1.4 → **3.1.5** (#128) |
| 0.31.10 | `tornado` 6.5.6 → 6.5.7 — transitive dev-group dep (#127) |
| 0.31.11 | CI: `actions/checkout` 6 → 7 (#132) |
| 0.31.12 | CI: `actions/setup-python` 6 → 7 (#136) |

Also adds the **0.31.13** "What's New" section (#134 + #135) to the README so it matches the CHANGELOG entry that shipped with that release. The CHANGELOG version list is now continuous (0.31.13 → 0.31.4).

No library code touched.