### PR TITLE
fix(cli): diff makemigrations against the live schema, not an empty one

### DIFF
--- a/src/surreal_orm/cli/commands.py
+++ b/src/surreal_orm/cli/commands.py
@@ -27,6 +27,32 @@ def run_async(coro: Any) -> Any:
     return asyncio.get_event_loop().run_until_complete(coro)
 
 
+async def _introspect_database(ctx: Any) -> Any:
+    """
+    Read the live database schema into a ``SchemaState``.
+
+    ``makemigrations`` needs to know what the database already has, otherwise it
+    diffs against nothing and re-emits the whole schema every run (#171).
+
+    Args:
+        ctx: The click context carrying the connection settings
+
+    Returns:
+        SchemaState describing the current database schema
+    """
+    from ..connection_manager import SurrealDBConnectionManager
+    from ..migrations.db_introspector import DatabaseIntrospector
+
+    SurrealDBConnectionManager.set_connection(
+        url=ctx.obj["url"],
+        user=ctx.obj["user"],
+        password=ctx.obj["password"],
+        namespace=ctx.obj["namespace"],
+        database=ctx.obj["database"],
+    )
+    return await DatabaseIntrospector().introspect()
+
+
 # Only define CLI if click is available
 if click is not None:
 
@@ -91,12 +117,18 @@ if click is not None:
     @click.option("--name", "-n", required=True, help="Migration name")  # type: ignore[untyped-decorator]
     @click.option("--empty", is_flag=True, help="Create empty migration for manual editing")  # type: ignore[untyped-decorator]
     @click.option("--models", "-m", multiple=True, help="Specific model modules to include")  # type: ignore[untyped-decorator]
+    @click.option(  # type: ignore[untyped-decorator]
+        "--from-db/--no-from-db",
+        default=True,
+        help="Diff against the live database schema (default) instead of an empty schema",
+    )
     @click.pass_context  # type: ignore[untyped-decorator]
     def makemigrations(
         ctx: click.Context,
         name: str,
         empty: bool,
         models: tuple[str, ...],
+        from_db: bool,
     ) -> None:
         """Generate migration files from model changes."""
         from ..migrations.generator import MigrationGenerator, generate_empty_migration
@@ -127,9 +159,22 @@ if click is not None:
             click.echo("No models found. Register models by importing them.")
             sys.exit(1)
 
-        # For now, assume current state is empty (first migration)
-        # In a full implementation, we'd load current state from database
-        current_state = SchemaState()
+        # The current state used to be an empty SchemaState, so every table was
+        # re-emitted on every run (#171). It comes from the live database now.
+        if from_db:
+            try:
+                current_state = run_async(_introspect_database(ctx))
+            except Exception as e:
+                # Falling back to an empty schema here would silently reintroduce
+                # the very bug this replaces, so fail and name the way out.
+                click.echo(f"Error reading the database schema: {e}", err=True)
+                click.echo(
+                    "Pass --no-from-db to generate against an empty schema instead (a first migration, or working offline).",
+                    err=True,
+                )
+                sys.exit(1)
+        else:
+            current_state = SchemaState()
 
         # Compute differences
         operations = current_state.diff(desired_state)

--- a/src/surreal_orm/migrations/state.py
+++ b/src/surreal_orm/migrations/state.py
@@ -12,6 +12,30 @@ if TYPE_CHECKING:
     from .operations import CreateIndex, Operation
 
 
