### PR TITLE
docs(security): correct the supported versions table

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,13 @@ Two release lines are actively maintained, one per SurrealDB major version:
 
 | Version     | SurrealDB   | Branch | Supported          |
 | ----------- | ----------- | ------ | ------------------ |
-| **0.30.x+** | >= 3.0      | `main` | :white_check_mark: |
-| **0.20.x**  | 2.6.x       | `v2`   | :white_check_mark: |
-| < 0.20.x    | -           | -      | :x:                |
+| **0.32.x**  | >= 3.2      | `main` | :white_check_mark: |
+| **0.21.x**  | 2.6.x       | `v2`   | :white_check_mark: |
+| < 0.21.x    | -           | -      | :x:                |
+
+`main` requires **SurrealDB 3.2+** as of ORM 0.32.0; 3.1.x and earlier are not
+supported there. The `v2` line stays on SurrealDB 2.6.x and receives security
+and bug fixes only.
 
 ## Versioning Scheme
 


### PR DESCRIPTION
`SECURITY.md` still advertised the version lines as they stood at 0.30. Both rows had drifted:

| | Before | After |
|---|---|---|
| `main` | `0.30.x+` — SurrealDB `>= 3.0` | `0.32.x` — SurrealDB `>= 3.2` |
| `v2` | `0.20.x` | `0.21.x` |
| unsupported | `< 0.20.x` | `< 0.21.x` |

**The SurrealDB floor was the consequential half.** The table told readers that 3.0 was enough for the current `main` line — untrue since 0.32.0, which dropped 3.1.x and earlier. Someone reading the security policy to decide whether their deployment was on a supported combination would have got the wrong answer.

Values verified against the branches rather than the docs: `main` is `0.32.6` with `.surrealdb-version` = `3.2.4`, `v2` is `0.21.3` with `2.6.5`. Added a sentence spelling out the 3.2+ requirement and the `v2` security-and-bug-fixes-only scope.

**No version bump**, deliberately — this is a documentation correction and must not trigger the release pipeline. Kept separate from the 0.32.7 release PR (#177) for the same reason.

Note: CI's path filter (`src/**`, `tests/**`, `devops/**`, `pyproject.toml`, `Makefile`) does not cover `SECURITY.md`, so no test run is expected on this PR.