### PR TITLE
chore(release): bump version to 0.32.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,93 @@ and adheres to [SemVer](https://semver.org/) versioning.
 
 ---
 
+## [0.32.7] - 2026-09-01
+
+**Bug fix release.** Two independent ORM fixes, both reported in #169: foreign
+key values never reached the database as record links, and Django's `on_delete`
+vocabulary generated invalid DDL.
+
+### Fixed — ORM
+
+- **`ForeignKey` values were never coerced to `RecordId` (#169, #174).** A
+  `ForeignKey` field holds a `"table:id"` string in Python, but nothing converted
+  it at the wire boundary, so a `record<>` column rejected the write outright and
+  a filter compared a string against a record value:
+
+  ```python
+  # Before: rejected by SurrealDB — a record<fk_authors> column will not take a string
+  await Article(title="Hello", author="fk_authors:alice").save()
+
+  # Before: the row exists, but the filter compares a string to a record value
+  await Article.objects().filter(author="fk_authors:alice").exec()  # []
+  ```
+
+  Every write path — `save()`, `merge()`, `update()`, `bulk_update()`,
+  `upsert()`, `bulk_upsert()` — and every whole-record filter lookup — `exact`,
+  `in`, `not_in`, including inside `Q` objects — now converts the value to a
+  `RecordId`. Four interchangeable forms are accepted and may be mixed freely
+  within a collection: the related model instance, a full `"table:id"` string, a
+  bare ID qualified through the field's target table, and a `RecordId`.
+
+  Deliberately left untouched: the string lookups (`contains`, `startswith`,
+  `regex`, ...), `isnull`, and explicit `$var` references bound via
+  `.variables()`, which pass through uncoerced by design.
+
+- **Aliased foreign keys were filtered as strings (#169).** The defect the issue
+  singled out as the worst of the three, because it returned a wrong answer
+  rather than an error. The write path resolved aliases while the read path keyed
+  off the Python field name only — so an aliased `ForeignKey` was *written* as a
+  record link and *filtered* as a plain string, yielding an empty result with no
+  error. The new `get_foreign_key_columns()` maps each foreign key under both its
+  field name and its declared alias, and both `_coerce_filter_value()` and
+  `bulk_update()` key off it.
+
+  Still outstanding, pre-existing and tracked separately: filtering by the
+  *Python* field name on an aliased model emits `author = ...` rather than the
+  real column `author_id`.
+
+- **Referencing an unsaved instance raised a confusing error.** Assigning an
+  unsaved model reported `Input should be a valid string`, and the write and
+  filter paths bound the model object straight into the query. The guard now
+  lives in the shared `record_link_to_str()` helper, so all three paths raise
+  `cannot reference an unsaved Author; save it first`. Note that the helper is
+  therefore no longer total — it can raise.
+
+- **`update()` leaked wire types into signal payloads.** `update()` passed its
+  coerced dict as `update_fields`, so handlers received `RecordId` objects while
+  `merge()` deliberately sent the uncoerced values. `update()` now mirrors
+  `merge()`: signals get the uncoerced dict, and only the wire call gets the
+  coerced one.
+
+### Fixed — Migrations
+
+- **Django's `on_delete` vocabulary produced invalid DDL (#169).** The value was
+  passed through verbatim, but SurrealDB accepts only
+  `CASCADE | UNSET | REJECT | IGNORE | THEN`. `AddField` and `AlterField` now map
+  through the new `on_delete_to_surql()`:
+
+  | Django | SurrealDB |
+  | --- | --- |
+  | `SET_NULL` | `UNSET` |
+  | `PROTECT` | `REJECT` |
+  | `CASCADE` / native keywords | unchanged |
+
+  The Django literals remain the public API; both vocabularies are accepted.
+
+### Added
+
+- **`instance.record_id`** — the reserved record-identity property, the analog of
+  Django's `Model.pk`. Returns the identity as a `RecordId`, ready to bind
+  against a `record<>` column in `raw_query()` / `.variables()`, where explicit
+  bindings still pass through uncoerced. `str(instance.record_id)` gives the
+  `"table:id"` form.
+- **`to_record_id()`, `record_link_to_str()`, `get_foreign_key_columns()`** —
+  public helpers in `model_base`.
+- The JSON protocol encoder renders a `RecordId` as `"table:id"`, so the fallback
+  protocol keeps working.
+
+---
+
 ## [0.32.6] - 2026-08-23
 
 **Bug fix release.** Three independent fixes: a CBOR decoding bug in the SDK, a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1702,6 +1702,53 @@ make ci-lint           # Run all linters (mypy, ruff)
 
 ---
 
+## Release Checklist
+
+A release is triggered by a **commit subject**, not by a tag: `tag-release.yml`
+fires on a push to `main` or `v2` whose head commit starts with
+`chore(release): bump version to X.Y.Z`. It then creates `vX.Y.Z` using
+`PAT_TOKEN` — required, because a tag pushed with `GITHUB_TOKEN` does not
+trigger other workflows — and that tag triggers `publish.yml`, which verifies
+the tag is on `main` before publishing to PyPI.
+
+**Consequence:** squash-merging a release PR with any other subject bumps the
+version on `main` but fires nothing, and the tag then has to be pushed by hand.
+Keep the PR title exactly `chore(release): bump version to X.Y.Z`.
+
+### Files to update on every bump
+
+| File | What |
+| --- | --- |
+| `pyproject.toml` | `version` |
+| `src/surreal_sdk/pyproject.toml` | `version` |
+| `src/surreal_orm/__init__.py` | `__version__` |
+| `src/surreal_sdk/__init__.py` | `__version__` |
+| `CHANGELOG.md` | new `[X.Y.Z]` entry |
+| `README.md` | "What's New in X.Y.Z" section |
+| `CLAUDE.md` | header line 3 date/version, `## Current Version`, new "What's New" section |
+| `SECURITY.md` | **supported-versions table** — only when the `X.Y` line or the SurrealDB floor moves |
+
+`SECURITY.md` is the one that silently rots: it changes on a minor bump, not on
+every patch, so it gets skipped and then misstates which versions are supported.
+It sat at `0.30.x` / SurrealDB `>= 3.0` well past 0.32.0 — which had already
+dropped 3.1.x — telling readers an unsupported combination was supported.
+
+### Order
+
+1. Merge the feature/fix PRs first. Their `fix(...)` / `feat(...)` subjects do
+   not match the gate, so nothing is released.
+2. Then open a single release PR titled `chore(release): bump version to X.Y.Z`
+   carrying the version strings and all the docs above.
+3. Squash-merge it. The tag, the GitHub Release and the PyPI publish follow
+   automatically.
+
+Verify before opening the release PR: `make test` (unit), `make test-integration`,
+`uv run python -m mypy src/` — run it as CI does, via `uv sync --group lint`, since
+syncing extras makes `cli/commands.py` report spurious `unused-ignore` errors —
+and `uv run ruff check src/ tests/`.
+
+---
+
 ## Useful Commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # SurrealDB-ORM - Development Context
 
-> Context document for Claude AI - Last updated: August 2026 (0.32.6)
+> Context document for Claude AI - Last updated: September 2026 (0.32.7)
 
 ## Project Vision
 
@@ -10,7 +10,7 @@
 
 ---
 
-## Current Version: 0.32.6 (Beta) — SurrealDB 3.2+ required
+## Current Version: 0.32.7 (Beta) — SurrealDB 3.2+ required
 
 ### Branch Strategy
 
@@ -18,6 +18,33 @@
 | ------ | ---------- | ----------- | ------------------------------- |
 | `main` | **3.2.4**  | 0.32.x      | Active development              |
 | `v2`   | **2.6.5**  | 0.21.x      | LTS (security & bug fixes only) |
+
+### What's New in 0.32.7
+
+Two ORM fixes, both from #169 (#174).
+
+- **`ForeignKey` values were never coerced to `RecordId`** — a `ForeignKey` holds a
+  `"table:id"` string in Python, and nothing converted it at the wire boundary, so a
+  `record<>` column rejected the write and a filter compared a string against a record
+  value, returning `[]` for a row that demonstrably existed. Every write path
+  (`save`, `merge`, `update`, `bulk_update`, `upsert`, `bulk_upsert`) and every
+  whole-record lookup (`exact`, `in`, `not_in`, incl. inside `Q`) now converts. Four
+  interchangeable forms: model instance, `"table:id"`, bare ID, `RecordId`. String
+  lookups, `isnull` and explicit `$var` references stay uncoerced by design.
+  **The aliased case was the dangerous one:** the write path resolved aliases but the
+  read path keyed off the Python field name, so an aliased FK was *written* as a record
+  link and *filtered* as a string — a wrong answer, not an error. `get_foreign_key_columns()`
+  now maps each FK under both its field name and its alias.
+  Still open, pre-existing: filtering by the *Python* field name on an aliased model emits
+  `author = ...` rather than the real column `author_id`.
+- **`on_delete` generated invalid DDL** — Django's vocabulary passed through verbatim, but
+  SurrealDB takes `CASCADE | UNSET | REJECT | IGNORE | THEN`. `AddField` / `AlterField` map
+  through `on_delete_to_surql()` (`SET_NULL` → `UNSET`, `PROTECT` → `REJECT`). Django
+  literals remain the API; both vocabularies accepted.
+- **New public API** — `instance.record_id` (the `Model.pk` analog, returning a `RecordId`
+  for binding against `record<>` columns in `raw_query()`), plus `to_record_id()`,
+  `record_link_to_str()` and `get_foreign_key_columns()`. The unsaved-instance guard lives in
+  `record_link_to_str()`, which is therefore no longer total — it can raise.
 
 ### What's New in 0.32.6
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,61 @@ Both branches receive automated daily security monitoring from `main` (GitHub Ac
 
 ---
 
+## What's New in 0.32.7
+
+**Bug fix release** — foreign key values never reached the database as record links, and
+Django's `on_delete` vocabulary generated invalid DDL. Both were reported in #169.
+
+- **`ForeignKey` values are coerced to `RecordId` (#169, #174).** A `ForeignKey` holds a
+  `"table:id"` string in Python, but nothing converted it at the wire boundary — so a
+  `record<>` column rejected the write, and a filter compared a string against a record
+  value and quietly returned nothing:
+
+  ```python
+  # Before: rejected — a record<fk_authors> column will not take a string
+  await Article(title="Hello", author="fk_authors:alice").save()
+  # Before: the row exists, yet the filter matches nothing
+  await Article.objects().filter(author="fk_authors:alice").exec()  # []
+  ```
+
+  Every write path (`save`, `merge`, `update`, `bulk_update`, `upsert`, `bulk_upsert`) and
+  every whole-record lookup (`exact`, `in`, `not_in`, including inside `Q`) now converts the
+  value. Four interchangeable forms are accepted, mixable within one collection:
+
+  ```python
+  Article(author=alice)                                   # model instance
+  Article(author="fk_authors:alice")                      # full "table:id"
+  Article(author="alice")                                 # bare ID, qualified via the field
+  Article(author=RecordId(table="fk_authors", id="alice"))
+
+  Article.objects().filter(author__in=[alice, "bob", RecordId(...)])
+  ```
+
+  String lookups (`contains`, `startswith`, `regex`, ...), `isnull`, and explicit `$var`
+  references bound via `.variables()` are deliberately left uncoerced.
+
+- **Aliased foreign keys are filtered correctly.** The worst of the three defects, because it
+  returned a *wrong answer* rather than an error: an aliased `ForeignKey` was written as a
+  record link but filtered as a plain string, so the query came back empty with nothing to
+  signal why. `get_foreign_key_columns()` now resolves a foreign key under its database
+  column name too.
+
+- **`on_delete` maps to SurrealDB's vocabulary.** Django's literals passed through verbatim
+  into DDL, which SurrealDB rejects — it takes `CASCADE | UNSET | REJECT | IGNORE | THEN`.
+  `SET_NULL` → `UNSET`, `PROTECT` → `REJECT`, native keywords unchanged. The Django literals
+  remain the API; both vocabularies are accepted.
+
+- **Clearer error on an unsaved reference.** Assigning an unsaved instance reported
+  `Input should be a valid string`; it now raises `cannot reference an unsaved Author; save
+  it first`. The write and filter paths previously bound the model object straight into the
+  query — they raise now too.
+
+- **New:** `instance.record_id`, the reserved record-identity property (the `Model.pk`
+  analog), returning a `RecordId` ready to bind against a `record<>` column in `raw_query()`.
+  Plus the `to_record_id()`, `record_link_to_str()` and `get_foreign_key_columns()` helpers.
+
+---
+
 ## What's New in 0.32.6
 
 **Bug fix release** — a CBOR decoding bug in the SDK, a migration operation that never did

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,13 @@ Two release lines are actively maintained, one per SurrealDB major version:
 
 | Version     | SurrealDB   | Branch | Supported          |
 | ----------- | ----------- | ------ | ------------------ |
-| **0.30.x+** | >= 3.0      | `main` | :white_check_mark: |
-| **0.20.x**  | 2.6.x       | `v2`   | :white_check_mark: |
-| < 0.20.x    | -           | -      | :x:                |
+| **0.32.x**  | >= 3.2      | `main` | :white_check_mark: |
+| **0.21.x**  | 2.6.x       | `v2`   | :white_check_mark: |
+| < 0.21.x    | -           | -      | :x:                |
+
+`main` requires **SurrealDB 3.2+** as of ORM 0.32.0; 3.1.x and earlier are not
+supported there. The `v2` line stays on SurrealDB 2.6.x and receives security
+and bug fixes only.
 
 ## Versioning Scheme
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surrealdb-orm"
-version = "0.32.6"
+version = "0.32.7"
 description = "SurrealDB ORM as 'DJango style' for Python with async support. Works with pydantic validation."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/surreal_orm/__init__.py
+++ b/src/surreal_orm/__init__.py
@@ -191,4 +191,4 @@ __all__ = [
     "retry_on_conflict",
 ]
 
-__version__ = "0.32.6"
+__version__ = "0.32.7"

--- a/src/surreal_sdk/__init__.py
+++ b/src/surreal_sdk/__init__.py
@@ -75,7 +75,7 @@ from .types import (
     ResponseStatus,
 )
 
-__version__ = "0.32.6"
+__version__ = "0.32.7"
 __all__ = [
     # Connections
     "BaseSurrealConnection",

--- a/src/surreal_sdk/pyproject.toml
+++ b/src/surreal_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surreal-sdk"
-version = "0.32.6"
+version = "0.32.7"
 description = "Custom Python SDK for SurrealDB with HTTP and WebSocket support. No dependency on official surrealdb package."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -271,7 +271,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -1594,7 +1594,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb-orm"
-version = "0.32.6"
+version = "0.32.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release PR for **0.32.7**, a patch release covering the two `ForeignKey` defects reported in #169 and fixed by #174 (merged as `d35ea98`).

## Contents

- Version strings bumped to `0.32.7` — `pyproject.toml`, `src/surreal_sdk/pyproject.toml`, and both `__version__` declarations.
- `CHANGELOG.md` — full `[0.32.7]` entry.
- README "What's New in 0.32.7" section.
- `CLAUDE.md` — current-version header and matching section.

No library code changes: #174 already landed on `main`.

## What ships

- `ForeignKey` values are coerced to `RecordId` across every write path and every whole-record filter lookup, so `record<>` columns accept the writes and filters match.
- Aliased foreign keys resolve under their database column name — the defect that returned a wrong answer rather than an error.
- Django's `on_delete` maps to SurrealDB's vocabulary (`SET_NULL` → `UNSET`, `PROTECT` → `REJECT`).
- New public API: `instance.record_id`, `to_record_id()`, `record_link_to_str()`, `get_foreign_key_columns()`.

## Verification

Unit suite green, mypy strict clean (66 files), ruff clean. The dynamic version tests pass against the new number.

## Release mechanics

**Merge this with squash, keeping the subject `chore(release): bump version to 0.32.7`.** That subject is what `tag-release.yml` gates on; it then creates `v0.32.7` with `PAT_TOKEN` — required, since a tag pushed with `GITHUB_TOKEN` would not trigger `publish.yml` — which publishes to PyPI. If the subject is altered, no tag fires and the version has to be tagged by hand.