+def _effective_permissions(permissions: dict[str, str] | None) -> dict[str, str]:
+    """
+    Drop permission entries that only restate SurrealDB's default.
+
+    A table defined without a ``PERMISSIONS`` clause is reported back by
+    ``INFO FOR DB`` as ``{"select": "NONE", "create": "NONE", ...}`` — those are
+    the server's defaults, not a configured value. Comparing the raw dicts made a
+    database-read state differ from a model state that configures nothing, so the
+    diff re-emitted ``CreateTable`` for every table on every run (#171).
+
+    Normalising both sides also makes an explicit ``NONE`` equal to omitting the
+    clause, which is what it means.
+
+    Args:
+        permissions: The permissions mapping, or None
+
+    Returns:
+        The mapping without its default-valued entries
+    """
+    if not permissions:
+        return {}
+    return {action: rule for action, rule in permissions.items() if str(rule).strip().upper() != "NONE"}
+
+
 @dataclass
 class FieldState:
     """
@@ -445,7 +469,7 @@ class SchemaState:
                 if (
                     current_table.schema_mode != target_table.schema_mode
                     or current_table.changefeed != target_table.changefeed
-                    or current_table.permissions != target_table.permissions
+                    or _effective_permissions(current_table.permissions) != _effective_permissions(target_table.permissions)
                     or current_table.view_query != target_table.view_query
                     or current_table.relation_in != target_table.relation_in
                     or current_table.relation_out != target_table.relation_out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -143,7 +143,12 @@ class TestMakeMigrationsCommand:
         assert "No models found" in result.output or result.exit_code != 0
 
     def test_makemigrations_with_model(self, runner: "CliRunner", cli_command, temp_migrations_dir: Path) -> None:
-        """Test makemigrations detects model changes."""
+        """Test makemigrations detects model changes.
+
+        Uses ``--no-from-db`` because this test has no database: since #171 the
+        default reads the current schema from the live server, and the point
+        here is only that a model turns into operations.
+        """
         from src.surreal_orm.model_base import BaseSurrealModel, clear_model_registry
 
         clear_model_registry()
@@ -162,6 +167,7 @@ class TestMakeMigrationsCommand:
                 "makemigrations",
                 "--name",
                 "create_user",
+                "--no-from-db",
             ],
         )
         assert result.exit_code == 0
@@ -170,6 +176,121 @@ class TestMakeMigrationsCommand:
 
         # Clean up
         clear_model_registry()
+
+
+class TestMakeMigrationsAgainstDatabase:
+    """Issue #171 — makemigrations diffed against an empty SchemaState.
+
+    It re-emitted every table on every run. The current state now comes from the
+    live database, so an already-migrated schema produces no operations.
+    """
+
+    @patch("src.surreal_orm.cli.commands.run_async")
+    def test_an_already_migrated_schema_produces_no_operations(
+        self, mock_run_async, runner: "CliRunner", cli_command, temp_migrations_dir: Path
+    ) -> None:
+        """A table the database already has is not re-emitted."""
+        from src.surreal_orm.migrations.introspector import introspect_models
+        from src.surreal_orm.model_base import BaseSurrealModel, clear_model_registry
+
+        clear_model_registry()
+
+        class MigratedUser(BaseSurrealModel):
+            id: str | None = None
+            name: str
+
+        # The database reports exactly what the models describe.
+        mock_run_async.side_effect = mock_run_async_factory(introspect_models())
+
+        result = runner.invoke(
+            cli_command,
+            ["--migrations-dir", str(temp_migrations_dir), "makemigrations", "--name", "noop"],
+        )
+
+        clear_model_registry()
+        assert result.exit_code == 0
+        assert "No changes detected" in result.output
+
+    @patch("src.surreal_orm.cli.commands.run_async")
+    def test_a_new_model_is_still_emitted(
+        self, mock_run_async, runner: "CliRunner", cli_command, temp_migrations_dir: Path
+    ) -> None:
+        """A model the database does not have still generates a migration."""
+        from src.surreal_orm.migrations.state import SchemaState
+        from src.surreal_orm.model_base import BaseSurrealModel, clear_model_registry
+
+        clear_model_registry()
+
+        class BrandNewThing(BaseSurrealModel):
+            id: str | None = None
+            label: str
+
+        mock_run_async.side_effect = mock_run_async_factory(SchemaState())  # empty database
+
+        result = runner.invoke(
+            cli_command,
+            ["--migrations-dir", str(temp_migrations_dir), "makemigrations", "--name", "create_thing"],
+        )
+
+        clear_model_registry()
+        assert result.exit_code == 0
+        assert "Created migration" in result.output
+
+    def test_no_from_db_skips_the_database_entirely(self, runner: "CliRunner", cli_command, temp_migrations_dir: Path) -> None:
+        """``--no-from-db`` restores the empty-state behaviour, with no connection.
+
+        This is the escape hatch for a true first migration and for offline use —
+        Django does not need a database to generate migrations either.
+        """
+        from src.surreal_orm.model_base import BaseSurrealModel, clear_model_registry
+
+        clear_model_registry()
+
+        class OfflineModel(BaseSurrealModel):
+            id: str | None = None
+            title: str
+
+        # No run_async patch: reaching the database at all would fail here.
+        result = runner.invoke(
+            cli_command,
+            [
+                "--migrations-dir",
+                str(temp_migrations_dir),
+                "makemigrations",
+                "--name",
+                "offline",
+                "--no-from-db",
+            ],
+        )
+
+        clear_model_registry()
+        assert result.exit_code == 0
+        assert "Created migration" in result.output
+
+    @patch("src.surreal_orm.cli.commands.run_async")
+    def test_an_unreachable_database_fails_loudly_and_names_the_escape_hatch(
+        self, mock_run_async, runner: "CliRunner", cli_command, temp_migrations_dir: Path
+    ) -> None:
+        """Falling back to an empty schema silently would be the bug itself."""
+        from src.surreal_orm.model_base import BaseSurrealModel, clear_model_registry
+
+        clear_model_registry()
+
+        class UnreachableModel(BaseSurrealModel):
+            id: str | None = None
+            name: str
+
+        mock_run_async.side_effect = mock_run_async_factory(exception=ConnectionError("refused"))
+
+        result = runner.invoke(
+            cli_command,
+            ["--migrations-dir", str(temp_migrations_dir), "makemigrations", "--name", "boom"],
+        )
+
+        clear_model_registry()
+        assert result.exit_code != 0
+        assert "--no-from-db" in result.output
+        assert "Created migration" not in result.output
 
 
 class TestMigrateCommand:

--- a/tests/test_issue_171_integration.py
+++ b/tests/test_issue_171_integration.py
@@ -1,0 +1,152 @@
+"""
+Integration tests for issue #171 — ``makemigrations`` diffed against an empty schema.
+
+The CLI plumbing (the ``--from-db`` flag, the error path, the empty-state fallback)
+is covered by ``tests/test_cli.py`` with a mocked database state. What only a live
+server can prove is the invariant the fix now depends on: the state read back from
+SurrealDB compares **equal** to the state introspected from the models, so an
+already-migrated schema produces no operations.
+
+That equality is exactly what #170 had to fix first. While foreign keys introspected
+as ``any`` and virtual fields produced columns, diffing against the database would
+have generated spurious operations on every run — a worse bug than the one #171
+reports.
+
+Run with: pytest -m integration tests/test_issue_171_integration.py
+"""
+
+import pytest
+
+from src import surreal_orm
+from src.surreal_orm.fields import ForeignKey, ManyToMany
+from src.surreal_orm.migrations.db_introspector import DatabaseIntrospector
+from src.surreal_orm.migrations.introspector import introspect_models
+from src.surreal_orm.migrations.operations import AddField, AlterField, CreateTable
+from src.surreal_orm.model_base import (
+    BaseSurrealModel,
+    SurrealConfigDict,
+    clear_model_registry,
+)
+from tests.conftest import SURREALDB_NAMESPACE, SURREALDB_PASS, SURREALDB_URL, SURREALDB_USER
+
+SURREALDB_DATABASE = "test_issue_171"
+
+TABLES = ["i171_articles", "i171_authors"]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_surrealdb() -> None:
+    """Point the ORM at the test database."""
+    surreal_orm.SurrealDBConnectionManager.set_connection(
+        SURREALDB_URL,
+        SURREALDB_USER,
+        SURREALDB_PASS,
+        SURREALDB_NAMESPACE,
+        SURREALDB_DATABASE,
+    )
+
+
+@pytest.fixture(autouse=True)
+async def clean_database():
+    """Drop the test tables before and after each test."""
+
+    async def cleanup() -> None:
+        client = await surreal_orm.SurrealDBConnectionManager.get_client()
+        for table in TABLES:
+            await client.query(f"REMOVE TABLE IF EXISTS {table};")
+
+    await cleanup()
+    yield
+    await cleanup()
+
+
+class I171Author(BaseSurrealModel):
+    """Target of the foreign key — a record link is the case #170 had to fix."""
+
+    model_config = SurrealConfigDict(table_name="i171_authors")
+
+    id: str | None = None
+    name: str
+
+
+class I171Article(BaseSurrealModel):
+    """Carries an optional scalar, a record link and a virtual graph relation."""
+
+    model_config = SurrealConfigDict(table_name="i171_articles")
+
+    id: str | None = None
+    title: str
+    subtitle: str | None = None
+    author: ForeignKey("I171Author")
+    shelves: ManyToMany("I171Author")
+
+
+def _operations_for(operations: list, *tables: str) -> list:
+    """Keep only the operations touching the tables under test.
+
+    The test database is shared, so other tables produce their own operations.
+    """
+    kept = []
+    for op in operations:
+        table = getattr(op, "table", None) or getattr(op, "name", None)
+        if table in tables:
+            kept.append(op)
+    return kept
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_a_migrated_schema_diffs_to_nothing() -> None:
+    """The reported symptom: every run re-created every table.
+
+    This is the comparison ``makemigrations`` now performs — the database state
+    against the model state — so an empty result is the fix.
+    """
+    await I171Author.define_table()
+    await I171Article.define_table()
+
+    current = await DatabaseIntrospector().introspect()
+    desired = introspect_models([I171Author, I171Article])
+
+    assert _operations_for(current.diff(desired), *TABLES) == []
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_an_empty_state_re_emits_everything() -> None:
+    """The old behaviour, kept as the ``--no-from-db`` escape hatch.
+
+    Diffing against nothing must still produce the full schema, otherwise a first
+    migration would generate an empty file.
+    """
+    from src.surreal_orm.migrations.state import SchemaState
+
+    operations = SchemaState().diff(introspect_models([I171Author, I171Article]))
+    relevant = _operations_for(operations, *TABLES)
+
+    assert any(isinstance(op, CreateTable) for op in relevant)
+    assert any(isinstance(op, AddField) and op.name == "title" for op in relevant)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_a_real_model_change_is_still_detected() -> None:
+    """A column the database does not have must still produce an operation."""
+    await I171Author.define_table()
+    await I171Article.define_table()
+
+    clear_model_registry()
+
+    class I171ArticleChanged(BaseSurrealModel):
+        model_config = SurrealConfigDict(table_name="i171_articles")
+        id: str | None = None
+        title: str
+        subtitle: str | None = None
+        author: ForeignKey("I171Author")
+        shelves: ManyToMany("I171Author")
+        published: bool = False  # new column
+
+    current = await DatabaseIntrospector().introspect()
+    operations = _operations_for(current.diff(introspect_models([I171ArticleChanged])), "i171_articles")
+
+    assert [op for op in operations if isinstance(op, (AddField, AlterField)) and op.name == "published"]

