### PR TITLE
chore(release): bump version to 0.33.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,55 @@ and adheres to [SemVer](https://semver.org/) versioning.
 
 ---
 
+## [0.33.1] - 2026-09-05
+
+**Bug fix release.** `makemigrations` regenerated the whole schema on every run,
+by two independent routes.
+
+### Fixed — Migrations
+
+- **`makemigrations` diffed against an empty schema (#171).** The current state
+  was a bare `SchemaState()` — the code said so outright — so every table was
+  re-emitted on every run:
+
+  ```python
+  # For now, assume current state is empty (first migration)
+  current_state = SchemaState()
+  ```
+
+  It now reads the current schema through `DatabaseIntrospector`, the same path
+  `schemadiff` already used. This only became viable once 0.33.0 fixed the
+  producer/parser symmetry — while foreign keys introspected as `any` and virtual
+  fields produced columns, diffing against the database would have generated
+  spurious operations on every run.
+
+- **A table's default permissions read as a configured value (#171).** SurrealDB
+  reports `{"select": "NONE", "create": "NONE", "update": "NONE", "delete": "NONE"}`
+  for a table defined with no `PERMISSIONS` clause. Those are its defaults, so a
+  state read from the database compared unequal to a model state configuring
+  nothing, and the diff emitted a redundant `CreateTable` for every table — the
+  same symptom by a second route. Both sides are normalised before comparison,
+  which also makes an explicit `NONE` equal to omitting the clause.
+
+### Changed
+
+- **`makemigrations` contacts the database by default.** It fails with a clear
+  error when the database cannot be read, rather than falling back to an empty
+  schema — that fallback is the bug above. Pass `--no-from-db` to generate against
+  an empty schema instead, which is what you want for a genuine first migration or
+  when working offline:
+
+  ```bash
+  surreal-orm makemigrations --name initial --no-from-db
+  ```
+
+### Notes
+
+- Generating migrations offline from the replayed migration history — what Django
+  does, and what would remove the database requirement entirely — is tracked in
+  #186. No operation currently folds back into a `SchemaState`, so that route is a
+  subsystem rather than a fix.
+
 ## [0.33.0] - 2026-09-05
 
 **Migration introspection release.** Foreign keys, record references, virtual graph

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # SurrealDB-ORM - Development Context
 
-> Context document for Claude AI - Last updated: September 2026 (0.33.0)
+> Context document for Claude AI - Last updated: September 2026 (0.33.1)
 
 ## Project Vision
 
@@ -10,7 +10,7 @@
 
 ---
 
-## Current Version: 0.33.0 (Beta) — SurrealDB 3.2+ required
+## Current Version: 0.33.1 (Beta) — SurrealDB 3.2+ required
 
 ### Branch Strategy
 
@@ -18,6 +18,34 @@
 | ------ | ---------- | ----------- | ------------------------------- |
 | `main` | **3.2.4**  | 0.33.x      | Active development              |
 | `v2`   | **2.6.5**  | 0.21.x      | LTS (security & bug fixes only) |
+
+### What's New in 0.33.1
+
+`makemigrations` regenerated the whole schema on every run (#171), by two independent routes.
+
+- **It diffed against an empty schema.** `current_state` was a bare `SchemaState()` — the
+  code said so outright ("For now, assume current state is empty") — so every table was
+  re-emitted every time. It reads the current schema through `DatabaseIntrospector` now, the
+  same path `schemadiff` already used, so no new machinery. Worth noting *why it works now*:
+  only 0.33.0's producer/parser fix made it viable — while foreign keys introspected as `any`
+  and virtual fields produced columns, diffing against the database would have generated
+  spurious operations on every run, a worse bug than the one reported.
+- **A table's default permissions read as a configured value.** SurrealDB reports
+  `{"select": "NONE", "create": "NONE", "update": "NONE", "delete": "NONE"}` for a table
+  defined with no `PERMISSIONS` clause. Those are its defaults, so a database-read state
+  compared unequal to a model state configuring nothing and the diff emitted a redundant
+  `CreateTable` for every table — the same symptom by a second route, found only by running
+  the fix end to end against a real server. Fixing the state source alone would have left the
+  issue half fixed. Both sides are normalised before comparison, which also makes an explicit
+  `NONE` equal to omitting the clause.
+- **BEHAVIOUR CHANGE — `makemigrations` contacts the database by default** and fails with a
+  clear error naming `--no-from-db` when it cannot read the schema. Falling back to an empty
+  schema is precisely the bug being fixed, so it is not a fallback. `--no-from-db` restores
+  the old behaviour for a genuine first migration or offline use — Django does not need a
+  database to generate migrations, and that gap is tracked in #186 (nothing currently folds an
+  operation back into a `SchemaState`, so offline replay is a subsystem, not a fix).
+- `test_makemigrations_with_model` relied on the old default of never touching a database; it
+  passes `--no-from-db` now, which is what its intent means with no server present.
 
 ### What's New in 0.33.0
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,31 @@ Both branches receive automated daily security monitoring from `main` (GitHub Ac
 
 ---
 
+## What's New in 0.33.1
+
+**Bug fix release (#171).** `makemigrations` regenerated the whole schema on every run,
+by two independent routes.
+
+- **It diffed against an empty schema.** The current state was a bare `SchemaState()`, so
+  every table was re-emitted every time. It now reads the current schema through
+  `DatabaseIntrospector` — the same path `schemadiff` already used. This only became viable
+  once 0.33.0 fixed the producer/parser symmetry.
+- **A table's default permissions read as a configured value.** SurrealDB reports
+  `{"select": "NONE", ...}` for a table defined with no `PERMISSIONS` clause; comparing that
+  against a model configuring nothing made every table look changed, emitting a redundant
+  `CreateTable`. Both sides are normalised now.
+
+> **Behaviour change.** `makemigrations` contacts the database by default and fails with a
+> clear error when it cannot read the schema, rather than silently falling back to an empty
+> one — that fallback *is* the bug. Use `--no-from-db` for a genuine first migration or when
+> working offline:
+>
+> ```bash
+> surreal-orm makemigrations --name initial --no-from-db
+> ```
+
+Generating migrations offline from the replayed migration history is tracked in #186.
+
 ## What's New in 0.33.0
 
 **Migration introspection release (#170).** Relation fields now survive the trip from a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surrealdb-orm"
-version = "0.33.0"
+version = "0.33.1"
 description = "SurrealDB ORM as 'DJango style' for Python with async support. Works with pydantic validation."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/surreal_orm/__init__.py
+++ b/src/surreal_orm/__init__.py
@@ -193,4 +193,4 @@ __all__ = [
     "retry_on_conflict",
 ]
 
-__version__ = "0.33.0"
+__version__ = "0.33.1"

--- a/src/surreal_sdk/__init__.py
+++ b/src/surreal_sdk/__init__.py
@@ -75,7 +75,7 @@ from .types import (
     ResponseStatus,
 )
 
-__version__ = "0.33.0"
+__version__ = "0.33.1"
 __all__ = [
     # Connections
     "BaseSurrealConnection",

--- a/src/surreal_sdk/pyproject.toml
+++ b/src/surreal_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surreal-sdk"
-version = "0.33.0"
+version = "0.33.1"
 description = "Custom Python SDK for SurrealDB with HTTP and WebSocket support. No dependency on official surrealdb package."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1594,7 +1594,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb-orm"
-version = "0.33.0"
+version = "0.33.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release PR for #185 (fixes #171), merged to `main` as `4b5fa7b`.

**Patch, not minor.** Both changes are bug fixes. The one behaviour change — `makemigrations` now contacts the database and fails when it cannot, instead of silently falling back to an empty schema — replaces output that was *wrong*, rather than removing something that worked, and `--no-from-db` preserves the old path. Say the word if you'd rather it be 0.34.0.

### What ships

- **`makemigrations` diffed against an empty schema.** The current state was a bare `SchemaState()`, so every table was re-emitted on every run. It reads the current schema through `DatabaseIntrospector` now — the same path `schemadiff` already used.
- **A table's default permissions read as a configured value.** SurrealDB reports `{"select": "NONE", "create": "NONE", ...}` for a table defined with no `PERMISSIONS` clause; comparing that against a model configuring nothing made every table look changed, emitting a redundant `CreateTable`. That was the same symptom by a second route, found only by running the fix end to end against a real server — fixing the state source alone would have left the issue half fixed.
- **Behaviour change:** `--no-from-db` restores the empty-schema behaviour for a genuine first migration or offline use.

### Files updated (release checklist)

| File | Change |
| --- | --- |
| `pyproject.toml`, `src/surreal_sdk/pyproject.toml` | `version` → 0.33.1 |
| `src/surreal_orm/__init__.py`, `src/surreal_sdk/__init__.py` | `__version__` → 0.33.1 |
| `uv.lock` | relocked |
| `CHANGELOG.md` | new `[0.33.1]` entry (Fixed / Changed / Notes) |
| `README.md` | "What's New in 0.33.1" |
| `CLAUDE.md` | header date/version, `## Current Version`, "What's New" |

**Deliberately untouched:** `SECURITY.md` — its table already covers `0.33.x`, and per the checklist it only moves when the minor line or the SurrealDB floor does. `docs/roadmap.md` likewise: 0.33.0 already carries this line's entry.

### Verification

`ruff format --check`, `ruff check`, `mypy src/` (66 files), the unit suite, the CLI suite (30 passed, run with the `cli` extra since the default environment skips them), and the integration suite against SurrealDB 3.2.4 — all clean.

### Follow-up filed

#186 — generating migrations offline from the replayed migration history, which would remove the database requirement entirely. No operation currently folds back into a `SchemaState`, so that is a subsystem rather than a fix.