### PR TITLE
chore(release): bump version to 0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,109 @@ and adheres to [SemVer](https://semver.org/) versioning.
 
 ---
 
+## [0.33.0] - 2026-09-05
+
+**Migration introspection release.** Foreign keys, record references, virtual graph
+fields and nullability now survive the trip from a model to a `DEFINE FIELD`
+statement — and `on_delete` becomes something SurrealDB enforces rather than a
+decorative annotation.
+
+### Fixed — Migrations
+
+- **Relation markers never reached the schema state (#170).** `_introspect_field`
+  did not unwrap `Annotated`, so every `ForeignKey` and `ReferencesField` fell
+  through `_map_type` to `any`. `FieldState`, the operations and the DB-side
+  `define_parser` all already carried `reference` / `on_delete`; this one producer
+  was the only thing that never filled them:
+
+  ```python
+  class Post(BaseSurrealModel):
+      author: ForeignKey("User")
+      citations: ReferencesField["posts"]
+
+  # Before: DEFINE FIELD author ON posts TYPE any;
+  # After:  DEFINE FIELD author ON posts TYPE option<record<users>> REFERENCE ON DELETE CASCADE;
+  #         DEFINE FIELD citations ON posts TYPE option<array<record<posts>>> REFERENCE;
+  ```
+
+  The target model name is resolved to the model's configured `table_name`; an
+  unresolvable target stays an untyped `record` rather than an invented table.
+
+- **`ManyToMany` and `Relation` were emitted as `any` columns (#170).** They are
+  virtual — their own core schema says `surreal_type: "virtual"` — and graph edges
+  live in their own tables, so they now define no column at all.
+
+- **Nullability was dropped at the diff boundary (#170).** `AddField` / `AlterField`
+  had no `nullable` parameter and never wrapped `option<>`, so only `define_table()`
+  preserved optionality and generated migrations silently lost it. Both operations
+  take `nullable` now; `AlterField` also takes `previous_nullable` so a rollback
+  restores the optionality the column actually had.
+
+- **Rollbacks silently dropped clauses.** `AlterField.backwards()` emitted no
+  `REFERENCE`, and the diff never forwarded `previous_flexible` / `previous_readonly`,
+  so rolling back a foreign-key alter disabled referential integrity without an error.
+
+- **`schema_diff()` proposed the same operation forever.** The model side stored
+  Django's `SET_NULL` while the database reported SurrealDB's `UNSET`, and
+  `FieldState.__eq__` compares raw strings — so every non-`CASCADE` strategy diffed
+  on every run and applying it never converged. `FieldState` now stores the SurrealDB
+  keyword, the spelling the database reports back.
+
+- **`inspectdb` turned a scalar foreign key into an array.** `ModelCodeGenerator`
+  mapped every `reference=True` field to `ReferencesField`, whose type is
+  `array<record<T>>`, so a generated model re-introspected into a destructive
+  scalar→array `AlterField` on a schema nobody had edited. Arity now decides:
+  `array<record<T>>` keeps `ReferencesField`, a scalar `record<T>` generates
+  `ForeignKey`.
+
+- **`option<>` wrapping misread unions.** Any type containing `|` was treated as
+  already optional, so `int | string` with `nullable=True` produced a non-nullable
+  column. Detection now mirrors `parse_define_field`: `option<`, `| null`, `none |`.
+
+- **A union-wrapped marker was invisible.** `author: ForeignKey("User") | None`
+  regressed to `any`, because the annotation's origin is a union rather than
+  `Annotated` and Pydantic does not lift metadata out of a union member.
+
+### Added
+
+- **`OnDelete`** — public type alias for the accepted strategies, exported from
+  `surreal_orm` and `surreal_orm.fields`. `ForeignKey` now accepts SurrealDB's own
+  vocabulary (`UNSET`, `REJECT`, `IGNORE`) alongside Django's (`CASCADE`,
+  `SET_NULL`, `PROTECT`).
+- **`AddField.from_field_state()` / `AlterField.from_field_states()`** — the single
+  place a `FieldState` becomes operation keyword arguments, replacing four
+  hand-copied argument lists. That duplication is what produced the fourth defect of
+  #170 in the first place.
+
+### Changed
+
+- **`on_delete` is now enforced by SurrealDB.** It used to be decorative: the column
+  landed as `any` with no `REFERENCE` clause, so nothing was applied. A `ForeignKey`
+  left at the default `on_delete="CASCADE"` now means deleting the referenced record
+  deletes the referencing one.
+
+  ```python
+  author: ForeignKey("User")                       # ON DELETE CASCADE — now enforced
+  author: ForeignKey("User", on_delete="IGNORE")   # opt out: nothing cascades
+  ```
+
+- `ON DELETE THEN` is no longer accepted. SurrealDB requires
+  `ON DELETE THEN <expression>` and no part of a field definition carries one, so the
+  bare keyword only produced DDL that fails mid-migration.
+
+### Notes
+
+- **Expect one-time `REMOVE FIELD` statements on the first diff after upgrading.**
+  `ManyToMany` / `Relation` previously introspected as real `any` columns, so existing
+  databases physically carry those `DEFINE FIELD` entries. The first
+  `schema_diff` / `makemigrations` after upgrading emits `REMOVE FIELD groups ON users;`
+  and friends, alongside `any -> option<record<...>>` `AlterField` operations. No data
+  is lost — the ORM never read those columns — but the statements are auto-generated
+  and worth reviewing rather than applying blind.
+- Foreign keys previously introspected as `any` while the database reported
+  `record<...>`, so `schema_diff()` proposed a phantom `AlterField` on every run. That
+  is gone; an integration test asserts the round trip is stable.
+
 ## [0.32.7] - 2026-09-01
 
 **Bug fix release.** Two independent ORM fixes, both reported in #169: foreign

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # SurrealDB-ORM - Development Context
 
-> Context document for Claude AI - Last updated: September 2026 (0.32.7)
+> Context document for Claude AI - Last updated: September 2026 (0.33.0)
 
 ## Project Vision
 
@@ -10,14 +10,61 @@
 
 ---
 
-## Current Version: 0.32.7 (Beta) — SurrealDB 3.2+ required
+## Current Version: 0.33.0 (Beta) — SurrealDB 3.2+ required
 
 ### Branch Strategy
 
 | Branch | SurrealDB  | ORM Version | Status                          |
 | ------ | ---------- | ----------- | ------------------------------- |
-| `main` | **3.2.4**  | 0.32.x      | Active development              |
+| `main` | **3.2.4**  | 0.33.x      | Active development              |
 | `v2`   | **2.6.5**  | 0.21.x      | LTS (security & bug fixes only) |
+
+### What's New in 0.33.0
+
+Migration introspection (#170). Relation fields survive the trip from a model to a
+`DEFINE FIELD`, and `on_delete` becomes something SurrealDB enforces.
+
+- **Relation markers never reached the schema state** — `_introspect_field` did not unwrap
+  `Annotated`, so every `ForeignKey`/`ReferencesField` fell through `_map_type` to `any`.
+  `FieldState`, the operations and the DB-side `define_parser` all already carried
+  `reference`/`on_delete`; this one producer was the only thing that never filled them. They
+  now introspect as `option<record<target>>` and `option<array<record<target>>>`, the target
+  resolved to the model's configured `table_name` (unresolvable → untyped `record`, never an
+  invented table).
+- **`ManyToMany`/`Relation` were emitted as `any` columns** — virtual by their own core
+  schema (`surreal_type: "virtual"`), excluded from DDL entirely now.
+- **Nullability was dropped at the diff boundary** — `AddField`/`AlterField` had no `nullable`
+  parameter, so only `define_table()` wrapped `option<>` and generated migrations silently lost
+  optionality. `AlterField` also gained `previous_nullable`/`previous_reference`/
+  `previous_on_delete`; without them a rollback dropped the `REFERENCE` clause and with it
+  referential integrity, and the diff never forwarded `previous_flexible`/`previous_readonly`.
+- **`schema_diff()` never converged for non-`CASCADE`** — the model stored `SET_NULL` while the
+  database reported `UNSET`, and `FieldState.__eq__` compares raw strings. `FieldState` stores
+  the SurrealDB keyword now. `CASCADE` — identical in both vocabularies — was the only case the
+  tests had covered, which is why this survived #169.
+- **`inspectdb` round-tripped a scalar FK into an array** — `ModelCodeGenerator` mapped every
+  `reference=True` field to `ReferencesField` (`array<record<T>>`), so a generated model
+  re-introspected into a destructive scalar→array `AlterField` on an unedited schema. Arity
+  decides now. A repo test asserted the defective mapping and was corrected.
+- **`option<>` wrapping misread unions** — any `|` counted as already-optional, so
+  `int | string` + `nullable=True` gave a non-nullable column; detection mirrors
+  `parse_define_field` (`option<`, `| null`, `none |`).
+- **A union-wrapped marker was invisible** — `ForeignKey("User") | None` regressed to `any`:
+  the origin is a union, not `Annotated`, and Pydantic does not lift metadata out of a union
+  member into `FieldInfo.metadata`.
+- **New public API** — `OnDelete` (accepts SurrealDB's `UNSET`/`REJECT`/`IGNORE` alongside
+  Django's), plus `AddField.from_field_state()` / `AlterField.from_field_states()`, the single
+  place a `FieldState` becomes operation kwargs. Four hand-copied kwarg lists are what produced
+  defect 4 of #170; that shape is gone.
+- **BEHAVIOUR CHANGE — `on_delete` is enforced now.** It was decorative (the column was `any`
+  with no `REFERENCE`). A `ForeignKey` at the default `CASCADE` means deleting the target
+  deletes the referencing record; `on_delete="IGNORE"` opts out. **On upgrade**, the first
+  `schema_diff`/`makemigrations` also emits one-time `REMOVE FIELD` for the `ManyToMany`/
+  `Relation` columns existing databases physically carry — no data loss, but review rather than
+  apply blind.
+- **Not backported to `v2`** — the `REFERENCE` clause is a SurrealDB 3.0 feature and
+  `ReferencesField` does not exist on that branch. The virtual-field and nullability halves are
+  real defects on `v2` (0.21.4) and remain open there as separate work.
 
 ### What's New in 0.32.7
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,55 @@ Both branches receive automated daily security monitoring from `main` (GitHub Ac
 
 ---
 
+## What's New in 0.33.0
+
+**Migration introspection release (#170).** Relation fields now survive the trip from a
+model to a `DEFINE FIELD` statement, and `on_delete` becomes something SurrealDB
+enforces rather than a decorative annotation.
+
+- **`ForeignKey` and `ReferencesField` introspected as `any` (#170)** — `_introspect_field`
+  never unwrapped `Annotated`, so the record link was lost entirely. `FieldState`, the
+  operations and the DB-side parser all already carried `reference` / `on_delete`; this one
+  producer was the only thing that never filled them.
+
+  ```python
+  class Post(BaseSurrealModel):
+      author: ForeignKey("User")
+      citations: ReferencesField["posts"]
+
+  # Before: DEFINE FIELD author ON posts TYPE any;
+  # After:  DEFINE FIELD author ON posts TYPE option<record<users>> REFERENCE ON DELETE CASCADE;
+  #         DEFINE FIELD citations ON posts TYPE option<array<record<posts>>> REFERENCE;
+  ```
+
+- **`ManyToMany` / `Relation` emitted real columns** — they are virtual (graph edges live in
+  their own tables) and now define no column at all.
+- **Nullability stopped at the diff boundary** — `AddField` / `AlterField` had no `nullable`
+  parameter, so only `define_table()` preserved optionality and generated migrations silently
+  lost it. `AlterField` also gained `previous_nullable`, `previous_reference` and
+  `previous_on_delete`, without which a rollback quietly dropped the `REFERENCE` clause.
+- **`schema_diff()` never converged for non-`CASCADE` strategies** — the model stored Django's
+  `SET_NULL` while the database reported SurrealDB's `UNSET`, and the states compare raw
+  strings. `FieldState` now stores the keyword the database reports back.
+- **`inspectdb` turned a scalar foreign key into an array** — every `reference=True` field was
+  mapped to `ReferencesField` (`array<record<T>>`), so a generated model re-introspected into a
+  destructive scalar→array `AlterField`. Arity now decides: scalar `record<T>` → `ForeignKey`.
+
+**New:** `OnDelete`, a public type alias exported from `surreal_orm` — `ForeignKey` accepts
+SurrealDB's vocabulary (`UNSET`, `REJECT`, `IGNORE`) alongside Django's. Plus
+`AddField.from_field_state()` / `AlterField.from_field_states()`, the single place a
+`FieldState` becomes operation arguments.
+
+> **Behaviour change.** `on_delete` used to be decorative — the column landed as `any` with no
+> `REFERENCE` clause, so nothing was applied. SurrealDB enforces it now, so a `ForeignKey` left
+> at the default `on_delete="CASCADE"` means deleting the referenced record deletes the
+> referencing one. Use `on_delete="IGNORE"` for a link that should stay decorative.
+>
+> **On upgrading**, the first `schema_diff` / `makemigrations` emits one-time `REMOVE FIELD`
+> statements for the `ManyToMany` / `Relation` columns existing databases physically carry, plus
+> `any -> option<record<...>>` alters. No data is lost — the ORM never read those columns — but
+> review the generated migration rather than applying it blind.
+
 ## What's New in 0.32.7
 
 **Bug fix release** — foreign key values never reached the database as record links, and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Two release lines are actively maintained, one per SurrealDB major version:
 
 | Version     | SurrealDB   | Branch | Supported          |
 | ----------- | ----------- | ------ | ------------------ |
-| **0.32.x**  | >= 3.2      | `main` | :white_check_mark: |
+| **0.33.x**  | >= 3.2      | `main` | :white_check_mark: |
 | **0.21.x**  | 2.6.x       | `v2`   | :white_check_mark: |
 | < 0.21.x    | -           | -      | :x:                |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,6 +34,7 @@
 | 0.30.0  | Released | SurrealDB 3.0 Compatibility                                |
 | 0.31.0  | Released | Phase 2b: GraphQL, Bearer, UPSERT, REBUILD INDEX           |
 | 0.32.0  | Released | SurrealDB 3.2+ required; `Subquery` `LET` prelude          |
+| 0.33.0  | Released | Migration introspection: relations, virtual fields, null   |
 
 ---
 
@@ -1851,10 +1852,11 @@ await User.objects().bulk_upsert(
 | 0.30.0  | SurrealDB 3.0    | Refresh tokens, Record references, DEFINE API (Done)                          |
 | 0.31.0  | SurrealDB 3.0    | Bearer access, GraphQL config, REBUILD INDEX, UPSERT ON DUPLICATE (Done)      |
 | 0.32.0  | SurrealDB 3.2    | **Breaking:** requires 3.2+; `Subquery` hoisted into a `LET` prelude (Done)   |
-| 0.33.0  | Graph Power      | Recursive traversal, shortest path, path collection                           |
-| 0.34.0  | ML & Data        | SurrealML inference, JSONL import/export, DB dump/restore                     |
-| 0.35.0  | Advanced Queries | Nested path queries (`[WHERE ...]`, `.?`), destructuring                      |
-| 0.36.0  | File Storage     | DEFINE BUCKET, FileField/ImageField, SDK bucket CRUD, upload/download helpers |
+| 0.33.0  | Migrations       | Relation markers, virtual fields, nullability in introspection (Done)         |
+| 0.34.0  | Graph Power      | Recursive traversal, shortest path, path collection                           |
+| 0.35.0  | ML & Data        | SurrealML inference, JSONL import/export, DB dump/restore                     |
+| 0.36.0  | Advanced Queries | Nested path queries (`[WHERE ...]`, `.?`), destructuring                      |
+| 0.37.0  | File Storage     | DEFINE BUCKET, FileField/ImageField, SDK bucket CRUD, upload/download helpers |
 
 ---
 
@@ -1943,12 +1945,12 @@ await User.objects().bulk_upsert(
 | DEFINE CONFIG GRAPHQL         | 0.31.0  | Medium   | Done    | Migrations           |
 | Bearer access (TYPE BEARER)   | 0.31.0  | High     | Done    | Auth + SDK           |
 | UPSERT ON DUPLICATE KEY       | 0.31.0  | Medium   | Done    | QuerySet             |
-| DEFINE BUCKET (migrations)    | 0.35.0  | High     | Planned | Migrations           |
-| BucketBackend enum + parser   | 0.35.0  | High     | Planned | DEFINE BUCKET        |
-| FileField / ImageField        | 0.35.0  | High     | Planned | DEFINE BUCKET        |
-| SDK bucket CRUD methods       | 0.35.0  | High     | Planned | SDK                  |
-| ORM upload/download helpers   | 0.35.0  | Medium   | Planned | FileField + SDK      |
-| Bucket introspection          | 0.35.0  | Medium   | Planned | DatabaseIntrospector |
+| DEFINE BUCKET (migrations)    | 0.37.0  | High     | Planned | Migrations           |
+| BucketBackend enum + parser   | 0.37.0  | High     | Planned | DEFINE BUCKET        |
+| FileField / ImageField        | 0.37.0  | High     | Planned | DEFINE BUCKET        |
+| SDK bucket CRUD methods       | 0.37.0  | High     | Planned | SDK                  |
+| ORM upload/download helpers   | 0.37.0  | Medium   | Planned | FileField + SDK      |
+| Bucket introspection          | 0.37.0  | Medium   | Planned | DatabaseIntrospector |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surrealdb-orm"
-version = "0.32.8"
+version = "0.33.0"
 description = "SurrealDB ORM as 'DJango style' for Python with async support. Works with pydantic validation."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/surreal_orm/__init__.py
+++ b/src/surreal_orm/__init__.py
@@ -193,4 +193,4 @@ __all__ = [
     "retry_on_conflict",
 ]
 
-__version__ = "0.32.8"
+__version__ = "0.33.0"

--- a/src/surreal_sdk/__init__.py
+++ b/src/surreal_sdk/__init__.py
@@ -75,7 +75,7 @@ from .types import (
     ResponseStatus,
 )
 
-__version__ = "0.32.8"
+__version__ = "0.33.0"
 __all__ = [
     # Connections
     "BaseSurrealConnection",

--- a/src/surreal_sdk/pyproject.toml
+++ b/src/surreal_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surreal-sdk"
-version = "0.32.8"
+version = "0.33.0"
 description = "Custom Python SDK for SurrealDB with HTTP and WebSocket support. No dependency on official surrealdb package."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -271,7 +271,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -1594,7 +1594,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb-orm"
-version = "0.32.8"
+version = "0.33.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release PR for the migration-introspection work merged in #179 (fixes #170).

**Minor, not patch.** The release adds public API and changes behaviour a user can observe in their database, so `0.32.9` would understate it:

- New public API: `OnDelete` (exported from `surreal_orm` and `surreal_orm.fields`), `AddField.from_field_state()`, `AlterField.from_field_states()`.
- **Behaviour change:** `on_delete` used to be decorative — the column landed as `any` with no `REFERENCE` clause, so nothing was applied. SurrealDB enforces it now, so a `ForeignKey` left at the default `on_delete="CASCADE"` means deleting the referenced record deletes the referencing one. `on_delete="IGNORE"` opts out.
- Foreign-key columns change type from `any` to `option<record<target>>`; `ManyToMany` / `Relation` stop emitting a column entirely.

### Files updated (release checklist)

| File | Change |
| --- | --- |
| `pyproject.toml` | `version` → 0.33.0 |
| `src/surreal_sdk/pyproject.toml` | `version` → 0.33.0 |
| `src/surreal_orm/__init__.py` | `__version__` → 0.33.0 |
| `src/surreal_sdk/__init__.py` | `__version__` → 0.33.0 |
| `uv.lock` | relocked |
| `CHANGELOG.md` | new `[0.33.0]` entry (Fixed / Added / Changed / Notes) |
| `README.md` | "What's New in 0.33.0" |
| `CLAUDE.md` | header date/version, `## Current Version`, branch table, "What's New" |
| `SECURITY.md` | supported line **0.32.x → 0.33.x** (the minor moved) |
| `docs/roadmap.md` | 0.33.0 marked Released; Graph Power and later shift one minor |

### Roadmap shift

`0.33.0` was earmarked for Graph Power, so it and everything after it move down one: Graph Power → 0.34.0, ML & Data → 0.35.0, Advanced Queries → 0.36.0, File Storage → 0.37.0.

While doing that: the Implementation Priority table's six File Storage rows pointed at `0.35.0`, already one minor adrift from the Future Versions table *before* this change. They now point at `0.37.0` so the two tables agree — a pre-existing inconsistency, corrected rather than made worse.

### Upgrade note (carried from the CHANGELOG)

The first `schema_diff` / `makemigrations` after upgrading emits one-time `REMOVE FIELD` statements for the `ManyToMany` / `Relation` columns existing databases physically carry, alongside `any -> option<record<...>>` alters. No data is lost — the ORM never read those columns — but the generated migration is worth reviewing rather than applying blind.

### Verification

`ruff format --check`, `ruff check`, `mypy src/`, unit suite and the integration suite against SurrealDB 3.2.4 all pass locally; version strings verified consistent across all four files and `uv.lock`, with no `0.32.8` remaining outside historical doc sections.

### Not backported to `v2`

`REFERENCE` is a SurrealDB 3.0 feature and `ReferencesField` does not exist on that branch, so this does not port as-is. The virtual-field and nullability halves *are* real defects on `v2` (0.21.4) and remain open there as separate work — see the comment on #179.