### PR TITLE
fix(migrations): make AlterField actually alter, and surface statement errors

### DIFF
--- a/src/surreal_orm/migrations/__init__.py
+++ b/src/surreal_orm/migrations/__init__.py
@@ -25,6 +25,7 @@ from .define_parser import (
     parse_define_index,
     parse_define_table,
 )
+from .executor import MigrationExecutor, MigrationStatementError
 from .migration import Migration
 from .model_generator import ModelCodeGenerator
 from .operations import (
@@ -43,6 +44,9 @@ from .operations import (
 )
 
 __all__ = [
+    # Execution
+    "MigrationExecutor",
+    "MigrationStatementError",
     # Introspection
     "DatabaseIntrospector",
     "ModelCodeGenerator",

--- a/src/surreal_orm/migrations/executor.py
+++ b/src/surreal_orm/migrations/executor.py
@@ -11,7 +11,7 @@ This module handles:
 import importlib.util
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ..connection_manager import SurrealDBConnectionManager
 from .migration import Migration, parse_migration_name
@@ -24,6 +24,47 @@ logger = logging.getLogger(__name__)
 
 # Table name for tracking migrations
 MIGRATIONS_TABLE = "_surreal_orm_migrations"
+
+
+class MigrationStatementError(RuntimeError):
+    """A statement inside a migration was rejected by SurrealDB."""
+
+
+def _check_statements(response: Any, sql: str, context: str) -> None:
+    """
+    Raise if any statement in a multi-statement response reported ERR.
+
+    ``client.query()`` only raises on an RPC-level failure. A statement that
+    SurrealDB rejects comes back as a perfectly successful RPC carrying
+    ``status: ERR`` per statement, so without this check a migration reports
+    success while having changed nothing (#162)::
+
+        DEFINE FIELD f ON t TYPE int;
+        -> [(ResponseStatus.ERR, "The field 'f' already exists")]
+
+    That is how ``AlterField`` stayed a silent no-op, and it hid statement-level
+    failures in ``DataMigration`` and ``RawSQL`` bodies just as effectively.
+
+    Migrations are not transactional, so a failure part-way through leaves a
+    partial state — raising is still better than reporting a success that did
+    not happen.
+
+    Args:
+        response: The value returned by ``client.query()``
+        sql: The SQL that produced it, for the error message
+        context: What was running, e.g. ``"migration 0003_add_email"``
+
+    Raises:
+        MigrationStatementError: If any statement reported ERR
+    """
+    results = getattr(response, "results", None)
+    if not results:
+        return
+
+    errors = [str(r.result) for r in results if getattr(getattr(r, "status", None), "value", None) == "ERR"]
+    if errors:
+        detail = "; ".join(errors)
+        raise MigrationStatementError(f"{context}: {detail}\nSQL: {sql.strip()[:500]}")
 
 
 class MigrationExecutor:
@@ -223,7 +264,8 @@ class MigrationExecutor:
                     if sql:
                         logger.debug(f"Executing: {sql[:100]}...")
                         try:
-                            await client.query(sql)
+                            response = await client.query(sql)
+                            _check_statements(response, sql, f"migration {migration.name} at {op.describe()}")
                         except Exception as e:
                             logger.error(f"Migration failed at {op.describe()}: {e}")
                             raise
@@ -281,7 +323,8 @@ class MigrationExecutor:
                 if sql:
                     logger.debug(f"Executing: {sql[:100]}...")
                     try:
-                        await client.query(sql)
+                        response = await client.query(sql)
+                        _check_statements(response, sql, f"rollback of migration {name}")
                     except Exception as e:
                         logger.error(f"Rollback failed for migration {name}, SQL: {sql[:200]}... Error: {e}")
                         raise RuntimeError(f"Rollback failed for migration {name}: {e}") from e
@@ -337,7 +380,8 @@ class MigrationExecutor:
                 sql = op.forwards()
                 if sql:
                     logger.debug(f"Executing: {sql[:100]}...")
-                    await client.query(sql)
+                    response = await client.query(sql)
+                    _check_statements(response, sql, f"data migration {name} at {op.describe()}")
 
                 if isinstance(op, DataMigration) and op.forwards_func:
                     await op.forwards_func()

--- a/src/surreal_orm/migrations/operations.py
+++ b/src/surreal_orm/migrations/operations.py
@@ -346,8 +346,12 @@ class AlterField(Operation):
         object.__setattr__(self, "reversible", self.previous_type is not None)
 
     def forwards(self) -> str:
-        # DEFINE FIELD is idempotent - it creates or updates
-        parts = [f"DEFINE FIELD {self.name} ON {self.table}"]
+        # OVERWRITE is required, not optional (#162). A plain `DEFINE FIELD` over
+        # an existing field does NOT update it — SurrealDB answers
+        # `The field 'x' already exists` and leaves the definition untouched, so
+        # every AlterField was a no-op. OVERWRITE is create-or-redefine, so it is
+        # still correct when the field happens to be missing.
+        parts = [f"DEFINE FIELD OVERWRITE {self.name} ON {self.table}"]
 
         if self.flexible:
             parts.append("FLEXIBLE")
@@ -387,7 +391,9 @@ class AlterField(Operation):
             return ""
 
         normalized_prev_type = _normalize_field_type(self.previous_type)
-        parts = [f"DEFINE FIELD {self.name} ON {self.table}"]
+        # OVERWRITE for the same reason as forwards(): a rollback re-defining the
+        # previous type is otherwise a silent no-op too.
+        parts = [f"DEFINE FIELD OVERWRITE {self.name} ON {self.table}"]
 
         if self.previous_flexible:
             parts.append("FLEXIBLE")

--- a/tests/test_issue_168_v2_integration.py
+++ b/tests/test_issue_168_v2_integration.py
@@ -1,0 +1,97 @@
+"""
+Integration tests for the #168 backport, against a live SurrealDB 2.6.x.
+
+Both halves were reproduced on 2.6.5 before porting:
+
+- a plain ``DEFINE FIELD`` over an existing field answers
+  ``The field 'a' already exists`` and leaves the definition untouched;
+- that rejection rides back inside a **successful** HTTP/RPC response, so
+  nothing downstream noticed.
+
+Run with: pytest -m integration tests/test_issue_168_v2_integration.py
+"""
+
+import pytest
+
+from src import surreal_orm
+from src.surreal_orm.migrations.executor import MigrationStatementError, _check_statements
+from src.surreal_orm.migrations.operations import AddField, AlterField, CreateTable
+from tests.conftest import SURREALDB_NAMESPACE, SURREALDB_PASS, SURREALDB_URL, SURREALDB_USER
+
+SURREALDB_DATABASE = "test_issue_168_v2"
+TABLE = "i168_probe"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_surrealdb() -> None:
+    """Point the ORM at the test database."""
+    surreal_orm.SurrealDBConnectionManager.set_connection(
+        SURREALDB_URL,
+        SURREALDB_USER,
+        SURREALDB_PASS,
+        SURREALDB_NAMESPACE,
+        SURREALDB_DATABASE,
+    )
+
+
+@pytest.fixture(autouse=True)
+async def clean_database():
+    """Drop the probe table before and after each test."""
+
+    async def cleanup() -> None:
+        client = await surreal_orm.SurrealDBConnectionManager.get_client()
+        await client.query(f"REMOVE TABLE IF EXISTS {TABLE};")
+
+    await cleanup()
+    yield
+    await cleanup()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_alter_field_actually_changes_the_column() -> None:
+    """The reported defect: every AlterField was a silent no-op."""
+    client = await surreal_orm.SurrealDBConnectionManager.get_client()
+    await client.query(CreateTable(name=TABLE).forwards())
+    await client.query(AddField(table=TABLE, name="a", field_type="string").forwards())
+
+    await client.query(AlterField(table=TABLE, name="a", field_type="int").forwards())
+
+    info = await client.query(f"INFO FOR TABLE {TABLE};")
+    definition = info.first_result.result["fields"]["a"]
+
+    assert "TYPE int" in definition, definition
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_a_plain_redefinition_is_still_rejected_by_the_server() -> None:
+    """Why OVERWRITE is required rather than merely tidier.
+
+    Pinning the server behaviour the fix exists for: if a future SurrealDB made a
+    plain re-DEFINE update the field, this test would start failing and tell us
+    the workaround is no longer needed.
+    """
+    client = await surreal_orm.SurrealDBConnectionManager.get_client()
+    await client.query(CreateTable(name=TABLE).forwards())
+    await client.query(AddField(table=TABLE, name="a", field_type="string").forwards())
+
+    response = await client.query(f"DEFINE FIELD a ON {TABLE} TYPE int;")
+
+    statuses = [r.status.value for r in response.results]
+    assert "ERR" in statuses, statuses
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_a_rejected_statement_no_longer_passes_for_success() -> None:
+    """The executor half: the RPC succeeds, the statement did not."""
+    client = await surreal_orm.SurrealDBConnectionManager.get_client()
+    await client.query(CreateTable(name=TABLE).forwards())
+    await client.query(AddField(table=TABLE, name="a", field_type="string").forwards())
+
+    sql = f"DEFINE FIELD a ON {TABLE} TYPE int;"
+    response = await client.query(sql)  # a *successful* RPC carrying status: ERR
+
+    with pytest.raises(MigrationStatementError, match="already exists"):
+        _check_statements(response, sql, "migration 0001_probe")

--- a/tests/test_issue_168_v2_unit.py
+++ b/tests/test_issue_168_v2_unit.py
@@ -1,0 +1,80 @@
+"""
+Unit tests for the #168 backport onto the v2 (SurrealDB 2.6.x) line.
+
+Two defects, both reproduced against a real SurrealDB 2.6.5 before porting:
+
+1. ``AlterField`` emitted a plain ``DEFINE FIELD``, which does not update an
+   existing field — the server answers ``The field 'a' already exists`` and
+   leaves the definition untouched, so every alter was a silent no-op.
+2. ``client.query()`` only raises on an RPC-level failure. A rejected statement
+   rides back inside a *successful* RPC as ``status: ERR`` per statement, so the
+   executor reported success for migrations that changed nothing.
+"""
+
+import pytest
+
+from src.surreal_orm.migrations.executor import MigrationStatementError, _check_statements
+from src.surreal_orm.migrations.operations import AddField, AlterField
+from src.surreal_sdk.types import QueryResponse, QueryResult, ResponseStatus
+
+
+class TestAlterFieldOverwrites:
+    """``OVERWRITE`` is required, not optional — plain DEFINE FIELD is a no-op."""
+
+    def test_forwards_overwrites(self) -> None:
+        """An alter must actually redefine the field."""
+        op = AlterField(table="users", name="age", field_type="int")
+
+        assert op.forwards().startswith("DEFINE FIELD OVERWRITE age ON users")
+
+    def test_backwards_overwrites(self) -> None:
+        """A rollback re-defining the previous type is otherwise a no-op too."""
+        op = AlterField(table="users", name="age", field_type="int", previous_type="string")
+
+        assert op.backwards().startswith("DEFINE FIELD OVERWRITE age ON users")
+
+    def test_add_field_does_not_overwrite(self) -> None:
+        """``AddField`` deliberately keeps plain DEFINE FIELD.
+
+        Adding a field that already exists should be an error the operator sees,
+        not a silent redefinition of someone else's column.
+        """
+        op = AddField(table="users", name="email", field_type="string")
+
+        assert "OVERWRITE" not in op.forwards()
+
+
+class TestStatementErrorsSurface:
+    """A rejected statement inside a successful RPC must not pass for success."""
+
+    def test_a_rejected_statement_raises(self) -> None:
+        """This is the shape SurrealDB returns for a duplicate DEFINE FIELD."""
+        response = QueryResponse(
+            results=[
+                QueryResult(status=ResponseStatus.OK, result=None),
+                QueryResult(status=ResponseStatus.ERR, result="The field 'a' already exists"),
+            ]
+        )
+
+        with pytest.raises(MigrationStatementError, match="already exists"):
+            _check_statements(response, "DEFINE FIELD a ON r TYPE int;", "migration 0001")
+
+    def test_the_context_and_sql_reach_the_message(self) -> None:
+        """An operator needs to know which migration and which statement."""
+        response = QueryResponse(results=[QueryResult(status=ResponseStatus.ERR, result="boom")])
+
+        with pytest.raises(MigrationStatementError) as excinfo:
+            _check_statements(response, "DEFINE FIELD a ON r TYPE int;", "migration 0007")
+
+        assert "migration 0007" in str(excinfo.value)
+        assert "DEFINE FIELD a ON r TYPE int;" in str(excinfo.value)
+
+    def test_an_all_ok_response_passes(self) -> None:
+        """The happy path stays silent."""
+        response = QueryResponse(results=[QueryResult(status=ResponseStatus.OK, result=None)])
+
+        _check_statements(response, "DEFINE TABLE t;", "migration 0001")
+
+    def test_a_response_without_results_passes(self) -> None:
+        """Some calls return no per-statement results; that is not an error."""
+        _check_statements(QueryResponse(), "DEFINE TABLE t;", "migration 0001")

--- a/tests/test_migrations_operations.py
+++ b/tests/test_migrations_operations.py
@@ -167,7 +167,7 @@ class TestAlterField:
             previous_type="string",
         )
         sql = op.forwards()
-        assert "DEFINE FIELD age ON users TYPE int" in sql
+        assert "DEFINE FIELD OVERWRITE age ON users TYPE int" in sql
 
     def test_alter_field_backwards(self) -> None:
         """Test rollback restores previous type."""


### PR DESCRIPTION
Backport of #162 / #168 from `main` onto the v2 LTS line. **Re-implemented against this branch's code, not cherry-picked** — `v2` has diverged, and the fix had to be fitted to its `migrate()` loop (which iterates `migration`, where `main` iterates `name`).

### Reproduced on 2.6.5 first

Not a speculative carry-over — the defect was confirmed against a live SurrealDB 2.6.5 before anything was changed:

```
DEFINE FIELD a ON r TYPE string;   -> OK
DEFINE FIELD a ON r TYPE int;      -> ERR "The field 'a' already exists"
INFO FOR TABLE r;                  -> a is still TYPE string
```

`AlterField` emitted exactly that plain `DEFINE FIELD`, so **every alter on this branch was a silent no-op**; `backwards()` had the same defect, so rollbacks did nothing either.

### The fix

Both emit `DEFINE FIELD OVERWRITE` now — create-or-redefine, so still correct when the field happens to be missing. `OVERWRITE` is verified working on 2.6.5 (the probe above, re-run with `OVERWRITE`, leaves the field as `TYPE int`). `AddField` deliberately keeps the plain form: adding a field that already exists should be an error the operator sees, not a silent redefinition of someone else's column.

### And the executor hid it

The whole probe above returns **HTTP 200**. `client.query()` raises only on an RPC-level failure; a rejected statement rides back inside a *successful* RPC as `status: ERR` per statement. So nothing downstream noticed — and the same blindness hid failures in `DataMigration` and `RawSQL` bodies.

`migrate()`, `rollback()` and `upgrade()` now check every statement and raise `MigrationStatementError` (exported from `surreal_orm.migrations`). Migrations are not transactional, so a mid-migration failure leaves a partial state — raising is still better than reporting a success that did not happen.

### One existing test changed

`test_alter_field_type` asserted the plain `DEFINE FIELD` form — that is, the defect. Updated to the `OVERWRITE` spelling, matching what `main` did in the original fix. The assertion's intent (the alter emits the right type) is unchanged.

### Verification

| Command | Result |
| --- | --- |
| `ruff format --check` / `ruff check` | clean |
| `mypy src/` | clean, 64 files |
| unit suite | exit 0, 0 failures |
| integration vs **SurrealDB 2.6.5** | exit 0, 0 failures |

New tests: `tests/test_issue_168_v2_unit.py` (the `OVERWRITE` spelling on both directions, `AddField` deliberately excluded, and the error-surfacing helper including its message content) and `tests/test_issue_168_v2_integration.py` (the alter actually changing the column on a live 2.6.5, plus a test pinning the server behaviour the workaround exists for — if a future SurrealDB made a plain re-DEFINE update the field, that test starts failing and tells us the workaround can go).

### Release notes required

Docs are not touched here, per the release-checklist convention. The next `0.21.x` release PR needs:

- **Fixed** — `AlterField` emitted a plain `DEFINE FIELD`, which SurrealDB 2.6.x rejects for an existing field, so every alter (and every rollback) was a silent no-op. Both now emit `DEFINE FIELD OVERWRITE`.
- **Fixed** — the executor treated a rejected statement as success, because `client.query()` only raises on RPC-level failures. `migrate()`, `rollback()` and `upgrade()` now raise `MigrationStatementError`, which also stops `DataMigration` / `RawSQL` bodies failing silently.
- **New public API** — `MigrationStatementError`, exported from `surreal_orm.migrations`.

### Backport programme

First of the fixes being carried from `main`, in dependency order: **#168 → #179 (partial) → #185 → #174 → #135**. Ordering matters — the `makemigrations` fix (#185) must land after the nullability half of #179, or `makemigrations` would diff against the database while the model side still loses optionality, proposing a phantom `AlterField` on every run. That is the same dependency #171 called out on `main`.