--- a/tests/test_issue_171_unit.py
+++ b/tests/test_issue_171_unit.py
@@ -1,0 +1,51 @@
+"""
+Unit tests for issue #171 — ``makemigrations`` diffed against an empty schema.
+
+The CLI half lives in ``tests/test_cli.py``. This file covers the comparison the
+fix depends on: SurrealDB reports its *default* permissions block for a table
+defined without a ``PERMISSIONS`` clause, so a state read back from the database
+compared unequal to the model state and ``diff()`` re-emitted ``CreateTable`` for
+every table — the same symptom #171 reports, by a second route.
+"""
+
+from src.surreal_orm.migrations.operations import CreateTable
+from src.surreal_orm.migrations.state import SchemaState, TableState
+
+#: What SurrealDB reports for a table defined with no PERMISSIONS clause.
+SURREAL_DEFAULT_PERMISSIONS = {"select": "NONE", "create": "NONE", "update": "NONE", "delete": "NONE"}
+
+
+def _states(current_permissions, target_permissions):
+    current = SchemaState()
+    current.tables["articles"] = TableState(name="articles", permissions=current_permissions)
+    target = SchemaState()
+    target.tables["articles"] = TableState(name="articles", permissions=target_permissions)
+    return current, target
+
+
+class TestDefaultPermissionsAreNotAChange:
+    """SurrealDB's implicit NONE block must not read as a configured value."""
+
+    def test_default_permissions_do_not_diff_against_none_configured(self) -> None:
+        """The database's default block equals a model that configures nothing."""
+        current, target = _states(SURREAL_DEFAULT_PERMISSIONS, {})
+
+        assert [op for op in current.diff(target) if isinstance(op, CreateTable)] == []
+
+    def test_explicitly_setting_none_is_also_the_default(self) -> None:
+        """Spelling out NONE is the same schema, so it is not a change either."""
+        current, target = _states(SURREAL_DEFAULT_PERMISSIONS, {"select": "NONE"})
+
+        assert [op for op in current.diff(target) if isinstance(op, CreateTable)] == []
+
+    def test_a_real_permission_still_diffs(self) -> None:
+        """A configured rule must still be detected against the default block."""
+        current, target = _states(SURREAL_DEFAULT_PERMISSIONS, {"select": "$auth.id = id"})
+
+        assert [op for op in current.diff(target) if isinstance(op, CreateTable)]
+
+    def test_removing_a_permission_still_diffs(self) -> None:
+        """Dropping a configured rule is a change in the other direction."""
+        current, target = _states({"select": "$auth.id = id"}, {})
+
+        assert [op for op in current.diff(target) if isinstance(op, CreateTable)]


