### PR TITLE
chore(release): bump version to 0.32.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,51 @@ and adheres to [SemVer](https://semver.org/) versioning.
 
 ---
 
-## [0.32.8] - 2026-08-23
+## [0.32.6] - 2026-08-23
 
-**Migration bug fix.** Addresses group 1 of #162 (reported by @leosilberg).
+**Bug fix release.** Three independent fixes: a CBOR decoding bug in the SDK, a
+migration operation that never did anything, and the CI monitor that pinned
+pre-release SurrealDB versions.
 
-### Fixed
+`0.32.3`, `0.32.4` and `0.32.5` are automation artifacts: each was published by
+the release pipeline off an auto-merged monitor PR that moved the SurrealDB pin
+to a pre-release (`3.3.0-beta.1` → `beta.2` → `beta.3`). The wheels behave
+identically to 0.32.2 — `.surrealdb-version` and `devops/docker-compose.yml` do
+not ship in the package — but the library was declaring support for, and running
+CI against, a beta database.
+
+### Fixed — SDK
+
+- **Compact CBOR datetimes decoded as a tuple of ints (#165).** SurrealDB 3.x sends
+  tag 12 as a compact `[seconds, nanoseconds]` pair, not an ISO 8601 string, and
+  `_cbor_tag_decoder()` only handled the string form. Every datetime the ORM does
+  not coerce from a model annotation — `raw_query()` results, datetimes nested
+  inside an object field — was returned as `(1739422800, 0)`:
+
+  ```python
+  rows = await Event.raw_query("SELECT * FROM events;")
+  rows[0]["occurred_at"]     # before: (1739422800, 0)
+  rows[0]["payload"]["at"]   # before: (1739422800, 0)
+  ```
+
+  Fields annotated `datetime` on a model were unaffected — the ORM rescued those
+  after the fact. Both forms now decode, wherever they appear in a payload.
+
+  **Upgrade note:** this changes the type of those values. Code that worked around
+  the bug by unpacking the tuple must drop the workaround.
+
+  Precision is kept to the microsecond (a Python `datetime` holds no more); the
+  remaining nanoseconds are truncated. Both branches fall back to the raw value
+  rather than raising: SurrealDB's datetime range is far wider than Python's year
+  1-9999, and an exception inside the tag hook comes back out of `cbor2` as a
+  `CBORDecodeError` that takes down every other value in the same response.
+
+  This makes `_parse_datetime()`'s array branch redundant for CBOR; it is left in
+  place for the JSON protocol. Covered by `tests/sdk/test_cbor_protocol.py`.
+
+### Fixed — Migrations
+
+Addresses group 1 of #162 (reported by @leosilberg).
 
 - **`AlterField` never altered anything.** It emitted a plain `DEFINE FIELD`,
   which on SurrealDB 3.x does not update an existing field — the server answers
@@ -44,62 +84,12 @@ and adheres to [SemVer](https://semver.org/) versioning.
   mid-migration leaves the earlier operations applied and the migration
   unrecorded, so the next `migrate()` replays it from the start.
 
-### Notes
-
 Two integration tests pin this against a live database — one asserts the field
 type actually changes, the other asserts its own precondition (that SurrealDB
 really does return a statement-level `ERR`) so it cannot silently stop testing
 the thing it is named after. Both were confirmed to fail without the fix.
 
----
-
-## [0.32.7] - 2026-08-23
-
-**SDK bug fix.**
-
-### Fixed
-
-- **Compact CBOR datetimes decoded as a tuple of ints (#165).** SurrealDB 3.x sends
-  tag 12 as a compact `[seconds, nanoseconds]` pair, not an ISO 8601 string, and
-  `_cbor_tag_decoder()` only handled the string form. Every datetime the ORM does
-  not coerce from a model annotation — `raw_query()` results, datetimes nested
-  inside an object field — was returned as `(1739422800, 0)`:
-
-  ```python
-  rows = await Event.raw_query("SELECT * FROM events;")
-  rows[0]["occurred_at"]     # before: (1739422800, 0)
-  rows[0]["payload"]["at"]   # before: (1739422800, 0)
-  ```
-
-  Fields annotated `datetime` on a model were unaffected — the ORM rescued those
-  after the fact. Both forms now decode, wherever they appear in a payload.
-
-  **Upgrade note:** this changes the type of those values. Code that worked around
-  the bug by unpacking the tuple must drop the workaround.
-
-  Precision is kept to the microsecond (a Python `datetime` holds no more); the
-  remaining nanoseconds are truncated. Both branches fall back to the raw value
-  rather than raising: SurrealDB's datetime range is far wider than Python's year
-  1-9999, and an exception inside the tag hook comes back out of `cbor2` as a
-  `CBORDecodeError` that takes down every other value in the same response.
-
-  This makes `_parse_datetime()`'s array branch redundant for CBOR; it is left in
-  place for the JSON protocol. Covered by `tests/sdk/test_cbor_protocol.py`.
-
----
-
-## [0.32.6] - 2026-08-23
-
-**CI fix.** No library code changes vs 0.32.2.
-
-`0.32.3`, `0.32.4` and `0.32.5` are automation artifacts: each was published by
-the release pipeline off an auto-merged monitor PR that moved the SurrealDB pin
-to a pre-release (`3.3.0-beta.1` → `beta.2` → `beta.3`). The wheels behave
-identically to 0.32.2 — `.surrealdb-version` and `devops/docker-compose.yml` do
-not ship in the package — but the library was declaring support for, and running
-CI against, a beta database.
-
-### Fixed
+### Fixed — CI
 
 - **The v3 monitor pinned pre-releases (#163).** Its release query deliberately
   included betas and RCs, left over from the 3.0 alpha migration:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # SurrealDB-ORM - Development Context
 
-> Context document for Claude AI - Last updated: August 2026 (0.32.2)
+> Context document for Claude AI - Last updated: August 2026 (0.32.6)
 
 ## Project Vision
 
@@ -10,7 +10,7 @@
 
 ---
 
-## Current Version: 0.32.2 (Beta) — SurrealDB 3.2+ required
+## Current Version: 0.32.6 (Beta) — SurrealDB 3.2+ required
 
 ### Branch Strategy
 
@@ -18,6 +18,37 @@
 | ------ | ---------- | ----------- | ------------------------------- |
 | `main` | **3.2.4**  | 0.32.x      | Active development              |
 | `v2`   | **2.6.5**  | 0.21.x      | LTS (security & bug fixes only) |
+
+### What's New in 0.32.6
+
+Three independent fixes; `0.32.3`-`0.32.5` were automation artifacts (see below).
+
+- **Compact CBOR datetimes decoded as a tuple of ints (#165, #166)** — SurrealDB 3.x sends
+  CBOR tag 12 as a `[seconds, nanoseconds]` pair, not an ISO 8601 string, and
+  `_cbor_tag_decoder()` only handled the string form. Every datetime the ORM does not coerce
+  from a model annotation — `raw_query()` results, datetimes nested in an object field — came
+  back as `(1739422800, 0)`. Both forms decode now, wherever they appear in a payload; an
+  out-of-range value falls back to the raw pair rather than raising, since an exception inside
+  the tag hook surfaces as a `CBORDecodeError` that kills the whole response.
+- **`AlterField` never altered anything (#162, #168)** — it emitted a plain `DEFINE FIELD`,
+  which on SurrealDB 3.x does not update an existing field (`The field 'x' already exists`,
+  definition untouched). `backwards()` had the same defect. Both emit `DEFINE FIELD OVERWRITE`
+  now; `AddField` deliberately does not.
+  **And the executor hid it:** `client.query()` raises only on an RPC-level failure, while a
+  rejected statement rides back inside a *successful* RPC as `status: ERR` per statement. That
+  hid failures in `DataMigration`/`RawSQL` bodies just as effectively. `migrate()`,
+  `rollback()` and `upgrade()` now check every statement and raise `MigrationStatementError`.
+  Migrations are not transactional, so a mid-migration failure leaves a partial state.
+- **The v3 monitor pinned pre-releases (#163, #167)** — its release query deliberately
+  included betas, left from the 3.0 alpha migration, so it pinned `3.3.0-beta.x` and burned
+  three PyPI releases (0.32.3-0.32.5). `sort -V` did not catch it — it ranks `3.3.0-beta.3`
+  *above* `3.3.0`, so a beta pin would refuse every later stable as a "downgrade" and stay
+  stuck. Both monitors now filter pre-releases at the API, reject a pre-release candidate
+  outright (covering the manual `workflow_dispatch` input) and treat any stable release as
+  superseding a pre-release pin. Pin restored to **3.2.4**.
+  **Third occurrence of the same cascade** (#155/#156, then #163): an auto-merged monitor PR
+  reaches PyPI with no human in the loop. What the monitors may *propose* matters more than
+  the release gate.
 
 ### What's New in 0.32.2
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,44 @@ Both branches receive automated daily security monitoring from `main` (GitHub Ac
 
 ---
 
-## What's New in 0.32.8
+## What's New in 0.32.6
 
-**Migration bug fix** — addresses group 1 of #162.
+**Bug fix release** — a CBOR decoding bug in the SDK, a migration operation that never did
+anything, and the CI monitor that pinned pre-release SurrealDB versions.
+
+> **0.32.3, 0.32.4 and 0.32.5 are automation artifacts.** Each was published by the release
+> pipeline off an auto-merged monitor PR that moved the SurrealDB pin to a **pre-release**
+> (`3.3.0-beta.1` → `beta.2` → `beta.3`). The wheels behave identically to 0.32.2 —
+> `.surrealdb-version` and `devops/docker-compose.yml` don't ship in the package — but the
+> library was declaring support for, and running CI against, a beta database.
+
+### SDK
+
+- **Datetimes came back as a pair of ints outside typed model fields (#165)** — SurrealDB 3.x
+  encodes CBOR tag 12 as a compact `[seconds, nanoseconds]` pair rather than an ISO 8601 string,
+  and the decoder only handled the string form. Anywhere the ORM does not coerce a value from its
+  model annotation — `raw_query()` results, datetimes nested inside an object field — the value
+  surfaced as `(1739422800, 0)` instead of a `datetime`:
+
+  ```python
+  rows = await Event.raw_query("SELECT * FROM events;")
+  rows[0]["occurred_at"]          # before: (1739422800, 0)   after: datetime(..., tzinfo=utc)
+  rows[0]["payload"]["at"]        # before: (1739422800, 0)   after: datetime(..., tzinfo=utc)
+  ```
+
+  Fields declared `datetime` on a model were never affected — the ORM already rescued those.
+
+  > **If you worked around this**, remove the workaround before upgrading: code that unpacked the
+  > tuple (`seconds, _ = row["occurred_at"]`) now receives a `datetime` and will break.
+
+  Sub-second precision is preserved to the microsecond, which is all a Python `datetime` can hold;
+  the remaining nanoseconds are truncated. A datetime outside Python's year 1–9999 range is
+  returned as the raw pair instead of raising, so one unrepresentable value can no longer abort the
+  decoding of the whole response.
+
+### Migrations
+
+Addresses group 1 of #162.
 
 - **`AlterField` never altered anything** — it emitted a plain `DEFINE FIELD`, which on
   SurrealDB 3.x does not update an existing field: the server answers `The field 'x' already
@@ -66,45 +101,7 @@ Both branches receive automated daily security monitoring from `main` (GitHub Ac
   > Migrations are not wrapped in a transaction, so a mid-migration failure leaves the earlier
   > operations applied and the migration unrecorded — the next `migrate()` replays it in full.
 
----
-
-## What's New in 0.32.7
-
-**SDK bug fix.**
-
-- **Datetimes came back as a pair of ints outside typed model fields (#165)** — SurrealDB 3.x
-  encodes CBOR tag 12 as a compact `[seconds, nanoseconds]` pair rather than an ISO 8601 string,
-  and the decoder only handled the string form. Anywhere the ORM does not coerce a value from its
-  model annotation — `raw_query()` results, datetimes nested inside an object field — the value
-  surfaced as `(1739422800, 0)` instead of a `datetime`:
-
-  ```python
-  rows = await Event.raw_query("SELECT * FROM events;")
-  rows[0]["occurred_at"]          # before: (1739422800, 0)   after: datetime(..., tzinfo=utc)
-  rows[0]["payload"]["at"]        # before: (1739422800, 0)   after: datetime(..., tzinfo=utc)
-  ```
-
-  Fields declared `datetime` on a model were never affected — the ORM already rescued those.
-
-  > **If you worked around this**, remove the workaround before upgrading: code that unpacked the
-  > tuple (`seconds, _ = row["occurred_at"]`) now receives a `datetime` and will break.
-
-  Sub-second precision is preserved to the microsecond, which is all a Python `datetime` can hold;
-  the remaining nanoseconds are truncated. A datetime outside Python's year 1–9999 range is
-  returned as the raw pair instead of raising, so one unrepresentable value can no longer abort the
-  decoding of the whole response.
-
----
-
-## What's New in 0.32.6
-
-**CI fix** — no library code changes vs 0.32.2.
-
-> **0.32.3, 0.32.4 and 0.32.5 are automation artifacts.** Each was published by the release
-> pipeline off an auto-merged monitor PR that moved the SurrealDB pin to a **pre-release**
-> (`3.3.0-beta.1` → `beta.2` → `beta.3`). The wheels behave identically to 0.32.2 —
-> `.surrealdb-version` and `devops/docker-compose.yml` don't ship in the package — but the
-> library was declaring support for, and running CI against, a beta database.
+### CI
 
 - **The v3 monitor pinned pre-releases (#163)** — its release query deliberately included
   betas and RCs, left over from the 3.0 alpha migration. Once 3.3.0 entered beta it started

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surrealdb-orm"
-version = "0.32.5"
+version = "0.32.6"
 description = "SurrealDB ORM as 'DJango style' for Python with async support. Works with pydantic validation."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/surreal_orm/__init__.py
+++ b/src/surreal_orm/__init__.py
@@ -191,4 +191,4 @@ __all__ = [
     "retry_on_conflict",
 ]
 
-__version__ = "0.32.5"
+__version__ = "0.32.6"

--- a/src/surreal_sdk/__init__.py
+++ b/src/surreal_sdk/__init__.py
@@ -75,7 +75,7 @@ from .types import (
     ResponseStatus,
 )
 
-__version__ = "0.32.5"
+__version__ = "0.32.6"
 __all__ = [
     # Connections
     "BaseSurrealConnection",

--- a/src/surreal_sdk/pyproject.toml
+++ b/src/surreal_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surreal-sdk"
-version = "0.32.5"
+version = "0.32.6"
 description = "Custom Python SDK for SurrealDB with HTTP and WebSocket support. No dependency on official surrealdb package."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1594,7 +1594,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb-orm"
-version = "0.32.5"
+version = "0.32.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Releases #167, #166 and #168 as a single version.

## Why one version and not three

Each fix branch wrote its own CHANGELOG/README section (0.32.6, 0.32.7, 0.32.8) on the assumption of sequential releases. They merged the same day, so publishing three wheels would leave 0.32.7 and 0.32.8 documented but — depending on how the bumps landed — either three near-identical releases or two version numbers that never exist on PyPI. The three sections are folded into one `0.32.6` entry, grouped **SDK / Migrations / CI**. No prose was dropped.

## What ships

- **SDK — compact CBOR datetimes (#165 / #166).** SurrealDB 3.x sends tag 12 as a `[seconds, nanoseconds]` pair; the decoder only handled the ISO string form, so every datetime the ORM does not coerce from a model annotation (`raw_query()` results, datetimes nested in an object field) came back as a tuple of ints. **Changes the type of those values** — the upgrade note is in both files.
- **Migrations — `AlterField` was a silent no-op (#162 / #168).** A plain `DEFINE FIELD` does not update an existing field on 3.x, and the executor never inspected per-statement `status`, so the rejection rode back inside a successful RPC. `DEFINE FIELD OVERWRITE` plus `MigrationStatementError`. **Migrations that used to report success while silently failing now raise.**
- **CI — the v3 monitor pinned pre-releases (#163 / #167).** Pin restored to SurrealDB 3.2.4.

## Also in here

`CLAUDE.md` still read `Current Version: 0.32.2` and had no section past 0.32.2 — corrected, with a 0.32.6 entry.

## Verification

- `ruff check` / `mypy src/` clean, unit suite green
- Version-consistency tests (`__version__` vs `pyproject.toml`, ORM **and** SDK) pass
- The three PRs were each verified against a live SurrealDB **3.2.4** before merge; `main` CI is green after all three

## Note

Merging this triggers `tag-release` → `publish`. A feature PR squash-merged with a bump does *not* auto-release, so if the tag does not appear, push `v0.32.6` manually.
