### PR TITLE
fix(orm): coerce ForeignKey values to RecordId on write and in filters

### DIFF
--- a/src/surreal_orm/fields/__init__.py
+++ b/src/surreal_orm/fields/__init__.py
@@ -27,6 +27,7 @@ from .relation import (
     is_graph_relation,
     is_many_to_many,
     is_relation_field,
+    on_delete_to_surql,
 )
 from .vector import VectorField, get_vector_info, is_vector_field
 
@@ -66,4 +67,5 @@ __all__ = [
     "is_graph_relation",
     "is_many_to_many",
     "is_relation_field",
+    "on_delete_to_surql",
 ]

--- a/src/surreal_orm/fields/relation.py
+++ b/src/surreal_orm/fields/relation.py
@@ -28,6 +28,7 @@ from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, core_schema
 
+from surreal_orm.model_base import record_link_to_str
 from surreal_orm.utils import escape_record_id
 
 if TYPE_CHECKING:
@@ -130,14 +131,17 @@ class _ForeignKeyMarker:
                 break
 
         return core_schema.nullable_schema(
-            core_schema.str_schema(
-                metadata={
-                    "relation_type": "foreign_key",
-                    "to_model": to_model,
-                    "on_delete": on_delete,
-                    "related_name": related_name,
-                    "surreal_type": "record",
-                }
+            core_schema.no_info_before_validator_function(
+                record_link_to_str,
+                core_schema.str_schema(
+                    metadata={
+                        "relation_type": "foreign_key",
+                        "to_model": to_model,
+                        "on_delete": on_delete,
+                        "related_name": related_name,
+                        "surreal_type": "record",
+                    }
+                ),
             )
         )
 
@@ -192,9 +196,13 @@ class _ManyToManyMarker:
                 related_name = arg.related_name
                 break
 
-        # ManyToMany is represented as a list of record IDs (virtual field)
+        # ManyToMany is represented as a list of record IDs (virtual field).
+        # Each item accepts a model instance, RecordId, or "table:id" string.
         return core_schema.list_schema(
-            core_schema.str_schema(),
+            core_schema.no_info_before_validator_function(
+                record_link_to_str,
+                core_schema.str_schema(),
+            ),
             metadata={
                 "relation_type": "many_to_many",
                 "to_model": to_model,
@@ -371,6 +379,34 @@ def Relation(
         - followers: SELECT * FROM user:id<-follows<-User
     """
     return Annotated[list, _RelationMarker(edge, to, reverse)]
+
+
+def on_delete_to_surql(on_delete: str | None) -> str | None:
+    """
+    Translate an ``on_delete`` value into its SurrealDB ``ON DELETE`` keyword.
+
+    :func:`ForeignKey` takes Django's vocabulary (``CASCADE``, ``SET_NULL``,
+    ``PROTECT``) while SurrealDB accepts
+    ``CASCADE | UNSET | REJECT | IGNORE | THEN``.  SurrealDB's own keywords
+    pass through unchanged.
+
+    Args:
+        on_delete: The configured delete behavior, in either vocabulary
+
+    Returns:
+        The SurrealDB keyword, or ``None`` when *on_delete* is ``None``
+
+    Examples:
+        on_delete_to_surql("SET_NULL")  # "UNSET"
+        on_delete_to_surql("PROTECT")   # "REJECT"
+        on_delete_to_surql("CASCADE")   # "CASCADE"
+    """
+    if on_delete is None:
+        return None
+
+    # SurrealDB has no SET_NULL/PROTECT; the equivalents are UNSET and REJECT
+    normalized = on_delete.upper()
+    return {"SET_NULL": "UNSET", "PROTECT": "REJECT"}.get(normalized, normalized)
 
 
 def is_relation_field(field_type: Any) -> bool:

--- a/src/surreal_orm/migrations/operations.py
+++ b/src/surreal_orm/migrations/operations.py
@@ -10,6 +10,7 @@ from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
 from typing import Any
 
+from ..fields.relation import on_delete_to_surql
 from ..types import FieldType
 
 
@@ -267,7 +268,7 @@ class AddField(Operation):
         if self.reference:
             parts.append("REFERENCE")
             if self.on_delete:
-                parts.append(f"ON DELETE {self.on_delete.upper()}")
+                parts.append(f"ON DELETE {on_delete_to_surql(self.on_delete)}")
 
         if self.comment:
             escaped_comment = self.comment.replace("'", "''")
@@ -398,7 +399,7 @@ class AlterField(Operation):
         if self.reference:
             parts.append("REFERENCE")
             if self.on_delete:
-                parts.append(f"ON DELETE {self.on_delete.upper()}")
+                parts.append(f"ON DELETE {on_delete_to_surql(self.on_delete)}")
 
         return " ".join(parts) + ";"
 

--- a/src/surreal_orm/model_base.py
+++ b/src/surreal_orm/model_base.py
@@ -13,6 +13,8 @@ from typing import (
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr, model_validator
 
+from surreal_sdk.protocol.cbor import RecordId
+
 from . import signals as model_signals
 from .connection_manager import SurrealDBConnectionManager
 from .debug import _elapsed_ms, _log_query, _start_timer
@@ -162,6 +164,129 @@ def _convert_record_id_to_string(value: Any) -> Any:
     ):
         return str(value)  # Returns "table:id" format
     return value
+
+
+def to_record_id(value: Any) -> Any:
+    """
+    Convert a full record-ID string (table:id) into a ``RecordId`` object.
+
+    A ``record<...>`` column rejects a bound string, so writes and filters on
+    record links must send a ``RecordId``.  Anything that is not a full
+    record-ID string is returned unchanged.
+
+    Args:
+        value: The value to convert
+
+    Returns:
+        A ``RecordId`` for a record-ID string, otherwise the original value
+
+    Examples:
+        to_record_id("users:abc123")   # RecordId(table="users", id="abc123")
+        to_record_id("users:`7abc`")   # RecordId(table="users", id="7abc")
+        to_record_id("abc123")         # "abc123"
+    """
+    if not isinstance(value, str):
+        return value
+
+    table, id_part = parse_record_id(value)
+    if table is None or not _SAFE_IDENTIFIER_RE.match(table):
+        return value
+
+    return RecordId(table=table, id=id_part)
+
+
+def record_link_to_str(value: Any) -> Any:
+    """
+    Render a model instance or ``RecordId`` as a ``"table:id"`` string.
+
+    Inverse of :func:`to_record_id`.  Values that are neither are returned
+    unchanged.
+
+    Args:
+        value: The value to convert
+
+    Returns:
+        The record link as a string, otherwise the original value
+
+    Examples:
+        record_link_to_str(user_instance)                    # "users:alice"
+        record_link_to_str(RecordId(table="users", id="a"))  # "users:a"
+        record_link_to_str("users:alice")                    # "users:alice"
+    """
+    # Duck-typed like _convert_record_id_to_string: avoids import path
+    # issues between src.surreal_orm and surreal_orm
+    get_record_link = getattr(value, "get_record_link", None)
+    if callable(get_record_link):
+        link = get_record_link()
+        if link is not None:
+            return link
+    if isinstance(value, RecordId):
+        return str(value)
+    return value
+
+
+def _to_record_link(value: Any, table: str | None) -> Any:
+    """
+    Convert a foreign-key value into a record link.
+
+    Accepts the related model instance, a ``RecordId``, a full ``"table:id"``
+    string, or - when the target table is known - a bare ID.  Anything else is
+    returned unchanged.
+
+    Args:
+        value: The foreign-key value
+        table: The target table, used to qualify a bare ID
+
+    Returns:
+        A ``RecordId``, or the original value
+    """
+    if isinstance(value, RecordId):
+        return value
+
+    value = record_link_to_str(value)
+
+    # A bare ID is only resolvable against a known target table. "$var"
+    # references stay untouched — they are user-supplied query variables.
+    if isinstance(value, str) and table and not value.startswith("$"):
+        value_table, id_part = parse_record_id(value)
+        if value_table is None:
+            return RecordId(table=table, id=id_part)
+
+    return to_record_id(value)
+
+
+def _resolve_target_table(model_name: str) -> str | None:
+    """
+    Resolve a :func:`ForeignKey` target model name to its table name.
+
+    ``ForeignKey("Article")`` names the model, which may configure a different
+    ``table_name``.  The table name itself is accepted too.  Returns ``None``
+    when nothing matches, in which case a bare ID cannot be qualified.
+
+    Walks the subclass tree rather than ``_MODEL_REGISTRY``, which
+    :func:`clear_model_registry` empties.  The first match wins when two models
+    share a name.
+
+    Args:
+        model_name: The target model name given to ForeignKey
+
+    Returns:
+        The target table name, or ``None`` when the target is unknown
+    """
+    models: list[type[BaseSurrealModel]] = []
+    pending = BaseSurrealModel.__subclasses__()
+    while pending:
+        model = pending.pop()
+        models.append(model)
+        pending.extend(model.__subclasses__())
+
+    for model in models:
+        if model.__name__ == model_name:
+            return model.get_table_name()
+    for model in models:
+        if model.get_table_name() == model_name:
+            return model_name
+    return None
 
 
 class SurrealConfigDict(ConfigDict):
@@ -577,6 +702,33 @@ class BaseSurrealModel(BaseModel):
             fields.update(computed.keys())
         return fields
 
+    @classmethod
+    def get_foreign_key_targets(cls) -> dict[str, str | None]:
+        """
+        Map each :func:`ForeignKey` field to the table it points at.
+
+        These fields hold record links, so their values must reach SurrealDB as
+        ``RecordId`` objects rather than strings.  The table is ``None`` when
+        the target model is not registered, in which case only fully-qualified
+        ``"table:id"`` values can be resolved.
+
+        Returns:
+            Dict mapping foreign-key field name to target table name.
+        """
+        # Local import: fields.relation imports record_link_to_str from this
+        # module at load time, so importing it at the top would be circular.
+        from .fields.relation import _ForeignKeyMarker
+
+        # Pydantic strips Annotated metadata off `annotation`, so the marker
+        # is read from FieldInfo.metadata instead.
+        targets: dict[str, str | None] = {}
+        for name, field_info in cls.model_fields.items():
+            for meta in field_info.metadata:
+                if isinstance(meta, _ForeignKeyMarker):
+                    targets[name] = _resolve_target_table(meta.to)
+                    break
+        return targets
+
     def get_id(self) -> str | None:
         """
         Get the ID of the model instance.
@@ -592,6 +744,18 @@ class BaseSurrealModel(BaseModel):
                 return str(primary_key_value) if primary_key_value is not None else None
 
         return None  # pragma: no cover
+
+    def get_record_link(self) -> str | None:
+        """
+        Get the full ``"table:id"`` reference for this instance.
+
+        Returns:
+            The record link, or ``None`` when the instance has no ID yet.
+        """
+        record_id = self.get_id()
+        if record_id is None:
+            return None
+        return f"{self.get_table_name()}:{record_id}"
 
     @classmethod
     def from_db(cls, record: dict[str, Any] | list[Any] | None) -> Self | list[Self]:
@@ -761,6 +925,31 @@ class BaseSurrealModel(BaseModel):
                             data[key] = original
         return data
 
+    def _coerce_foreign_keys(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Wrap foreign-key values into record links before writing.
+
+        ``model_dump()`` renders a :func:`ForeignKey` as a ``"table:id"``
+        string, which a ``record<...>`` column rejects.  A bare ID is qualified
+        with the target model's table.
+
+        Handles aliased fields: when ``model_dump(by_alias=True)`` is used,
+        dict keys may be aliases rather than Python field names.
+
+        Returns:
+            A new dict with foreign-key values converted.
+        """
+        fk_targets = self.__class__.get_foreign_key_targets()
+        if not fk_targets:
+            return data
+
+        coerced = dict(data)
+        for field_name, table in fk_targets.items():
+            alias = self.__class__.model_fields[field_name].alias
+            key = alias if alias and alias in coerced else field_name
+            if key in coerced:
+                coerced[key] = _to_record_link(coerced[key], table)
+        return coerced
+
     async def save(
         self,
         tx: "BaseTransaction | None" = None,
@@ -834,6 +1023,7 @@ class BaseSurrealModel(BaseModel):
         table = self.get_table_name()
         data = self.model_dump(exclude=exclude_fields, exclude_unset=True, by_alias=True)
         data = self._restore_datetime_fields(data)
+        data = self._coerce_foreign_keys(data)
 
         # Merge server-side function values
         if server_values:
@@ -1132,6 +1322,7 @@ class BaseSurrealModel(BaseModel):
         exclude_fields = {"id"} | self.get_server_fields()
         data = self.model_dump(exclude=exclude_fields, exclude_unset=True, by_alias=True)
         data = self._restore_datetime_fields(data)
+        data = self._coerce_foreign_keys(data)
         record_id = self.get_id()
 
         if record_id is None:
@@ -1220,6 +1411,8 @@ class BaseSurrealModel(BaseModel):
         self._check_not_view()
 
         data_set = {key: value for key, value in data.items()}
+        # data_set keeps the original values for signals and the local setattr
+        wire_data = self._coerce_foreign_keys(data_set)
 
         record_id = self.get_id()
         if not record_id:
@@ -1245,7 +1438,7 @@ class BaseSurrealModel(BaseModel):
             result: Any
             if self._has_surreal_funcs(data_set):
                 # Use raw query path for SurrealFunc values
-                set_clause, variables = self._build_set_clause(data_set)
+                set_clause, variables = self._build_set_clause(wire_data)
                 if extra_vars:
                     conflicting = set(variables) & set(extra_vars)
                     if conflicting:
@@ -1271,18 +1464,19 @@ class BaseSurrealModel(BaseModel):
                     await self.refresh()
             elif tx is not None:
                 start = _start_timer()
-                result = await tx.merge(thing, data_set)
-                _log_query(f"MERGE {thing}", data_set, _elapsed_ms(start))
+                result = await tx.merge(thing, wire_data)
+                _log_query(f"MERGE {thing}", wire_data, _elapsed_ms(start))
                 self._raise_if_no_record_affected(result, thing, tx)
-                # Update local instance with merged data
-                for key, value in data_set.items():
+                # Update local instance with merged data — from wire_data, so a
+                # foreign key given as a model instance lands as "table:id"
+                for key, value in wire_data.items():
                     if hasattr(self, key):
-                        setattr(self, key, value)
+                        setattr(self, key, _convert_record_id_to_string(value))
             else:
                 client = await SurrealDBConnectionManager.get_client(self.get_connection_name())
                 start = _start_timer()
-                result = await client.merge(thing, data_set)
-                _log_query(f"MERGE {thing}", data_set, _elapsed_ms(start))
+                result = await client.merge(thing, wire_data)
+                _log_query(f"MERGE {thing}", wire_data, _elapsed_ms(start))
                 # A permission-denied (or missing-record) merge affects no
                 # records. Raise rather than silently returning self, so a
                 # denied write is never mistaken for a successful one.

--- a/src/surreal_orm/model_base.py
+++ b/src/surreal_orm/model_base.py
@@ -214,12 +214,11 @@ def record_link_to_str(value: Any) -> Any:
         record_link_to_str("users:alice")                    # "users:alice"
     """
     # Duck-typed like _convert_record_id_to_string: avoids import path
-    # issues between src.surreal_orm and surreal_orm
-    get_record_link = getattr(value, "get_record_link", None)
-    if callable(get_record_link):
-        link = get_record_link()
-        if link is not None:
-            return link
+    # issues between src.surreal_orm and surreal_orm. The isinstance guard
+    # keeps unrelated objects with a plain `record_id` attribute untouched.
+    record_id = getattr(value, "record_id", None)
+    if isinstance(record_id, RecordId):
+        return str(record_id)
     if isinstance(value, RecordId):
         return str(value)
     return value
@@ -745,17 +744,24 @@ class BaseSurrealModel(BaseModel):
 
         return None  # pragma: no cover
 
-    def get_record_link(self) -> str | None:
+    @property
+    def record_id(self) -> RecordId | None:
         """
-        Get the full ``"table:id"`` reference for this instance.
+        This record's full identity as a ``RecordId`` — the ``Model.pk`` analog.
+
+        Use it wherever a value is bound against a ``record<...>`` column,
+        e.g. ``variables={"a": author.record_id}``; ``str(instance.record_id)``
+        gives the ``"table:id"`` string form.  Not a Pydantic field, so it is
+        never serialized; a model that declares its own ``record_id`` field
+        shadows it (Pydantic warns).
 
         Returns:
-            The record link, or ``None`` when the instance has no ID yet.
+            The ``RecordId``, or ``None`` when the instance has no ID yet.
         """
         record_id = self.get_id()
         if record_id is None:
             return None
-        return f"{self.get_table_name()}:{record_id}"
+        return RecordId(table=self.get_table_name(), id=record_id)
 
     @classmethod
     def from_db(cls, record: dict[str, Any] | list[Any] | None) -> Self | list[Self]:

--- a/src/surreal_orm/model_base.py
+++ b/src/surreal_orm/model_base.py
@@ -208,6 +208,11 @@ def record_link_to_str(value: Any) -> Any:
     Returns:
         The record link as a string, otherwise the original value
 
+    Raises:
+        ValueError: If a model instance has no ID yet.  An unsaved record
+            cannot be referenced, and reporting it here beats the string
+            schema's "Input should be a valid string".
+
     Examples:
         record_link_to_str(user_instance)                    # "users:alice"
         record_link_to_str(RecordId(table="users", id="a"))  # "users:a"
@@ -221,6 +226,8 @@ def record_link_to_str(value: Any) -> Any:
         return str(record_id)
     if isinstance(value, RecordId):
         return str(value)
+    if record_id is None and callable(getattr(value, "get_id", None)):
+        raise ValueError(f"cannot reference an unsaved {type(value).__name__}; save it first")
     return value
 
 
@@ -727,6 +734,26 @@ class BaseSurrealModel(BaseModel):
                     targets[name] = _resolve_target_table(meta.to)
                     break
         return targets
+
+    @classmethod
+    def get_foreign_key_columns(cls) -> dict[str, str | None]:
+        """
+        Map each foreign-key *column* name to its target table.
+
+        Filters and bulk writes address database columns, so an aliased
+        :func:`ForeignKey` must be resolvable under its alias too.
+
+        Returns:
+            Dict mapping foreign-key column name — the field name and, when
+            declared, its alias — to the target table name.
+        """
+        columns: dict[str, str | None] = {}
+        for field_name, table in cls.get_foreign_key_targets().items():
+            columns[field_name] = table
+            alias = cls.model_fields[field_name].alias
+            if alias:
+                columns[alias] = table
+        return columns
 
     def get_id(self) -> str | None:
         """
@@ -1328,7 +1355,8 @@ class BaseSurrealModel(BaseModel):
         exclude_fields = {"id"} | self.get_server_fields()
         data = self.model_dump(exclude=exclude_fields, exclude_unset=True, by_alias=True)
         data = self._restore_datetime_fields(data)
-        data = self._coerce_foreign_keys(data)
+        # data keeps the original values for signals; only the wire copy is coerced
+        wire_data = self._coerce_foreign_keys(data)
         record_id = self.get_id()
 
         if record_id is None:
@@ -1354,13 +1382,13 @@ class BaseSurrealModel(BaseModel):
         ):
             if tx is not None:
                 start = _start_timer()
-                await tx.merge(thing, data)
-                _log_query(f"UPDATE MERGE {thing}", data, _elapsed_ms(start))
+                await tx.merge(thing, wire_data)
+                _log_query(f"UPDATE MERGE {thing}", wire_data, _elapsed_ms(start))
             else:
                 client = await SurrealDBConnectionManager.get_client(self.get_connection_name())
                 start = _start_timer()
-                result = await client.merge(thing, data)
-                _log_query(f"UPDATE MERGE {thing}", data, _elapsed_ms(start))
+                result = await client.merge(thing, wire_data)
+                _log_query(f"UPDATE MERGE {thing}", wire_data, _elapsed_ms(start))
                 result_records = result.records
 
         # Send post_update signal

--- a/src/surreal_orm/query_set.py
+++ b/src/surreal_orm/query_set.py
@@ -992,13 +992,14 @@ class QuerySet(Generic[T]):
         Returns:
             The value with record references converted to ``RecordId`` objects.
         """
-        targets = self.model.get_foreign_key_targets()
+        targets = self.model.get_foreign_key_columns()
         if field_name not in targets or lookup_name not in ("exact", "in", "not_in"):
             return value
 
         table = targets[field_name]
         if isinstance(value, (list, tuple, set)):
-            return type(value)(_to_record_link(item, table) for item in value)
+            # Always a list: RecordId is unhashable, and IN takes an array anyway
+            return [_to_record_link(item, table) for item in value]
         return _to_record_link(value, table)
 
     @staticmethod
@@ -1935,7 +1936,7 @@ class QuerySet(Generic[T]):
 
         # Build SET clause — foreign-key values are bound as record links,
         # since a record<...> column rejects a plain string on write
-        fk_targets = self.model.get_foreign_key_targets()
+        fk_targets = self.model.get_foreign_key_columns()
         set_parts = []
         update_vars: dict[str, Any] = {}
         for field, value in data.items():
@@ -2050,6 +2051,13 @@ class QuerySet(Generic[T]):
 
         table = self._model_table
         variables: dict[str, Any] = {}
+        # Bind foreign keys as record links, as the other write paths do
+        fk_columns = self.model.get_foreign_key_columns()
+
+        def _bind(field_name: str, value: Any) -> Any:
+            if field_name in fk_columns:
+                return _to_record_link(value, fk_columns[field_name])
+            return value
 
         if on_conflict:
             # Use INSERT INTO ... ON DUPLICATE KEY UPDATE syntax
@@ -2064,7 +2072,7 @@ class QuerySet(Generic[T]):
                 else:
                     var_name = f"_up_{field_name}"
                     obj_parts.append(f"{field_name}: ${var_name}")
-                    variables[var_name] = value
+                    variables[var_name] = _bind(field_name, value)
 
             conflict_parts: list[str] = []
             for field_name, value in on_conflict.items():
@@ -2074,7 +2082,7 @@ class QuerySet(Generic[T]):
                 else:
                     var_name = f"_oc_{field_name}"
                     conflict_parts.append(f"{field_name} = ${var_name}")
-                    variables[var_name] = value
+                    variables[var_name] = _bind(field_name, value)
 
             query = f"INSERT INTO {table} {{{', '.join(obj_parts)}}} ON DUPLICATE KEY UPDATE {', '.join(conflict_parts)};"
         else:
@@ -2092,7 +2100,7 @@ class QuerySet(Generic[T]):
                 else:
                     var_name = f"_up_{field_name}"
                     set_parts.append(f"{field_name} = ${var_name}")
-                    variables[var_name] = value
+                    variables[var_name] = _bind(field_name, value)
             query = f"UPSERT {thing} SET {', '.join(set_parts)};"
 
         client = await SurrealDBConnectionManager.get_client(self.model.get_connection_name())
@@ -2156,12 +2164,14 @@ class QuerySet(Generic[T]):
         # Build a single batch query with semicolons
         queries: list[str] = []
         all_variables: dict[str, Any] = {}
+        fk_columns = self.model.get_foreign_key_columns()
 
         for idx, instance in enumerate(instances):
             record_id = instance.get_id() if hasattr(instance, "get_id") else getattr(instance, "id", None)
 
             data = instance.model_dump(exclude_unset=True, by_alias=True)
             data.pop("id", None)
+            data = instance._coerce_foreign_keys(data)
 
             if on_conflict:
                 # Use INSERT INTO ... ON DUPLICATE KEY UPDATE
@@ -2186,6 +2196,8 @@ class QuerySet(Generic[T]):
                     else:
                         var_name = f"_oc{idx}_{field_name}"
                         conflict_parts.append(f"{field_name} = ${var_name}")
+                        if field_name in fk_columns:
+                            value = _to_record_link(value, fk_columns[field_name])
                         all_variables[var_name] = value
 
                 query = f"INSERT INTO {table} {{{', '.join(obj_parts)}}} ON DUPLICATE KEY UPDATE {', '.join(conflict_parts)}"

--- a/src/surreal_orm/query_set.py
+++ b/src/surreal_orm/query_set.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
 import logging
 
-from .model_base import SurrealDbError
+from .model_base import SurrealDbError, _to_record_link
 
 logger = logging.getLogger(__name__)
 
@@ -967,6 +967,40 @@ class QuerySet(Generic[T]):
                     related = grouped.get(thing, [])
                     object.__setattr__(inst, to_attr, related)
 
+    def _coerce_filter_value(self, field_name: str, lookup_name: str, value: Any) -> Any:
+        """
+        Convert a filter value on a :func:`ForeignKey` field to a record link.
+
+        SurrealDB never equates a bound string with a record, so
+        ``filter(author="users:abc")`` on a ``record<...>`` column returns an
+        empty result instead of raising.  The related instance and a bare ID
+        are accepted too, so all three of these are equivalent::
+
+            filter(author=alice)
+            filter(author="users:alice")
+            filter(author="alice")
+
+        Only lookups that compare whole records are converted — the string
+        lookups (``contains``, ``startswith``, ``regex``, ...) still match on
+        the raw value.  ``in`` values are converted element-wise.
+
+        Args:
+            field_name: The database field name being filtered on.
+            lookup_name: The lookup type (e.g. "exact", "in").
+            value: The filter value as supplied by the caller.
+
+        Returns:
+            The value with record references converted to ``RecordId`` objects.
+        """
+        targets = self.model.get_foreign_key_targets()
+        if field_name not in targets or lookup_name not in ("exact", "in", "not_in"):
+            return value
+
+        table = targets[field_name]
+        if isinstance(value, (list, tuple, set)):
+            return type(value)(_to_record_link(item, table) for item in value)
+        return _to_record_link(value, table)
+
     @staticmethod
     def _render_condition(
         field_name: str,
@@ -1130,6 +1164,7 @@ class QuerySet(Generic[T]):
                     parts.append(rendered)
             else:
                 field_name, lookup_name, value = child
+                value = self._coerce_filter_value(field_name, lookup_name, value)
                 parts.append(self._render_condition(field_name, lookup_name, value, variables, counter, prelude))
 
         if not parts:
@@ -1161,6 +1196,7 @@ class QuerySet(Generic[T]):
 
         # Keyword-based filters (always AND-joined)
         for field_name, lookup_name, value in self._filters:
+            value = self._coerce_filter_value(field_name, lookup_name, value)
             parts.append(self._render_condition(field_name, lookup_name, value, variables, counter, prelude))
 
         # Q object filters
@@ -1897,11 +1933,15 @@ class QuerySet(Generic[T]):
         """
         where_clause = self._compile_where_clause()
 
-        # Build SET clause
+        # Build SET clause — foreign-key values are bound as record links,
+        # since a record<...> column rejects a plain string on write
+        fk_targets = self.model.get_foreign_key_targets()
         set_parts = []
         update_vars: dict[str, Any] = {}
         for field, value in data.items():
             validate_identifier(field, "field name")
+            if field in fk_targets:
+                value = _to_record_link(value, fk_targets[field])
             var_name = f"_bu{len(update_vars)}"
             update_vars[var_name] = value
             set_parts.append(f"{field} = ${var_name}")

--- a/src/surreal_sdk/protocol/rpc.py
+++ b/src/surreal_sdk/protocol/rpc.py
@@ -43,10 +43,13 @@ class SurrealJSONEncoder(json.JSONEncoder):
     - time → ISO 8601 string
     - Decimal → float
     - UUID → string
+    - RecordId → "table:id" string
     """
 
     def default(self, obj: Any) -> Any:
         """Encode non-standard types to JSON-serializable values."""
+        if isinstance(obj, cbor_module.RecordId):
+            return str(obj)
         if isinstance(obj, datetime):
             return obj.isoformat()
         if isinstance(obj, date):

--- a/tests/test_foreign_key_coercion_integration.py
+++ b/tests/test_foreign_key_coercion_integration.py
@@ -1,0 +1,223 @@
+"""Integration tests for ForeignKey fields against a real ``record<>`` column.
+
+Every test here fails without the coercion: the write is rejected by SurrealDB,
+and the filter returns an empty result for a row that demonstrably exists.
+"""
+
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+from pydantic import Field
+
+from src.surreal_orm import SurrealDBConnectionManager
+from src.surreal_orm.fields.relation import ForeignKey
+from src.surreal_orm.model_base import BaseSurrealModel, SurrealConfigDict
+from src.surreal_orm.q import Q
+from surreal_sdk.protocol.cbor import RecordId
+from tests.conftest import SURREALDB_NAMESPACE, SURREALDB_PASS, SURREALDB_URL, SURREALDB_USER
+
+SURREALDB_DATABASE = "test_fk_coercion"
+
+
+class Author(BaseSurrealModel):
+    """Target of the foreign key."""
+
+    model_config = SurrealConfigDict(table_name="fk_authors")
+
+    id: str | None = None
+    name: str = Field(default="")
+
+
+class Article(BaseSurrealModel):
+    """Model whose author column is a real record<fk_authors>."""
+
+    model_config = SurrealConfigDict(table_name="fk_articles")
+
+    id: str | None = None
+    title: str = Field(default="")
+    author: ForeignKey("Author")  # type: ignore[valid-type]
+
+
+@pytest.fixture(scope="module", autouse=True)
+async def setup_connection() -> AsyncGenerator[Any, Any]:
+    """Setup connection for the test module."""
+    SurrealDBConnectionManager.set_connection(
+        SURREALDB_URL,
+        SURREALDB_USER,
+        SURREALDB_PASS,
+        SURREALDB_NAMESPACE,
+        SURREALDB_DATABASE,
+    )
+    yield
+    await SurrealDBConnectionManager.close_connection()
+    await SurrealDBConnectionManager.unset_connection()
+
+
+@pytest.fixture(autouse=True)
+async def schemafull_tables() -> AsyncGenerator[Any, Any]:
+    """Define a SCHEMAFULL table with a record<> column before each test."""
+    client = await SurrealDBConnectionManager.get_client()
+    await client.query("REMOVE TABLE IF EXISTS fk_articles; REMOVE TABLE IF EXISTS fk_authors;")
+    await client.query("DEFINE TABLE fk_authors SCHEMALESS;")
+    await client.query(
+        "DEFINE TABLE fk_articles SCHEMAFULL;"
+        "DEFINE FIELD title ON fk_articles TYPE string;"
+        "DEFINE FIELD author ON fk_articles TYPE record<fk_authors>;"
+    )
+    await client.query("CREATE fk_authors:alice SET name = 'Alice';")
+    yield
+    await client.query("REMOVE TABLE IF EXISTS fk_articles; REMOVE TABLE IF EXISTS fk_authors;")
+
+
+@pytest.mark.integration
+async def test_save_accepted_by_record_column() -> None:
+    """A foreign key must be written as a record link, not a string."""
+    article = Article(title="Hello", author="fk_authors:alice")
+    await article.save()
+
+    loaded = await Article.objects().get(article.get_id())
+    assert loaded.author == "fk_authors:alice"
+
+
+@pytest.mark.integration
+async def test_filter_matches_existing_row() -> None:
+    """A filter on a record<> column must not silently return nothing."""
+    client = await SurrealDBConnectionManager.get_client()
+    # Created server-side so the write path is not involved.
+    await client.query("CREATE fk_articles:a1 SET title = 'Hello', author = fk_authors:alice;")
+
+    found = await Article.objects().filter(author="fk_authors:alice").exec()
+    assert len(found) == 1
+    assert found[0].title == "Hello"
+
+
+@pytest.mark.integration
+async def test_filter_in_matches_existing_row() -> None:
+    """Collection lookups are converted element-wise."""
+    client = await SurrealDBConnectionManager.get_client()
+    await client.query("CREATE fk_articles:a1 SET title = 'Hello', author = fk_authors:alice;")
+
+    found = await Article.objects().filter(author__in=["fk_authors:alice", "fk_authors:bob"]).exec()
+    assert len(found) == 1
+
+
+@pytest.mark.integration
+async def test_save_and_filter_by_bare_id() -> None:
+    """A bare ID is qualified with the target model's table."""
+    article = Article(title="Hello", author="alice")
+    await article.save()
+
+    found = await Article.objects().filter(author="alice").exec()
+    assert len(found) == 1
+    assert found[0].author == "fk_authors:alice"
+
+
+@pytest.mark.integration
+async def test_save_and_filter_by_instance() -> None:
+    """The related object can be used directly, Django-style."""
+    author = await Author.objects().get("alice")
+
+    article = Article(title="Hello", author=author)
+    await article.save()
+
+    found = await Article.objects().filter(author=author).exec()
+    assert len(found) == 1
+    assert found[0].title == "Hello"
+
+
+@pytest.mark.integration
+async def test_filter_by_record_id() -> None:
+    """A RecordId passes straight through to the binding."""
+    client = await SurrealDBConnectionManager.get_client()
+    await client.query("CREATE fk_articles:a1 SET title = 'Hello', author = fk_authors:alice;")
+
+    found = await Article.objects().filter(author=RecordId(table="fk_authors", id="alice")).exec()
+    assert len(found) == 1
+
+
+@pytest.mark.integration
+async def test_filter_in_mixed_forms() -> None:
+    """Instance, full string, bare ID, and RecordId can be mixed in __in."""
+    client = await SurrealDBConnectionManager.get_client()
+    await client.query(
+        "CREATE fk_authors:bob SET name = 'Bob';"
+        "CREATE fk_articles:a1 SET title = 'ByAlice', author = fk_authors:alice;"
+        "CREATE fk_articles:a2 SET title = 'ByBob', author = fk_authors:bob;"
+    )
+    alice = await Author.objects().get("alice")
+
+    found = await Article.objects().filter(author__in=[alice, "bob"]).exec()
+    assert len(found) == 2
+
+    found = (
+        await Article.objects()
+        .filter(
+            author__in=["fk_authors:alice", RecordId(table="fk_authors", id="bob")],
+        )
+        .exec()
+    )
+    assert len(found) == 2
+
+
+@pytest.mark.integration
+async def test_filter_not_in() -> None:
+    """not_in excludes converted record links."""
+    client = await SurrealDBConnectionManager.get_client()
+    await client.query(
+        "CREATE fk_authors:bob SET name = 'Bob';"
+        "CREATE fk_articles:a1 SET title = 'ByAlice', author = fk_authors:alice;"
+        "CREATE fk_articles:a2 SET title = 'ByBob', author = fk_authors:bob;"
+    )
+
+    found = await Article.objects().filter(author__not_in=["fk_authors:alice"]).exec()
+    assert len(found) == 1
+    assert found[0].title == "ByBob"
+
+
+@pytest.mark.integration
+async def test_filter_q_objects() -> None:
+    """OR / NOT compositions convert foreign keys too."""
+    client = await SurrealDBConnectionManager.get_client()
+    await client.query(
+        "CREATE fk_authors:bob SET name = 'Bob';"
+        "CREATE fk_authors:carol SET name = 'Carol';"
+        "CREATE fk_articles:a1 SET title = 'ByAlice', author = fk_authors:alice;"
+        "CREATE fk_articles:a2 SET title = 'ByBob', author = fk_authors:bob;"
+        "CREATE fk_articles:a3 SET title = 'ByCarol', author = fk_authors:carol;"
+    )
+
+    found = await Article.objects().filter(Q(author="alice") | Q(author="fk_authors:bob")).exec()
+    assert {a.title for a in found} == {"ByAlice", "ByBob"}
+
+    found = await Article.objects().filter(~Q(author="fk_authors:carol")).exec()
+    assert {a.title for a in found} == {"ByAlice", "ByBob"}
+
+
+@pytest.mark.integration
+async def test_bulk_update_accepted_by_record_column() -> None:
+    """bulk_update() writes the foreign key as a record link."""
+    client = await SurrealDBConnectionManager.get_client()
+    await client.query(
+        "CREATE fk_authors:bob SET name = 'Bob';CREATE fk_articles:a1 SET title = 'Hello', author = fk_authors:alice;"
+    )
+
+    updated = await Article.objects().filter(title="Hello").bulk_update({"author": "bob"})
+    assert updated == 1
+
+    found = await Article.objects().filter(author="fk_authors:bob").exec()
+    assert len(found) == 1
+
+
+@pytest.mark.integration
+async def test_merge_accepted_by_record_column() -> None:
+    """merge() writes the record link too."""
+    client = await SurrealDBConnectionManager.get_client()
+    await client.query("CREATE fk_authors:bob SET name = 'Bob';")
+
+    article = Article(title="Hello", author="fk_authors:alice")
+    await article.save()
+    await article.merge(author="fk_authors:bob", refresh=False)
+
+    found = await Article.objects().filter(author="fk_authors:bob").exec()
+    assert len(found) == 1

--- a/tests/test_foreign_key_coercion_unit.py
+++ b/tests/test_foreign_key_coercion_unit.py
@@ -1,0 +1,420 @@
+"""
+Unit tests for ForeignKey values being sent as record links.
+
+A :func:`ForeignKey` holds a ``"table:id"`` string in Python, but a
+``record<...>`` column only ever matches a real record value.  Historically the
+string was passed straight through, which failed in two different ways:
+
+- A **write** was rejected by SurrealDB (``Expected record<users> but found
+  'users:alice'``) — loud, and therefore easy to spot.
+- A **filter** silently matched nothing, because a bound string never equates
+  to a record — an empty result rather than an error.
+
+These tests pin down the fixed behavior on both paths, and the three ways a
+reference may be given: the related instance, a full ``"table:id"`` string, or
+a bare ID resolved against the target model's table.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import Field
+from pydantic_core import ValidationError
+
+from src.surreal_orm.fields.relation import ForeignKey, ManyToMany
+from src.surreal_orm.model_base import BaseSurrealModel, SurrealConfigDict, to_record_id
+from src.surreal_orm.q import Q
+from surreal_sdk.protocol.cbor import RecordId
+from surreal_sdk.protocol.rpc import SurrealJSONEncoder
+
+# ==================== Test Models ====================
+# Names are prefixed because the model registry is global: a target is resolved
+# by model name, so a plain "User" would collide with other test modules.
+
+
+class FkUser(BaseSurrealModel):
+    """Target of the foreign key — its table name differs from the class name."""
+
+    model_config = SurrealConfigDict(table_name="fk_users")
+
+    id: str | None = None
+    name: str = Field(default="")
+
+
+class FkPost(BaseSurrealModel):
+    """Model with a ForeignKey field."""
+
+    model_config = SurrealConfigDict(table_name="fk_posts")
+
+    id: str | None = None
+    title: str = Field(default="")
+    author: ForeignKey("FkUser")  # type: ignore[valid-type]
+
+
+class FkComment(BaseSurrealModel):
+    """Model whose ForeignKey is stored under a different column name."""
+
+    model_config = SurrealConfigDict(table_name="fk_comments")
+
+    id: str | None = None
+    body: str = Field(default="")
+    post: ForeignKey("FkPost") = Field(default=None, alias="post_id")  # type: ignore[valid-type]
+
+
+class FkOrphan(BaseSurrealModel):
+    """Model whose ForeignKey points at a model that was never defined."""
+
+    model_config = SurrealConfigDict(table_name="fk_orphans")
+
+    id: str | None = None
+    ref: ForeignKey("NeverDefined")  # type: ignore[valid-type]
+
+
+class FkTag(BaseSurrealModel):
+    """Model without any relation field."""
+
+    model_config = SurrealConfigDict(table_name="fk_tags")
+
+    id: str | None = None
+    label: str = Field(default="")
+
+
+class FkGroup(BaseSurrealModel):
+    """Target of a many-to-many relation."""
+
+    model_config = SurrealConfigDict(table_name="fk_groups")
+
+    id: str | None = None
+
+
+class FkMember(BaseSurrealModel):
+    """Model with a ManyToMany field."""
+
+    model_config = SurrealConfigDict(table_name="fk_members")
+
+    id: str | None = None
+    groups: ManyToMany("FkGroup") = Field(default_factory=list)  # type: ignore[valid-type]
+
+
+# ==================== to_record_id() ====================
+
+
+class TestToRecordId:
+    """Tests for the string → RecordId conversion helper."""
+
+    def test_full_record_id_is_converted(self) -> None:
+        assert to_record_id("users:alice") == RecordId(table="users", id="alice")
+
+    def test_escaped_id_is_unescaped(self) -> None:
+        assert to_record_id("users:`7abc`") == RecordId(table="users", id="7abc")
+
+    def test_bare_id_is_unchanged(self) -> None:
+        """Without a target table this helper cannot qualify a bare ID."""
+        assert to_record_id("alice") == "alice"
+
+    def test_none_is_unchanged(self) -> None:
+        assert to_record_id(None) is None
+
+    def test_non_string_is_unchanged(self) -> None:
+        assert to_record_id(42) == 42
+
+    def test_record_id_is_unchanged(self) -> None:
+        record = RecordId(table="users", id="alice")
+        assert to_record_id(record) is record
+
+    def test_variable_reference_is_unchanged(self) -> None:
+        assert to_record_id("$author") == "$author"
+
+    def test_non_identifier_prefix_is_unchanged(self) -> None:
+        """A timestamp contains ':' but '2026-08-23T10' is not a table name."""
+        assert to_record_id("2026-08-23T10:00:00Z") == "2026-08-23T10:00:00Z"
+
+
+# ==================== get_foreign_key_targets() ====================
+
+
+class TestGetForeignKeyTargets:
+    """Tests for foreign-key discovery and target resolution."""
+
+    def test_resolves_target_table(self) -> None:
+        """The target is the model's table name, not its class name."""
+        assert FkPost.get_foreign_key_targets() == {"author": "fk_users"}
+
+    def test_unknown_target_resolves_to_none(self) -> None:
+        assert FkOrphan.get_foreign_key_targets() == {"ref": None}
+
+    def test_model_without_relations(self) -> None:
+        assert FkTag.get_foreign_key_targets() == {}
+
+
+# ==================== Assignment ====================
+
+
+class TestGetRecordLink:
+    """Tests for the model's own "table:id" accessor."""
+
+    def test_saved_instance(self) -> None:
+        assert FkUser(id="alice").get_record_link() == "fk_users:alice"
+
+    def test_unsaved_instance(self) -> None:
+        assert FkUser(name="Alice").get_record_link() is None
+
+
+class TestForeignKeyAssignment:
+    """Tests that a foreign-key field accepts the related object."""
+
+    def test_instance_is_stored_as_string(self) -> None:
+        author = FkUser(id="alice", name="Alice")
+        post = FkPost(title="Hello", author=author)
+        assert post.author == "fk_users:alice"
+
+    def test_record_id_is_stored_as_string(self) -> None:
+        post = FkPost(title="Hello", author=RecordId(table="fk_users", id="alice"))
+        assert post.author == "fk_users:alice"
+
+    def test_string_is_left_alone(self) -> None:
+        post = FkPost(title="Hello", author="fk_users:alice")
+        assert post.author == "fk_users:alice"
+
+    def test_assignment_after_construction(self) -> None:
+        post = FkPost(title="Hello", author="fk_users:alice")
+        post.author = FkUser(id="bob", name="Bob")  # type: ignore[assignment]
+        assert post.author == "fk_users:bob"
+
+    def test_unsaved_instance_is_rejected(self) -> None:
+        """An instance with no ID has nothing to reference yet."""
+        with pytest.raises(ValidationError):
+            FkPost(title="Hello", author=FkUser(name="Alice"))
+
+    def test_many_to_many_accepts_mixed_references(self) -> None:
+        """A ManyToMany list takes instances, RecordIds, and strings alike."""
+        member = FkMember(
+            groups=[
+                FkGroup(id="g1"),
+                RecordId(table="fk_groups", id="g2"),
+                "fk_groups:g3",
+            ],
+        )
+        assert member.groups == ["fk_groups:g1", "fk_groups:g2", "fk_groups:g3"]
+
+
+# ==================== Write path ====================
+
+
+class TestCoerceForeignKeysOnWrite:
+    """Tests that foreign keys leave the ORM as record links."""
+
+    def test_string_is_wrapped(self) -> None:
+        post = FkPost(title="Hello", author="fk_users:alice")
+        data = post._coerce_foreign_keys({"title": "Hello", "author": "fk_users:alice"})
+        assert data["author"] == RecordId(table="fk_users", id="alice")
+        assert data["title"] == "Hello"
+
+    def test_bare_id_is_qualified_with_target_table(self) -> None:
+        post = FkPost(title="Hello", author="alice")
+        data = post._coerce_foreign_keys({"author": "alice"})
+        assert data["author"] == RecordId(table="fk_users", id="alice")
+
+    def test_bare_id_without_known_target_is_unchanged(self) -> None:
+        orphan = FkOrphan(ref="alice")
+        data = orphan._coerce_foreign_keys({"ref": "alice"})
+        assert data["ref"] == "alice"
+
+    def test_none_is_preserved(self) -> None:
+        post = FkPost(title="Hello", author=None)
+        data = post._coerce_foreign_keys({"author": None})
+        assert data["author"] is None
+
+    def test_non_relation_field_is_untouched(self) -> None:
+        """Only declared foreign keys are converted, colon or not."""
+        tag = FkTag(label="data:image/png;base64,AAA")
+        data = tag._coerce_foreign_keys({"label": "data:image/png;base64,AAA"})
+        assert data["label"] == "data:image/png;base64,AAA"
+
+    def test_aliased_field_is_resolved(self) -> None:
+        comment = FkComment(body="Nice", post_id="fk_posts:1")
+        data = comment._coerce_foreign_keys({"post_id": "fk_posts:1"})
+        assert data["post_id"] == RecordId(table="fk_posts", id="1")
+
+    def test_input_dict_is_not_mutated(self) -> None:
+        post = FkPost(title="Hello", author="fk_users:alice")
+        original = {"author": "fk_users:alice"}
+        post._coerce_foreign_keys(original)
+        assert original["author"] == "fk_users:alice"
+
+    @pytest.mark.asyncio
+    async def test_save_sends_record_id(self) -> None:
+        """save() on a new record must not send the foreign key as a string."""
+        mock_client = AsyncMock()
+        mock_client.create = AsyncMock(
+            return_value=MagicMock(exists=True, record={"id": "fk_posts:1", "title": "Hello"}),
+        )
+
+        post = FkPost(title="Hello", author="fk_users:alice")
+        with patch(
+            "src.surreal_orm.model_base.SurrealDBConnectionManager",
+            new=MagicMock(get_client=AsyncMock(return_value=mock_client)),
+        ):
+            await post.save()
+
+        _table, data = mock_client.create.call_args[0]
+        assert data["author"] == RecordId(table="fk_users", id="alice")
+
+    @pytest.mark.asyncio
+    async def test_merge_accepts_an_instance(self) -> None:
+        """merge() takes the related object and writes a record link."""
+        mock_client = AsyncMock()
+        mock_client.merge = AsyncMock(return_value=MagicMock(is_empty=False))
+
+        post = FkPost(id="1", title="Hello", author="fk_users:alice")
+        post._db_persisted = True
+        with patch(
+            "src.surreal_orm.model_base.SurrealDBConnectionManager",
+            new=MagicMock(get_client=AsyncMock(return_value=mock_client)),
+        ):
+            await post.merge(refresh=False, author=FkUser(id="bob", name="Bob"))
+
+        _thing, data = mock_client.merge.call_args[0]
+        assert data["author"] == RecordId(table="fk_users", id="bob")
+
+
+# ==================== Filter path ====================
+
+
+class TestCoerceForeignKeysInFilters:
+    """Tests that foreign-key filters bind a record link, not a string."""
+
+    def test_exact_filter_binds_record_id(self) -> None:
+        qs = FkPost.objects().filter(author="fk_users:alice")
+        qs._compile_query()
+        assert qs._variables["_f0"] == RecordId(table="fk_users", id="alice")
+
+    def test_bare_id_filter_binds_record_id(self) -> None:
+        qs = FkPost.objects().filter(author="alice")
+        qs._compile_query()
+        assert qs._variables["_f0"] == RecordId(table="fk_users", id="alice")
+
+    def test_instance_filter_binds_record_id(self) -> None:
+        qs = FkPost.objects().filter(author=FkUser(id="alice", name="Alice"))
+        qs._compile_query()
+        assert qs._variables["_f0"] == RecordId(table="fk_users", id="alice")
+
+    def test_record_id_filter_is_passed_through(self) -> None:
+        qs = FkPost.objects().filter(author=RecordId(table="fk_users", id="alice"))
+        qs._compile_query()
+        assert qs._variables["_f0"] == RecordId(table="fk_users", id="alice")
+
+    def test_in_filter_binds_record_ids(self) -> None:
+        qs = FkPost.objects().filter(author__in=["fk_users:alice", "bob"])
+        qs._compile_query()
+        assert qs._variables["_f0"] == [
+            RecordId(table="fk_users", id="alice"),
+            RecordId(table="fk_users", id="bob"),
+        ]
+
+    def test_in_filter_accepts_mixed_forms(self) -> None:
+        """All four reference forms can be mixed in one collection."""
+        qs = FkPost.objects().filter(
+            author__in=[
+                FkUser(id="alice", name="Alice"),
+                "fk_users:bob",
+                "carol",
+                RecordId(table="fk_users", id="dave"),
+            ],
+        )
+        qs._compile_query()
+        assert qs._variables["_f0"] == [
+            RecordId(table="fk_users", id="alice"),
+            RecordId(table="fk_users", id="bob"),
+            RecordId(table="fk_users", id="carol"),
+            RecordId(table="fk_users", id="dave"),
+        ]
+
+    def test_in_filter_accepts_tuple(self) -> None:
+        qs = FkPost.objects().filter(author__in=("alice", "bob"))
+        qs._compile_query()
+        assert list(qs._variables["_f0"]) == [
+            RecordId(table="fk_users", id="alice"),
+            RecordId(table="fk_users", id="bob"),
+        ]
+
+    def test_not_in_filter_binds_record_ids(self) -> None:
+        qs = FkPost.objects().filter(author__not_in=["fk_users:spam"])
+        query = qs._compile_query()
+        assert "author NOT IN $_f0" in query
+        assert qs._variables["_f0"] == [RecordId(table="fk_users", id="spam")]
+
+    def test_q_object_filter_binds_record_id(self) -> None:
+        qs = FkPost.objects().filter(Q(author="fk_users:alice") | Q(author="fk_users:bob"))
+        qs._compile_query()
+        assert qs._variables["_f0"] == RecordId(table="fk_users", id="alice")
+        assert qs._variables["_f1"] == RecordId(table="fk_users", id="bob")
+
+    def test_negated_q_filter_binds_record_id(self) -> None:
+        qs = FkPost.objects().filter(~Q(author="fk_users:banned"))
+        query = qs._compile_query()
+        assert "NOT (author = $_f0)" in query
+        assert qs._variables["_f0"] == RecordId(table="fk_users", id="banned")
+
+    def test_mixed_fk_and_plain_fields(self) -> None:
+        """Only the foreign key is converted; other fields bind raw values."""
+        qs = FkPost.objects().filter(author="alice", title="Hello")
+        qs._compile_query()
+        assert qs._variables["_f0"] == RecordId(table="fk_users", id="alice")
+        assert qs._variables["_f1"] == "Hello"
+
+    def test_string_lookups_are_untouched(self) -> None:
+        """A record link makes no sense inside string::starts_with()."""
+        qs = FkPost.objects().filter(author__startswith="fk_users:a")
+        qs._compile_query()
+        assert qs._variables["_f0"] == "fk_users:a"
+
+    def test_non_relation_field_is_untouched(self) -> None:
+        qs = FkPost.objects().filter(title="a:b")
+        qs._compile_query()
+        assert qs._variables["_f0"] == "a:b"
+
+    def test_isnull_filter_is_untouched(self) -> None:
+        qs = FkPost.objects().filter(author__isnull=True)
+        query = qs._compile_query()
+        assert "author IS NULL" in query
+
+    def test_variable_reference_is_untouched(self) -> None:
+        qs = FkPost.objects().filter(author="$author").variables(author="fk_users:alice")
+        query = qs._compile_query()
+        assert "author = $author" in query
+
+    @pytest.mark.asyncio
+    async def test_bulk_update_binds_record_id(self) -> None:
+        """bulk_update() writes foreign keys as record links too."""
+        mock_client = AsyncMock()
+        mock_client.query = AsyncMock(return_value=MagicMock(all_records=[{}]))
+
+        with patch(
+            "src.surreal_orm.query_set.SurrealDBConnectionManager",
+            new=MagicMock(get_client=AsyncMock(return_value=mock_client)),
+        ):
+            await FkPost.objects().filter(title="Hello").bulk_update({"author": "bob"})
+
+        _query, variables = mock_client.query.call_args[0]
+        assert RecordId(table="fk_users", id="bob") in variables.values()
+
+
+# ==================== JSON protocol fallback ====================
+
+
+class TestJSONEncoderRecordId:
+    """RecordId must stay serializable when the JSON protocol is selected."""
+
+    def test_record_id_encodes_as_string(self) -> None:
+        payload: dict[str, Any] = {"author": RecordId(table="fk_users", id="alice")}
+        assert json.loads(json.dumps(payload, cls=SurrealJSONEncoder)) == {"author": "fk_users:alice"}
+
+    def test_datetime_still_encodes(self) -> None:
+        payload = {"at": datetime(2026, 8, 23, 10, 0, 0)}
+        assert json.loads(json.dumps(payload, cls=SurrealJSONEncoder)) == {"at": "2026-08-23T10:00:00"}

--- a/tests/test_foreign_key_coercion_unit.py
+++ b/tests/test_foreign_key_coercion_unit.py
@@ -155,14 +155,30 @@ class TestGetForeignKeyTargets:
 # ==================== Assignment ====================
 
 
-class TestGetRecordLink:
-    """Tests for the model's own "table:id" accessor."""
+class TestRecordIdProperty:
+    """Tests for the reserved ``record_id`` accessor (the Django ``pk`` analog)."""
 
     def test_saved_instance(self) -> None:
-        assert FkUser(id="alice").get_record_link() == "fk_users:alice"
+        assert FkUser(id="alice").record_id == RecordId(table="fk_users", id="alice")
 
     def test_unsaved_instance(self) -> None:
-        assert FkUser(name="Alice").get_record_link() is None
+        assert FkUser(name="Alice").record_id is None
+
+    def test_str_form(self) -> None:
+        """str() of the property is the "table:id" record link."""
+        assert str(FkUser(id="alice").record_id) == "fk_users:alice"
+
+    def test_not_serialized(self) -> None:
+        """A property, not a field — never leaks into dumps or saves."""
+        assert "record_id" not in FkUser(id="alice").model_dump()
+
+    def test_usable_as_bound_variable(self) -> None:
+        """The intended use: binding against a record<> column."""
+        author = FkUser(id="alice")
+        qs = FkPost.objects().filter(author="$a").variables(a=author.record_id)
+        query = qs._compile_query()
+        assert "author = $a" in query
+        assert qs._variables["a"] == RecordId(table="fk_users", id="alice")
 
 
 class TestForeignKeyAssignment:

--- a/tests/test_foreign_key_coercion_unit.py
+++ b/tests/test_foreign_key_coercion_unit.py
@@ -26,8 +26,14 @@ import pytest
 from pydantic import Field
 from pydantic_core import ValidationError
 
+from src.surreal_orm import signals as model_signals
 from src.surreal_orm.fields.relation import ForeignKey, ManyToMany
-from src.surreal_orm.model_base import BaseSurrealModel, SurrealConfigDict, to_record_id
+from src.surreal_orm.model_base import (
+    BaseSurrealModel,
+    SurrealConfigDict,
+    record_link_to_str,
+    to_record_id,
+)
 from src.surreal_orm.q import Q
 from surreal_sdk.protocol.cbor import RecordId
 from surreal_sdk.protocol.rpc import SurrealJSONEncoder
@@ -434,3 +440,220 @@ class TestJSONEncoderRecordId:
     def test_datetime_still_encodes(self) -> None:
         payload = {"at": datetime(2026, 8, 23, 10, 0, 0)}
         assert json.loads(json.dumps(payload, cls=SurrealJSONEncoder)) == {"at": "2026-08-23T10:00:00"}
+
+
+# ==================== Review findings (PR #174) ====================
+
+
+class TestFilterCollectionTypes:
+    """`__in` accepts any collection, including an unhashable-safe set."""
+
+    def test_set_is_accepted(self) -> None:
+        """A set of references must not raise — RecordId is unhashable."""
+        qs = FkPost.objects().filter(author__in={"fk_users:alice", "fk_users:bob"})
+        qs._compile_where_clause()
+        bound = qs._variables["_f0"]
+        assert isinstance(bound, list)
+        assert sorted(str(item) for item in bound) == ["fk_users:alice", "fk_users:bob"]
+
+    def test_tuple_becomes_a_list(self) -> None:
+        qs = FkPost.objects().filter(author__in=("alice", "bob"))
+        qs._compile_where_clause()
+        assert qs._variables["_f0"] == [
+            RecordId(table="fk_users", id="alice"),
+            RecordId(table="fk_users", id="bob"),
+        ]
+
+
+class TestAliasedForeignKeyColumns:
+    """A filter addresses the column, so an alias must resolve too."""
+
+    def test_columns_map_covers_both_spellings(self) -> None:
+        assert FkComment.get_foreign_key_columns() == {
+            "post": "fk_posts",
+            "post_id": "fk_posts",
+        }
+
+    def test_filter_by_alias_binds_a_record_id(self) -> None:
+        qs = FkComment.objects().filter(post_id="fk_posts:1")
+        qs._compile_where_clause()
+        assert qs._variables["_f0"] == RecordId(table="fk_posts", id="1")
+
+    def test_filter_by_alias_in_list(self) -> None:
+        qs = FkComment.objects().filter(post_id__in=["1", "fk_posts:2"])
+        qs._compile_where_clause()
+        assert qs._variables["_f0"] == [
+            RecordId(table="fk_posts", id="1"),
+            RecordId(table="fk_posts", id="2"),
+        ]
+
+    def test_filter_by_alias_in_q_object(self) -> None:
+        qs = FkComment.objects().filter(Q(post_id="fk_posts:1"))
+        qs._compile_where_clause()
+        assert qs._variables["_f0"] == RecordId(table="fk_posts", id="1")
+
+    def test_string_lookups_on_an_alias_stay_untouched(self) -> None:
+        qs = FkComment.objects().filter(post_id__contains="posts")
+        qs._compile_where_clause()
+        assert qs._variables["_f0"] == "posts"
+
+    @pytest.mark.asyncio
+    async def test_bulk_update_coerces_an_aliased_column(self) -> None:
+        mock_client = AsyncMock()
+        mock_client.query = AsyncMock(return_value=MagicMock(all_records=[{}]))
+
+        with patch(
+            "src.surreal_orm.query_set.SurrealDBConnectionManager",
+            new=MagicMock(get_client=AsyncMock(return_value=mock_client)),
+        ):
+            await FkComment.objects().filter(body="Nice").bulk_update({"post_id": "1"})
+
+        _query, variables = mock_client.query.call_args[0]
+        assert RecordId(table="fk_posts", id="1") in variables.values()
+
+
+class TestUpsertForeignKeys:
+    """upsert()/bulk_upsert() write record links like the other write paths."""
+
+    @pytest.mark.asyncio
+    async def test_upsert_defaults_are_coerced(self) -> None:
+        mock_client = AsyncMock()
+        mock_client.query = AsyncMock(
+            return_value=MagicMock(all_records=[{"id": "fk_posts:1", "title": "Hello", "author": "fk_users:alice"}]),
+        )
+
+        with patch(
+            "src.surreal_orm.query_set.SurrealDBConnectionManager",
+            new=MagicMock(get_client=AsyncMock(return_value=mock_client)),
+        ):
+            await FkPost.objects().upsert(
+                defaults={"title": "Hello", "author": "alice"},
+                id="fk_posts:1",
+            )
+
+        _query, variables = mock_client.query.call_args[0]
+        assert variables["_up_author"] == RecordId(table="fk_users", id="alice")
+        assert variables["_up_title"] == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_upsert_on_conflict_is_coerced(self) -> None:
+        mock_client = AsyncMock()
+        mock_client.query = AsyncMock(
+            return_value=MagicMock(all_records=[{"id": "fk_posts:1", "title": "Hello", "author": "fk_users:alice"}]),
+        )
+
+        with patch(
+            "src.surreal_orm.query_set.SurrealDBConnectionManager",
+            new=MagicMock(get_client=AsyncMock(return_value=mock_client)),
+        ):
+            await FkPost.objects().upsert(
+                defaults={"title": "Hello", "author": "alice"},
+                id="fk_posts:1",
+                on_conflict={"author": FkUser(id="bob", name="Bob")},
+            )
+
+        _query, variables = mock_client.query.call_args[0]
+        assert variables["_oc_author"] == RecordId(table="fk_users", id="bob")
+
+    @pytest.mark.asyncio
+    async def test_bulk_upsert_coerces_instance_data(self) -> None:
+        mock_client = AsyncMock()
+        mock_client.query = AsyncMock(return_value=MagicMock(all_records=[]))
+
+        posts = [FkPost(id="1", title="Hello", author="fk_users:alice")]
+        with patch(
+            "src.surreal_orm.query_set.SurrealDBConnectionManager",
+            new=MagicMock(get_client=AsyncMock(return_value=mock_client)),
+        ):
+            await FkPost.objects().bulk_upsert(posts)
+
+        _query, variables = mock_client.query.call_args[0]
+        assert RecordId(table="fk_users", id="alice") in variables.values()
+
+    @pytest.mark.asyncio
+    async def test_bulk_upsert_coerces_on_conflict(self) -> None:
+        mock_client = AsyncMock()
+        mock_client.query = AsyncMock(return_value=MagicMock(all_records=[]))
+
+        posts = [FkPost(id="1", title="Hello", author="fk_users:alice")]
+        with patch(
+            "src.surreal_orm.query_set.SurrealDBConnectionManager",
+            new=MagicMock(get_client=AsyncMock(return_value=mock_client)),
+        ):
+            await FkPost.objects().bulk_upsert(posts, on_conflict={"author": "bob"})
+
+        _query, variables = mock_client.query.call_args[0]
+        assert variables["_oc0_author"] == RecordId(table="fk_users", id="bob")
+
+
+class TestUpdateSignalPayload:
+    """Signals are a public API and must not see wire types."""
+
+    @pytest.mark.asyncio
+    async def test_update_signals_get_uncoerced_values(self) -> None:
+        mock_client = AsyncMock()
+        mock_client.merge = AsyncMock(return_value=MagicMock(records=[]))
+        seen: list[Any] = []
+
+        async def handler(sender: Any, instance: Any, **kwargs: Any) -> None:
+            seen.append(kwargs["update_fields"]["author"])
+
+        post = FkPost(id="1", title="Hello", author="fk_users:alice")
+        model_signals.pre_update.connect(FkPost)(handler)
+        try:
+            with patch(
+                "src.surreal_orm.model_base.SurrealDBConnectionManager",
+                new=MagicMock(get_client=AsyncMock(return_value=mock_client)),
+            ):
+                await post.update()
+        finally:
+            model_signals.pre_update.disconnect(handler, FkPost)
+
+        assert seen == ["fk_users:alice"]
+
+    @pytest.mark.asyncio
+    async def test_update_still_writes_a_record_id(self) -> None:
+        mock_client = AsyncMock()
+        mock_client.merge = AsyncMock(return_value=MagicMock(records=[]))
+
+        post = FkPost(id="1", title="Hello", author="fk_users:alice")
+        with patch(
+            "src.surreal_orm.model_base.SurrealDBConnectionManager",
+            new=MagicMock(get_client=AsyncMock(return_value=mock_client)),
+        ):
+            await post.update()
+
+        _thing, data = mock_client.merge.call_args[0]
+        assert data["author"] == RecordId(table="fk_users", id="alice")
+
+
+class TestUnsavedReference:
+    """An unsaved instance cannot be referenced — say so explicitly."""
+
+    def test_foreign_key_rejects_an_unsaved_instance(self) -> None:
+        with pytest.raises(ValidationError, match="cannot reference an unsaved FkUser"):
+            FkPost(title="Hello", author=FkUser(name="Alice"))
+
+    def test_many_to_many_rejects_an_unsaved_instance(self) -> None:
+        with pytest.raises(ValidationError, match="cannot reference an unsaved FkGroup"):
+            FkMember(groups=[FkGroup()])
+
+    def test_filter_rejects_an_unsaved_instance(self) -> None:
+        with pytest.raises(ValueError, match="cannot reference an unsaved FkUser"):
+            FkPost.objects().filter(author=FkUser(name="Alice"))._compile_where_clause()
+
+    def test_unrelated_object_with_record_id_passes_through(self) -> None:
+        """The guard must not fire on anything that merely has the attribute."""
+
+        class NotAModel:
+            record_id = "not-a-record-id"
+
+        obj = NotAModel()
+        assert record_link_to_str(obj) is obj
+
+    def test_saved_instance_is_still_accepted(self) -> None:
+        post = FkPost(title="Hello", author=FkUser(id="alice", name="Alice"))
+        assert post.author == "fk_users:alice"
+
+    def test_none_is_still_accepted(self) -> None:
+        assert FkComment(body="Nice", post_id=None).post is None

--- a/tests/test_migrations_operations.py
+++ b/tests/test_migrations_operations.py
@@ -132,6 +132,18 @@ class TestAddField:
         sql = op.forwards()
         assert "ASSERT is::email($value)" in sql
 
+    def test_add_field_maps_on_delete_keyword(self) -> None:
+        """Test Django's on_delete vocabulary is translated for SurrealDB."""
+        op = AddField(
+            table="posts",
+            name="author",
+            field_type="record<users>",
+            reference=True,
+            on_delete="SET_NULL",
+        )
+        sql = op.forwards()
+        assert "REFERENCE ON DELETE UNSET" in sql
+
     def test_add_field_backwards(self) -> None:
         """Test field removal on rollback."""
         op = AddField(table="users", name="email", field_type="string")
@@ -172,6 +184,18 @@ class TestAlterField:
         )
         sql = op.forwards()
         assert "DEFINE FIELD OVERWRITE age ON users TYPE int" in sql
+
+    def test_alter_field_maps_on_delete_keyword(self) -> None:
+        """Test Django's on_delete vocabulary is translated for SurrealDB."""
+        op = AlterField(
+            table="posts",
+            name="author",
+            field_type="record<users>",
+            reference=True,
+            on_delete="PROTECT",
+        )
+        sql = op.forwards()
+        assert "REFERENCE ON DELETE REJECT" in sql
 
     def test_alter_field_backwards(self) -> None:
         """Test rollback restores previous type."""

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -12,6 +12,7 @@ from src.surreal_orm.fields.relation import (
     is_graph_relation,
     is_many_to_many,
     is_relation_field,
+    on_delete_to_surql,
 )
 from src.surreal_orm.model_base import BaseSurrealModel
 
@@ -66,6 +67,22 @@ def test_foreign_key_with_on_delete() -> None:
     assert info_set_null.on_delete == "SET_NULL"
     assert info_protect is not None
     assert info_protect.on_delete == "PROTECT"
+
+
+def test_on_delete_maps_django_vocabulary() -> None:
+    """Test SET_NULL and PROTECT are translated to SurrealDB keywords."""
+    assert on_delete_to_surql("SET_NULL") == "UNSET"
+    assert on_delete_to_surql("PROTECT") == "REJECT"
+    assert on_delete_to_surql("set_null") == "UNSET"
+
+
+def test_on_delete_passes_surrealdb_keywords_through() -> None:
+    """Test SurrealDB's own keywords are left unchanged."""
+    assert on_delete_to_surql("CASCADE") == "CASCADE"
+    assert on_delete_to_surql("UNSET") == "UNSET"
+    assert on_delete_to_surql("REJECT") == "REJECT"
+    assert on_delete_to_surql("IGNORE") == "IGNORE"
+    assert on_delete_to_surql(None) is None
 
 
 def test_foreign_key_with_related_name() -> None:


### PR DESCRIPTION
Fixes #169

## 1. ForeignKey coercion — supported syntax

`ForeignKey` fields keep holding `"table:id"` strings in Python, but every write path (`save`, `merge`, `update`, `bulk_update`) and every whole-record filter lookup (`exact`, `in`, `not_in`, incl. `Q` objects) now converts the value to a `RecordId` at the wire boundary — so `record<>` columns accept the writes, and filters match instead of silently returning empty results.

A foreign key reference is now callable in **four interchangeable forms**, mixed freely in collections:

```python
# Assignment / save — all equivalent
Article(author=alice)                                  # model instance (Django-style)
Article(author="fk_authors:alice")                     # full "table:id" string
Article(author="alice")                                # bare ID → qualified via ForeignKey("Author")
Article(author=RecordId(table="fk_authors", id="alice"))

# Filters — object filtering, same four forms
Article.objects().filter(author=alice)
Article.objects().filter(author="alice")
Article.objects().filter(author__in=[alice, "bob", "fk_authors:carol", RecordId(...)])  # mixed
Article.objects().filter(author__not_in=["fk_authors:spam"])
Article.objects().filter(Q(author=alice) | Q(author="bob"))
Article.objects().filter(~Q(author="fk_authors:banned"))

# ManyToMany items accept the same forms
Member(groups=[group_obj, "groups:g2", RecordId(table="groups", id="g3")])

# bulk_update writes record links too
Article.objects().filter(title="Hello").bulk_update({"author": "bob"})
```

Deliberately untouched: string lookups (`startswith`, `contains`, `regex`, …), `isnull`, and explicit `$var` references bound via `.variables()`.

New public API: the reserved `instance.record_id` property (the Django `Model.pk` analog) — the record identity as a `RecordId`, ready to bind against `record<>` columns in `raw_query()` / `.variables()`, where explicit bindings deliberately pass through uncoerced; `str(instance.record_id)` gives the `"table:id"` string form. Plus `to_record_id()` / `record_link_to_str()` helpers in `model_base` next to the existing `_convert_record_id_to_string`. The JSON protocol encoder now renders `RecordId` as `"table:id"` so the fallback protocol keeps working.

## 2. `on_delete` DDL fix

Django's `on_delete` vocabulary passed through verbatim into migration DDL, generating invalid clauses — SurrealDB takes `CASCADE | UNSET | REJECT | IGNORE | THEN`. `AddField` / `AlterField` now map through the new `on_delete_to_surql()`:

| Django | SurrealDB |
|---|---|
| `SET_NULL` | `UNSET` |
| `PROTECT` | `REJECT` |
| `CASCADE` / native keywords | unchanged |

As preferred in the issue, the Django literals stay the API; both vocabularies are accepted.

## Tests

- **46 unit tests** (`tests/test_foreign_key_coercion_unit.py`) covering every form above on write, filter, and assignment paths, plus alias handling, unknown targets, and the JSON encoder.
- **11 integration tests** (`tests/test_foreign_key_coercion_integration.py`) against a real SCHEMAFULL `record<fk_authors>` column — rows are created server-side with raw SurrealQL so the filters are proven against real record values, not just ORM-written ones. Each fails without the coercion.
- `on_delete` mapping guarded in `tests/test_migrations_operations.py` and `tests/test_relations.py`.
- Full suite: 1893 unit tests pass, mypy strict clean (66 files), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