### PR DESCRIPTION
Fixes #171

`makemigrations` built its current state as a bare `SchemaState()` — the code said so outright — so it re-emitted every table on every run:

```python
# For now, assume current state is empty (first migration)
# In a full implementation, we'd load current state from database
current_state = SchemaState()
```

It now reads the current schema through `DatabaseIntrospector`, the same path `schemadiff` already uses. No new machinery.

### Why the live database and not a replayed history

#171 offers both. Replaying the migration files is the Django-correct answer and works offline, but **nothing in this repo folds an operation back into a `SchemaState`** — there is no `state_forwards()` on any of the 21 operation classes, so that route is a subsystem, not a fix. The database side is already built and already trusted by `schemadiff`.

Worth noting *why this works at all now*: it only became viable once #170 fixed the producer/parser symmetry. While foreign keys introspected as `any` and virtual fields produced columns, diffing against the database would have generated spurious operations on every run — a worse bug than the one reported here. The issue predicted exactly that ("worth doing after #170").

The offline replay is filed separately as a follow-up.

### `--no-from-db`

Requiring a reachable database to *generate* migrations would be a regression — Django does not need one, and a genuine first migration has nothing to read. `--no-from-db` restores the previous behaviour explicitly.

An unreachable database **fails loudly and names that flag** rather than falling back to an empty schema, which would silently reintroduce the bug being fixed.

