### PR TITLE
ci: SurrealDB pre-release canary (test 3.3 betas without pinning them)

### DIFF
--- a/.github/workflows/surrealdb-prerelease-canary.yml
+++ b/.github/workflows/surrealdb-prerelease-canary.yml
@@ -1,0 +1,211 @@
+# SurrealDB Pre-release Canary
+#
+# Early warning only. Runs the suite against the newest SurrealDB 3.x
+# *pre-release* and opens an issue when it breaks — so a regression in a beta
+# is known before that line ships stable and the monitor proposes the pin.
+#
+# What this workflow deliberately does NOT do (#163):
+#   - it never writes .surrealdb-version or devops/docker-compose.yml
+#   - it never opens a PR, and never bumps the ORM version
+#   - it therefore cannot reach PyPI
+# The pin is the version the library declares support for, and a bump to it
+# cascades into a published release. Pinning a beta burned three of them
+# (0.32.3-0.32.5). Both monitors reject pre-releases; this job tests them
+# without adopting them. `permissions:` below is the structural guarantee —
+# with `contents: read` it cannot push even if the steps were edited.
+
+name: SurrealDB Pre-release Canary
+
+on:
+  schedule:
+    # Mondays at 7:30 AM Montreal time (UTC-5 -> 12:30 UTC), after the daily monitor.
+    - cron: '30 12 * * 1'
+  workflow_dispatch:
+    inputs:
+      surrealdb_version:
+        description: 'Pre-release to test (e.g. 3.3.0-beta.3, leave empty for the newest v3.x pre-release)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  SURREALDB_URL: http://localhost:8000
+  SURREALDB_USER: root
+  SURREALDB_PASS: root
+  SURREALDB_NAMESPACE: test
+  SURREALDB_DATABASE: test
+
+jobs:
+  # =============================================================================
+  # Step 1: Find the newest v3.x pre-release worth testing
+  # =============================================================================
+  check-prerelease:
+    name: Check for a pre-release
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+      docker-tag: ${{ steps.check.outputs.docker-tag }}
+      pin: ${{ steps.check.outputs.pin }}
+      found: ${{ steps.check.outputs.found }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Resolve pre-release
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Never interpolate an input straight into the shell.
+          INPUT_VERSION: ${{ inputs.surrealdb_version }}
+        run: |
+          if [[ -n "$INPUT_VERSION" ]]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION=$(gh api repos/surrealdb/surrealdb/releases \
+              --jq '[.[] | select(.tag_name | startswith("v3.")) | select(.prerelease == true) | select(.draft == false) | .tag_name][0]' \
+              | sed 's/^v//')
+          fi
+
+          PIN=$(cat .surrealdb-version | tr -d '[:space:]')
+
+          # --- Decide: only a pre-release ahead of the stable pin is worth testing ---
+          FOUND="false"
+
+          if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
+            echo "No open v3.x pre-release — nothing to canary."
+          elif [[ "$VERSION" != *-* ]]; then
+            # Guard against the inverse mistake: this workflow exists to test
+            # pre-releases, and must never quietly exercise a stable one that
+            # the monitor is responsible for.
+            echo "Candidate ($VERSION) is not a pre-release — the monitor owns stable releases."
+          else
+            # Only interesting once its base version is ahead of the stable pin;
+            # a 3.2.x pre-release after pinning 3.2.4 tells us nothing new.
+            BASE="${VERSION%%-*}"
+            NEWEST=$(printf '%s\n%s\n' "$PIN" "$BASE" | sort -V | tail -1)
+            if [[ "$BASE" == "$PIN" || "$NEWEST" != "$BASE" ]]; then
+              echo "Pre-release $VERSION is not ahead of the pin ($PIN) — skipping."
+            else
+              echo "Will test SurrealDB $VERSION against the current pin $PIN."
+              FOUND="true"
+            fi
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "docker-tag=v$VERSION" >> $GITHUB_OUTPUT
+          echo "pin=$PIN" >> $GITHUB_OUTPUT
+          echo "found=$FOUND" >> $GITHUB_OUTPUT
+
+  # =============================================================================
+  # Step 2: Run the suite against it — informational, never gating
+  # =============================================================================
+  test-prerelease:
+    name: Test SurrealDB ${{ needs.check-prerelease.outputs.version }}
+    needs: check-prerelease
+    if: needs.check-prerelease.outputs.found == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Start SurrealDB ${{ needs.check-prerelease.outputs.docker-tag }}
+        env:
+          DOCKER_TAG: ${{ needs.check-prerelease.outputs.docker-tag }}
+        run: |
+          docker run -d \
+            --name surrealdb-canary \
+            -p 8000:8000 \
+            "surrealdb/surrealdb:${DOCKER_TAG}" \
+            start --log error --user root --pass root memory
+
+          ./devops/wait-for-healthy.sh localhost 8000 60
+
+          echo "Running SurrealDB version: $(curl -s http://localhost:8000/version || echo unknown)"
+
+      - name: Run unit tests
+        run: uv run pytest tests/ -m "not integration" --junitxml=junit-unit.xml
+
+      - name: Run integration tests
+        env:
+          SURREALDB_SKIP_CONTAINER: "true"
+        run: uv run pytest tests/ -m integration --junitxml=junit-integration.xml -v
+
+      - name: Stop SurrealDB
+        if: always()
+        run: docker stop surrealdb-canary && docker rm surrealdb-canary || true
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: surrealdb-canary-results
+          path: junit-*.xml
+
+  # =============================================================================
+  # Step 3: Report a break — an issue, never a pin change
+  # =============================================================================
+  report-failure:
+    name: Report Canary Failure
+    needs: [check-prerelease, test-prerelease]
+    # `always()` is required: without a status-check function GitHub implicitly
+    # ANDs `success()` into the condition, so this job — which by definition
+    # only runs when the tests failed — would always be skipped (#146).
+    if: |
+      always() &&
+      needs.check-prerelease.outputs.found == 'true' &&
+      needs.test-prerelease.result == 'failure'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.check-prerelease.outputs.version }}
+          PIN: ${{ needs.check-prerelease.outputs.pin }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          ISSUE_TITLE="SurrealDB $VERSION (pre-release) — canary tests failed"
+
+          EXISTING=$(gh issue list --state open --search "$ISSUE_TITLE" --json number -q '.[0].number')
+          if [[ -n "$EXISTING" ]]; then
+            echo "Issue #$EXISTING already open — skipping."
+            exit 0
+          fi
+
+          gh issue create \
+            --title "$ISSUE_TITLE" \
+            --label "surrealdb,needs-investigation" \
+            --body "$(cat <<EOF
+          The suite fails against SurrealDB **$VERSION**, an upcoming pre-release.
+
+          | Field | Value |
+          |---|---|
+          | Pre-release tested | \`$VERSION\` |
+          | Current stable pin | \`$PIN\` |
+
+          **Nothing is broken for users today** — the pin is unchanged and no release
+          was published. This is early warning: unless it is fixed upstream or here,
+          the same failure will block the pin bump when this line ships stable.
+
+          [Workflow run]($RUN_URL)
+
+          ---
+          *Automatically created by the SurrealDB pre-release canary.*
+          EOF
+          )"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,6 +139,12 @@ def pytest_configure(config: pytest.Config) -> None:
     if SKIP_CONTAINER:
         print(f"\n[conftest] SURREALDB_SKIP_CONTAINER set — skipping container management (port {TEST_PORT})")
         _container_started_by_tests = False
+        # Skipping container *management* is not skipping setup (#172): SurrealDB
+        # 3.x no longer auto-creates a namespace/database on USE, so a server we
+        # did not start still needs them. This is the path CI takes when it
+        # provides its own SurrealDB service, and the suite only survived it
+        # because some early test happened to define them as a side effect.
+        ensure_namespace_and_database()
         return
 
     # If SurrealDB is already healthy (container or external), skip startup

--- a/tests/test_surrealdb_monitor.py
+++ b/tests/test_surrealdb_monitor.py
@@ -24,6 +24,8 @@ from pathlib import Path
 
 import pytest
 
+yaml = pytest.importorskip("yaml", reason="pyyaml required for workflow lint tests")
+
 WORKFLOW_DIR = Path(__file__).resolve().parent.parent / ".github" / "workflows"
 
 MONITORS = ["surrealdb-security.yml", "surrealdb-v2-security.yml"]
@@ -148,3 +150,98 @@ def test_pinned_version_is_not_a_prerelease() -> None:
     """`.surrealdb-version` must name a stable release (#163)."""
     pin = (WORKFLOW_DIR.parent.parent / ".surrealdb-version").read_text(encoding="utf-8").strip()
     assert "-" not in pin, f"the pinned SurrealDB version {pin!r} is a pre-release"
+
+
+CANARY = "surrealdb-prerelease-canary.yml"
+
+
+class TestPrereleaseCanary:
+    """The canary tests pre-releases; it must never adopt one.
+
+    Testing a beta and *pinning* a beta are different acts. `.surrealdb-version`
+    is the version the library declares support for, and a bump to it cascades
+    into a published PyPI release — that is what burned 0.32.3-0.32.5 (#163).
+    The canary exists to give early warning on an upcoming SurrealDB line
+    without touching either.
+    """
+
+    def _text(self) -> str:
+        return (WORKFLOW_DIR / CANARY).read_text(encoding="utf-8")
+
+    def test_canary_exists(self) -> None:
+        assert (WORKFLOW_DIR / CANARY).is_file(), f"{CANARY} not found"
+
+    def test_it_cannot_write_to_the_repository(self) -> None:
+        """`contents: read` is the structural guarantee, not the step bodies."""
+        data = yaml.safe_load(self._text())
+        assert data["permissions"]["contents"] == "read", (
+            "the canary must not be able to push — testing a pre-release is not adopting it (#163)"
+        )
+        assert "pull-requests" not in data["permissions"], "the canary must not open PRs (#163)"
+
+    def test_it_never_touches_the_pin_or_the_compose_file(self) -> None:
+        text = self._text()
+        for forbidden in ("> .surrealdb-version", ">> .surrealdb-version", "sed -i"):
+            assert forbidden not in text, f"the canary must never rewrite the pin ({forbidden!r} found)"
+        assert "gh pr create" not in text, "the canary must never open a PR"
+
+    def test_it_only_considers_pre_releases(self) -> None:
+        text = self._text()
+        query = next(line for line in text.splitlines() if 'startswith("v3.")' in line)
+        assert "select(.prerelease == true)" in query, "the canary is for pre-releases only"
+        assert "select(.draft == false)" in query, "drafts are not testable releases"
+
+    def test_a_stable_candidate_is_refused(self) -> None:
+        """The inverse mistake: the monitor owns stable releases, not this job."""
+        assert 'if [[ "$VERSION" != *-* ]]; then' in self._text(), (
+            "the canary must refuse a stable candidate — otherwise a manual dispatch would silently duplicate the monitor's job"
+        )
+
+
+_CANARY_START = "# --- Decide:"
+_CANARY_END = 'echo "version=$VERSION"'
+
+
+def _canary_decide(version: str, pin: str) -> str:
+    """Run the canary's own selection block and return the FOUND it computes."""
+    text = (WORKFLOW_DIR / CANARY).read_text(encoding="utf-8")
+    start = text.index(_CANARY_START)
+    end = text.index(_CANARY_END, start)
+    block = textwrap.dedent(text[start:end])
+    script = f"""
+        set -euo pipefail
+        VERSION={version!r}
+        PIN={pin!r}
+        {block}
+        echo "$FOUND"
+    """
+    result = subprocess.run(
+        ["bash", "-c", textwrap.dedent(script)],
+        capture_output=True,
+        text=True,
+        check=True,
+        env={"PATH": "/usr/bin:/bin", "GITHUB_OUTPUT": "/dev/null"},
+    )
+    return result.stdout.strip().splitlines()[-1]
+
+
+@pytest.mark.parametrize(
+    ("version", "pin", "expected"),
+    [
+        # The case that motivated the canary: a beta of the next minor line.
+        ("3.3.0-beta.3", "3.2.4", "true"),
+        ("3.3.0-rc.1", "3.2.4", "true"),
+        # Numeric, not lexical — "3.10.0" is ahead of "3.9.0" despite sorting below.
+        ("3.10.0-beta.1", "3.9.0", "true"),
+        # A pre-release of the pinned version teaches nothing.
+        ("3.2.4-beta.1", "3.2.4", "false"),
+        # Behind the pin.
+        ("3.1.0-beta.1", "3.2.4", "false"),
+        # Stable releases belong to the monitor, not here.
+        ("3.3.0", "3.2.4", "false"),
+        # No open pre-release.
+        ("", "3.2.4", "false"),
+    ],
+)
+def test_canary_selection(version: str, pin: str, expected: str) -> None:
+    assert _canary_decide(version, pin) == expected, f"canary: version={version!r} pin={pin!r} should yield found={expected}"


### PR DESCRIPTION
Adds early warning on upcoming SurrealDB releases without declaring support for them.

## Context

The suite passes fully against **3.3.0-beta.3** today — 437 tests, 0 failures, including the SDK suite. That says the beta *works*; it does not say we should *pin* it. `.surrealdb-version` is the version the library announces to its users, and a bump to it cascades into a published PyPI release — which is exactly what burned 0.32.3-0.32.5 (#163). `sort -V` also ranks `3.3.0-beta.3` **above** `3.3.0`, so a beta pin strands the repo until someone intervenes.

This job separates the two: test the beta, keep the pin stable.

## What it does

Weekly (and on demand), the canary resolves the newest v3.x **pre-release** whose base version is ahead of the current pin, runs the unit + integration suites against it, and opens an issue if they fail. If it is green, it says nothing.

What it deliberately cannot do:

- write `.surrealdb-version` or `devops/docker-compose.yml`
- open a PR, or bump the ORM version
- therefore, reach PyPI

`permissions: contents: read` is the guarantee — structural, not a promise about the step bodies. It also refuses a *stable* candidate, so a manual dispatch cannot quietly duplicate the monitor's job.

## Also fixes #172

The canary runs with `SURREALDB_SKIP_CONTAINER`, the one conftest path that never called `ensure_namespace_and_database()`. SurrealDB 3.x no longer auto-creates a namespace/database on `USE`, so on a fresh runner the suite only survived because some early test happened to define them as a side effect. Fixed here rather than separately, since the canary would otherwise inherit that flakiness on every run.

## Tests

- Permissions, absence of `gh pr create`, no writes to the pin, pre-release-only release query
- The selection logic is **extracted from the workflow and executed** — the same harness the monitor tests use — over 7 version pairs, including the digit-width case (`3.10.0-beta.1` vs pin `3.9.0`) and the inverse mistake (a stable candidate must be refused)
- The existing `if:`-condition lint (#146) covers the new `report-failure` job automatically

Verified locally: `ruff`/`mypy` clean, unit suite green, and the `SURREALDB_SKIP_CONTAINER` path now prints its namespace/database setup where it previously printed nothing.
