### PR TITLE
ci(canary): fix two defects found by running it for real

### DIFF
--- a/.github/workflows/surrealdb-prerelease-canary.yml
+++ b/.github/workflows/surrealdb-prerelease-canary.yml
@@ -138,13 +138,19 @@ jobs:
 
           echo "Running SurrealDB version: $(curl -s http://localhost:8000/version || echo unknown)"
 
+      # --no-cov on both: `--cov-fail-under=30` lives in pyproject addopts, and a
+      # partial selection never reaches it (the integration selection alone
+      # measures ~28%). Without this the job fails green — "435 passed" followed
+      # by a coverage error — and the canary reports that SurrealDB broke when
+      # nothing did. A compatibility check answers one question: does the suite
+      # pass. Coverage is CI's job, not this one's.
       - name: Run unit tests
-        run: uv run pytest tests/ -m "not integration" --junitxml=junit-unit.xml
+        run: uv run pytest tests/ -m "not integration" --no-cov --junitxml=junit-unit.xml
 
       - name: Run integration tests
         env:
           SURREALDB_SKIP_CONTAINER: "true"
-        run: uv run pytest tests/ -m integration --junitxml=junit-integration.xml -v
+        run: uv run pytest tests/ -m integration --no-cov --junitxml=junit-integration.xml -v
 
       - name: Stop SurrealDB
         if: always()
@@ -176,6 +182,9 @@ jobs:
       - name: Create issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This job has no checkout — `gh` resolves the repo from git otherwise
+          # and dies with "not a git repository" before it can file anything.
+          GH_REPO: ${{ github.repository }}
           VERSION: ${{ needs.check-prerelease.outputs.version }}
           PIN: ${{ needs.check-prerelease.outputs.pin }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/tests/test_surrealdb_monitor.py
+++ b/tests/test_surrealdb_monitor.py
@@ -191,6 +191,25 @@ class TestPrereleaseCanary:
         assert "select(.prerelease == true)" in query, "the canary is for pre-releases only"
         assert "select(.draft == false)" in query, "drafts are not testable releases"
 
+    def test_pytest_steps_disable_coverage(self) -> None:
+        """A coverage gate must never be able to masquerade as a broken database.
+
+        ``--cov-fail-under=30`` lives in pyproject addopts and a partial selection
+        never reaches it — the integration selection alone measures ~28%. The
+        canary's first live run failed exactly this way: ``435 passed`` followed
+        by a coverage error, which the workflow would have reported as SurrealDB
+        3.3.0-beta.3 breaking the suite.
+        """
+        for line in self._text().splitlines():
+            if "uv run pytest" in line:
+                assert "--no-cov" in line, f"canary pytest step must disable coverage: {line.strip()!r}"
+
+    def test_the_reporting_job_can_reach_the_api_without_a_checkout(self) -> None:
+        """`gh` resolves the repo from git; that job has no checkout (#175 follow-up)."""
+        data = yaml.safe_load(self._text())
+        step = next(s for s in data["jobs"]["report-failure"]["steps"] if "gh issue" in str(s.get("run", "")))
+        assert "GH_REPO" in step["env"], "without GH_REPO, gh dies with 'not a git repository' before filing anything"
+
     def test_a_stable_candidate_is_refused(self) -> None:
         """The inverse mistake: the monitor owns stable releases, not this job."""
         assert 'if [[ "$VERSION" != *-* ]]; then' in self._text(), (


### PR DESCRIPTION
Follow-up to #175, both defects found by dispatching the canary against 3.3.0-beta.3.

## The test job failed while the suite passed

```
435 passed, 1 skipped, 1 xfailed
ERROR: Coverage failure: total of 28 is less than fail-under=30
```

`--cov-fail-under=30` lives in pyproject addopts, and no partial selection reaches it — the integration selection alone measures ~28%. So the canary would have filed *"SurrealDB 3.3.0-beta.3 — canary tests failed"* when 3.3.0-beta.3 is in fact green. A compat job that cries wolf is worse than no compat job. Both pytest steps now run `--no-cov`; coverage is CI's business, not this job's.

## The reporting job could not file anything

It has no `actions/checkout`, and `gh` resolves the repository from git:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

`GH_REPO: ${{ github.repository }}` is enough — cheaper than adding a checkout to a job that only posts an issue.

## Tests

Both pinned: every `uv run pytest` line in the canary must carry `--no-cov`, and the reporting step must carry `GH_REPO`.

## Note on 3.3.0-beta.3

Between the local run and this CI run, the beta now has two independent green results: **435 passed, 1 skipped, 1 xfailed, 0 failures**. The xfail is the known upstream sub-SELECT bug (#147), still unfixed in 3.3.