### Second defect, same path

Found while proving the fix end to end against a real server: SurrealDB reports

```
{"select": "NONE", "create": "NONE", "update": "NONE", "delete": "NONE"}
```

for a table defined with **no** `PERMISSIONS` clause. Those are its defaults, not a configured value — so a database-read state compared unequal to a model state that configures nothing, and `diff()` emitted a redundant `CreateTable` for every table. That is the same symptom by another route, and it would have left #171 only half fixed.

Both sides are normalised before comparison, which also makes an explicit `NONE` equal to omitting the clause — which is what it means. A real rule (`$auth.id = id`) still diffs, in both directions; there are tests for each.

### One existing test changed

`test_makemigrations_with_model` relied on the old default of never touching a database. It now passes `--no-from-db` — that is what its stated intent ("detects model changes") means with no server present. The assertion itself is unchanged.

### Verification

| Command | Result |
| --- | --- |
| `ruff format --check` / `ruff check` | clean |
| `mypy src/` | clean, 66 files |
| unit suite | 0 failures |
| `pytest --extra cli tests/test_cli.py` | 30 passed |
| integration (SurrealDB 3.2.4) | 0 failures |

New tests: `tests/test_issue_171_unit.py` (the permissions normalisation, both directions), `tests/test_issue_171_integration.py` (the round trip a migrated schema must satisfy, against a live server), plus four CLI cases in `tests/test_cli.py` covering the flag, the no-op case, a genuine change, and the unreachable-database error.

### Release notes required

Docs are not touched here, per the release-checklist convention. The release PR needs:

- **Fixed** — `makemigrations` diffed against an empty schema and re-emitted every table on every run; it now reads the current schema from the database (`--no-from-db` restores the old behaviour for a first migration or offline use).
- **Fixed** — a table's default `PERMISSIONS` block (`NONE` for every action) read as a configured value, so every table diffed as changed; both sides are normalised now.
- **Behaviour change** — `makemigrations` contacts the database by default and fails with a clear error when it cannot; pass `--no-from-db` to generate without one.