### PR TITLE
ci: merge version-bump PRs even when the base branch is unprotected (#153)

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -138,10 +138,82 @@ jobs:
             echo "new-ver=$SYNC_NEW_VER" >> "$GITHUB_OUTPUT"
           fi
 
+      # Written to $RUNNER_TEMP rather than committed as .github/scripts/*.sh:
+      # under `pull_request_target` the workflow file always comes from the
+      # default branch, but the checkout is of the PR's *base* branch — a
+      # committed helper would be missing whenever the base is `v2`.
+      - name: Prepare merge helper
+        run: |
+          cat > "$RUNNER_TEMP/merge-when-green.sh" <<'HELPER'
+          #!/usr/bin/env bash
+          # Merge a PR as soon as its required CI check is green.
+          #
+          # `gh pr merge --auto` is preferred, but GitHub only accepts it when the
+          # PR's BASE branch has protection / a ruleset with required status checks.
+          # `v2` had none (its ruleset targeted `refs/heads/V2` — wrong case), so the
+          # call failed outright and every v2 version-bump PR stalled (#153). Fall
+          # back to polling the required check and merging explicitly.
+          #
+          # NOTE (#118): never gate on `gh pr checks --watch` here. This job is itself
+          # reported as the "Auto-merge & Tag" check, so watching *all* checks waits on
+          # this job — a self-referential deadlock that ran to the 6h job timeout. We
+          # poll one named check ("CI Success") that is produced by a different workflow.
+          set -euo pipefail
+
+          PR="${1:?usage: merge-when-green.sh <pr-number-or-branch> [required-check]}"
+          REQUIRED_CHECK="${2:-CI Success}"
+          POLL_INTERVAL="${POLL_INTERVAL:-20}"
+          MAX_ATTEMPTS="${MAX_ATTEMPTS:-90}"  # 90 * 20s = 30 min
+
+          if gh pr merge --auto --squash "$PR"; then
+            echo "auto-merge enabled (or merged) for $PR"
+            exit 0
+          fi
+
+          echo "::warning::native auto-merge unavailable for $PR (base branch likely unprotected) — falling back to an explicit '$REQUIRED_CHECK' gate"
+
+          for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+            STATE=$(gh pr view "$PR" --json state --jq '.state')
+            case "$STATE" in
+              MERGED) echo "$PR is merged"; exit 0 ;;
+              CLOSED) echo "::error::$PR was closed without merging"; exit 1 ;;
+            esac
+
+            CONCLUSION=$(gh pr view "$PR" --json statusCheckRollup --jq '.statusCheckRollup' \
+              | jq -r --arg c "$REQUIRED_CHECK" '
+                  [.[] | select((.name // .context) == $c)] | .[0]
+                  | if . == null then "PENDING"
+                    elif .__typename == "StatusContext" then .state
+                    elif .status != "COMPLETED" then "PENDING"
+                    else .conclusion end')
+
+            case "$CONCLUSION" in
+              SUCCESS|NEUTRAL|SKIPPED)
+                echo "'$REQUIRED_CHECK' is $CONCLUSION — merging $PR"
+                gh pr merge --squash "$PR"
+                exit 0
+                ;;
+              FAILURE|ERROR|CANCELLED|TIMED_OUT|ACTION_REQUIRED|STARTUP_FAILURE)
+                echo "::error::'$REQUIRED_CHECK' concluded $CONCLUSION on $PR — not merging"
+                exit 1
+                ;;
+              *)
+                echo "waiting for '$REQUIRED_CHECK' on $PR ($CONCLUSION) — attempt $attempt/$MAX_ATTEMPTS"
+                sleep "$POLL_INTERVAL"
+                ;;
+            esac
+          done
+
+          echo "::error::'$REQUIRED_CHECK' did not conclude on $PR within the timeout"
+          exit 1
+          HELPER
+          chmod +x "$RUNNER_TEMP/merge-when-green.sh"
+
       - name: Enable auto-merge
-        run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
+        run: '"$RUNNER_TEMP/merge-when-green.sh" "$PR_NUMBER"'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
 
       - name: Wait for merge
         id: wait-merge
@@ -239,7 +311,7 @@ jobs:
             --base "$BASE_BRANCH" \
             --head "$BRANCH"
 
-          gh pr merge --auto --squash "$BRANCH"
+          "$RUNNER_TEMP/merge-when-green.sh" "$BRANCH"
 
   # =============================================================================
   # Sync dependency update to V2 branch (if the same dep exists there)

--- a/tests/test_dependabot_automerge.py
+++ b/tests/test_dependabot_automerge.py
@@ -1,0 +1,96 @@
+"""Lint tests for the Dependabot auto-merge workflow.
+
+Guards two regressions in the release chain:
+
+* **#153** — ``gh pr merge --auto`` is rejected by GitHub when the PR's *base*
+  branch has no protection ("Protected branch rules not configured for this
+  branch"). ``v2`` was unprotected, so every version-bump PR based on it stalled
+  and the LTS line stopped publishing. Every merge call must therefore go
+  through the fallback helper, never bare ``--auto``.
+* **#118** — the auto-merge job is itself reported as the "Auto-merge & Tag"
+  check on the PR, so ``gh pr checks --watch`` waits on its own job until the 6h
+  timeout. No watch-all gate may come back into this workflow.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+yaml = pytest.importorskip("yaml", reason="pyyaml required for workflow lint tests")
+
+WORKFLOW = Path(__file__).resolve().parent.parent / ".github" / "workflows" / "dependabot-automerge.yml"
+
+HELPER = "merge-when-green.sh"
+
+# `gh pr merge --auto ...` written directly in a step, i.e. not delegated to the
+# helper that falls back to an explicit CI gate.
+_BARE_AUTO_MERGE = re.compile(r"gh\s+pr\s+merge\b[^\n]*--auto")
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _steps() -> list[tuple[str, dict[str, Any]]]:
+    """Yield ``(job_id, step)`` for every step of every job."""
+    data: dict[str, Any] = yaml.safe_load(_workflow_text())
+    return [(job_id, step) for job_id, job in data["jobs"].items() for step in (job.get("steps") or [])]
+
+
+class TestWorkflowShape:
+    def test_workflow_exists_and_parses(self) -> None:
+        assert WORKFLOW.is_file(), f"{WORKFLOW} not found"
+        data = yaml.safe_load(_workflow_text())
+        assert data["jobs"]["automerge"]["steps"], "automerge job defines no steps"
+
+
+class TestMergeGate:
+    """Regression tests for #153."""
+
+    def test_helper_is_defined_before_any_use(self) -> None:
+        text = _workflow_text()
+        definition = text.find(f'cat > "$RUNNER_TEMP/{HELPER}"')
+        assert definition != -1, f"{HELPER} is never written to $RUNNER_TEMP"
+        first_use = text.find(f'"$RUNNER_TEMP/{HELPER}"', definition + 1)
+        assert first_use != -1, f"{HELPER} is defined but never invoked"
+
+    def test_every_merge_goes_through_the_helper(self) -> None:
+        """No step may call ``gh pr merge --auto`` outside the helper body.
+
+        A bare ``--auto`` hard-fails on an unprotected base branch, which is what
+        left PR #152 open and blocked the whole v2 release chain.
+        """
+        offenders = [
+            f"{job_id}::{step.get('name') or 'unnamed step'}"
+            for job_id, step in _steps()
+            if HELPER not in str(step.get("run", "")) and _BARE_AUTO_MERGE.search(str(step.get("run", "")))
+        ]
+        assert not offenders, (
+            "These steps call `gh pr merge --auto` directly; on a base branch without "
+            f"protection GitHub rejects it and the step fails. Use {HELPER} instead:\n  " + "\n  ".join(offenders)
+        )
+
+    def test_helper_falls_back_to_an_explicit_check_gate(self) -> None:
+        text = _workflow_text()
+        assert "CI Success" in text, "helper has no required-check name to gate on"
+        assert "gh pr merge --squash" in text, "helper never performs the fallback merge"
+
+    def test_bump_pr_creation_ends_with_the_helper(self) -> None:
+        step = next(s for _, s in _steps() if s.get("name") == "Create version bump PR")
+        assert HELPER in str(step["run"]), "the version-bump PR is created but never gated for merge"
+
+
+class TestNoSelfWatchDeadlock:
+    """Regression test for #118."""
+
+    def test_no_watch_all_checks_gate(self) -> None:
+        # Comments legitimately mention the banned flag to explain why it is banned.
+        code = "\n".join(line for line in _workflow_text().splitlines() if not line.lstrip().startswith("#"))
+        assert "--watch" not in code, (
+            "`gh pr checks --watch` waits on the Auto-merge & Tag check produced by "
+            "this very job — a self-referential deadlock (#118)"
+        )


### PR DESCRIPTION
Fixes #153.

## Root cause

`gh pr merge --auto` is only accepted when the PR's **base** branch has a ruleset / branch protection with required status checks. The `V2 LTS Protection` ruleset targeted `refs/heads/V2`, but the branch is `v2` — ref matching is case-sensitive, so `v2` had **no rules at all**:

```
$ gh api repos/:owner/:repo/rules/branches/v2
[]
$ gh api repos/:owner/:repo/rules/branches/main
["deletion","non_fast_forward","creation","required_status_checks",...]
```

GitHub therefore rejected the call on the freshly-created bump PR:

```
GraphQL: Pull request Protected branch rules not configured for this branch (enablePullRequestAutoMerge)
```

The step failed *after* pushing the bump branch and opening the PR, so #152 (`0.21.3`) sat open from 2026-08-05: no `v0.21.3` tag, no PyPI publish for the v2 LTS line — while the aiohttp 3.14.3 security fix was already merged into `v2`.

## What this changes

The ruleset casing was corrected in repo settings (`refs/heads/V2` → `refs/heads/v2`); `v2` now carries the same required `CI Success` check as `main`, and #152 was merged (`v0.21.3` tagged and published).

This PR removes the remaining single point of failure: the release chain no longer depends on the base branch being protected. A `merge-when-green.sh` helper prefers native auto-merge and, when GitHub rejects it, polls the named `CI Success` check on that PR and merges explicitly once it is green. Both merge call sites — the dependency PR and the version-bump PR — go through it.

The helper is written to `$RUNNER_TEMP` rather than committed under `.github/scripts/`: `pull_request_target` takes the workflow from the default branch but checks out the PR's *base* branch, so a committed helper would be missing whenever the base is `v2`.

### Not a return of #118

The self-watch deadlock was `gh pr checks --watch`, which waits on **all** checks including this job's own `Auto-merge & Tag`. The helper polls **one named check** (`CI Success`), produced by a different workflow — no self-reference. `tests/test_dependabot_automerge.py` asserts `--watch` never reappears.

## Verification

- `jq` conclusion extraction validated against the real `statusCheckRollup` of PR #152 (`SUCCESS`) and against synthetic pending / failed / missing-check payloads.
- Embedded helper passes `bash -n`.
- `tests/test_dependabot_automerge.py` — 6 tests: helper defined before use, no bare `--auto` in any step, fallback gate present, bump PR ends with the helper, no `--watch`.
