### PR TITLE
fix(migrations): exclude virtual relation fields and carry nullability into DDL

### DIFF
--- a/src/surreal_orm/migrations/introspector.py
+++ b/src/surreal_orm/migrations/introspector.py
@@ -13,6 +13,7 @@ from pydantic_core import PydanticUndefined
 
 from ..fields.computed import _ComputedMarker, get_computed_expression, is_computed_field
 from ..fields.encrypted import is_encrypted_field
+from ..fields.relation import is_graph_relation, is_many_to_many
 from ..types import PYTHON_TO_SURREAL_TYPE, FieldType, TableType
 from .state import AccessState, FieldState, SchemaState, TableState
 
@@ -99,6 +100,13 @@ class ModelIntrospector:
                 continue
 
             field_type_hint = type_hints.get(field_name, field_info.annotation)
+
+            # ManyToMany and Relation are virtual: the edges live in their own
+            # tables, so the attribute has no column to define. They used to be
+            # emitted as `any` columns (#170).
+            if is_many_to_many(field_type_hint) or is_graph_relation(field_type_hint):
+                continue
+
             field_state = self._introspect_field(field_name, field_type_hint, field_info, model)
             table_state.fields[field_name] = field_state
 

--- a/src/surreal_orm/migrations/operations.py
+++ b/src/surreal_orm/migrations/operations.py
@@ -8,9 +8,12 @@ applied (forwards) or reverted (backwards).
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ..types import FieldType
+
+if TYPE_CHECKING:
+    from .state import FieldState
 
 
 def _normalize_field_type(field_type: FieldType | str) -> str:
@@ -56,6 +59,35 @@ def _normalize_field_type(field_type: FieldType | str) -> str:
         f"Must be a FieldType enum value, a valid SurrealDB type string, "
         f"or a generic type like 'array<string>' or 'record<users>'."
     )
+
+
+def _apply_nullable(field_type: str, nullable: bool) -> str:
+    """
+    Wrap a field type in ``option<>`` when the column is optional.
+
+    ``FieldState.nullable`` stopped at the operation boundary: nothing wrapped
+    the type, so an optional model field reached the database as a required
+    column and generated migrations silently lost optionality (#170).
+
+    The wrap is skipped when the type already carries its own optionality —
+    ``option<T>``, or a union with a ``none``/``null`` member — so a hand-written
+    migration is never double-wrapped. Detection mirrors ``parse_define_field``,
+    the other side of the round-trip; a union *without* such a member
+    (``int | string``) is not optional and is wrapped like any other type.
+
+    Args:
+        field_type: The normalized SurrealDB type
+        nullable: Whether the column accepts NONE
+
+    Returns:
+        The type, wrapped in ``option<>`` when that is both needed and absent
+    """
+    if not nullable:
+        return field_type
+    lowered = field_type.lower()
+    if lowered.startswith("option<") or "| null" in lowered or lowered.startswith("none |"):
+        return field_type
+    return f"option<{field_type}>"
 
 
 @dataclass
@@ -221,11 +253,41 @@ class AddField(Operation):
     readonly: bool = False
     value: str | None = None
     comment: str | None = None
+    nullable: bool = False
 
     def __post_init__(self) -> None:
         """Validate field_type on initialization."""
         # Validate the field type (raises ValueError if invalid)
         _normalize_field_type(self.field_type)
+
+    @classmethod
+    def from_field_state(cls, table: str, state: "FieldState") -> "AddField":
+        """
+        Build the operation that defines *state* on *table*.
+
+        Every attribute is wired here and only here. Enumerating them by hand at
+        each call site is what let ``nullable`` go missing from every diff branch
+        and from ``define_table()`` at once.
+
+        Args:
+            table: Name of the table the field belongs to
+            state: The desired field state
+
+        Returns:
+            An ``AddField`` carrying the whole field state
+        """
+        return cls(
+            table=table,
+            name=state.name,
+            field_type=state.field_type,
+            nullable=state.nullable,
+            default=state.default,
+            assertion=state.assertion,
+            encrypted=state.encrypted,
+            flexible=state.flexible,
+            readonly=state.readonly,
+            value=state.value,
+        )
 
     def forwards(self) -> str:
         parts = [f"DEFINE FIELD {self.name} ON {self.table}"]
@@ -233,7 +295,7 @@ class AddField(Operation):
         if self.flexible:
             parts.append("FLEXIBLE")
 
-        normalized_type = _normalize_field_type(self.field_type)
+        normalized_type = _apply_nullable(_normalize_field_type(self.field_type), self.nullable)
         parts.append(f"TYPE {normalized_type}")
 
         # For encrypted fields, use VALUE clause with crypto function
@@ -330,11 +392,50 @@ class AlterField(Operation):
     readonly: bool = False
     value: str | None = None
     # Store previous definition for rollback
+    nullable: bool = False
     previous_type: FieldType | str | None = None
     previous_default: Any = None
     previous_assertion: str | None = None
     previous_flexible: bool = False
     previous_readonly: bool = False
+    previous_nullable: bool = False
+
+    @classmethod
+    def from_field_states(cls, table: str, current: "FieldState", target: "FieldState") -> "AlterField":
+        """
+        Build the operation that moves *current* to *target* on *table*.
+
+        The counterpart to :meth:`AddField.from_field_state`, wiring the target
+        state forwards and the current state into the ``previous_*`` attributes
+        ``backwards()`` needs. Hand-copying these is what left ``FLEXIBLE`` and
+        ``READONLY`` off every generated rollback.
+
+        Args:
+            table: Name of the table the field belongs to
+            current: The field state the database is in
+            target: The field state the models describe
+
+        Returns:
+            An ``AlterField`` carrying both states in full
+        """
+        return cls(
+            table=table,
+            name=target.name,
+            field_type=target.field_type,
+            nullable=target.nullable,
+            default=target.default,
+            assertion=target.assertion,
+            encrypted=target.encrypted,
+            flexible=target.flexible,
+            readonly=target.readonly,
+            value=target.value,
+            previous_type=current.field_type,
+            previous_nullable=current.nullable,
+            previous_default=current.default,
+            previous_assertion=current.assertion,
+            previous_flexible=current.flexible,
+            previous_readonly=current.readonly,
+        )
 
     def __post_init__(self) -> None:
         """Validate field_type and set reversible based on previous state."""
@@ -357,7 +458,7 @@ class AlterField(Operation):
             parts.append("FLEXIBLE")
 
         if self.field_type:
-            normalized_type = _normalize_field_type(self.field_type)
+            normalized_type = _apply_nullable(_normalize_field_type(self.field_type), self.nullable)
             parts.append(f"TYPE {normalized_type}")
 
         if self.encrypted:
@@ -390,7 +491,7 @@ class AlterField(Operation):
         if not self.previous_type:
             return ""
 
-        normalized_prev_type = _normalize_field_type(self.previous_type)
+        normalized_prev_type = _apply_nullable(_normalize_field_type(self.previous_type), self.previous_nullable)
         # OVERWRITE for the same reason as forwards(): a rollback re-defining the
         # previous type is otherwise a silent no-op too.
         parts = [f"DEFINE FIELD OVERWRITE {self.name} ON {self.table}"]

--- a/src/surreal_orm/migrations/state.py
+++ b/src/surreal_orm/migrations/state.py
@@ -328,20 +328,8 @@ class SchemaState:
                     )
                 )
                 # Add all fields
-                for field_name, field_state in target_table.fields.items():
-                    operations.append(
-                        AddField(
-                            table=table_name,
-                            name=field_name,
-                            field_type=field_state.field_type,
-                            default=field_state.default,
-                            assertion=field_state.assertion,
-                            encrypted=field_state.encrypted,
-                            flexible=field_state.flexible,
-                            readonly=field_state.readonly,
-                            value=field_state.value,
-                        )
-                    )
+                for _field_name, field_state in target_table.fields.items():
+                    operations.append(AddField.from_field_state(table_name, field_state))
                 # Add all indexes
                 for _index_name, index_state in target_table.indexes.items():
                     operations.append(self._create_index_from_state(table_name, index_state))
@@ -406,38 +394,11 @@ class SchemaState:
                 # Fields to add
                 for field_name, field_state in target_table.fields.items():
                     if field_name not in current_table.fields:
-                        operations.append(
-                            AddField(
-                                table=table_name,
-                                name=field_name,
-                                field_type=field_state.field_type,
-                                default=field_state.default,
-                                assertion=field_state.assertion,
-                                encrypted=field_state.encrypted,
-                                flexible=field_state.flexible,
-                                readonly=field_state.readonly,
-                                value=field_state.value,
-                            )
-                        )
+                        operations.append(AddField.from_field_state(table_name, field_state))
                     elif current_table.fields[field_name] != field_state:
                         # Field changed
                         current_field = current_table.fields[field_name]
-                        operations.append(
-                            AlterField(
-                                table=table_name,
-                                name=field_name,
-                                field_type=field_state.field_type,
-                                default=field_state.default,
-                                assertion=field_state.assertion,
-                                encrypted=field_state.encrypted,
-                                flexible=field_state.flexible,
-                                readonly=field_state.readonly,
-                                value=field_state.value,
-                                previous_type=current_field.field_type,
-                                previous_default=current_field.default,
-                                previous_assertion=current_field.assertion,
-                            )
-                        )
+                        operations.append(AlterField.from_field_states(table_name, current_field, field_state))
 
                 # Fields to drop
                 for field_name in current_table.fields:

--- a/tests/test_issue_179_v2_unit.py
+++ b/tests/test_issue_179_v2_unit.py
@@ -1,0 +1,149 @@
+"""
+Unit tests for the #179 backport onto the v2 (SurrealDB 2.6.x) line.
+
+Two of the four defects from the original issue apply here. Both were reproduced
+against this branch before porting:
+
+  colonnes introspectées : ['name', 'nickname', 'groups', 'follows']
+  DEFINE FIELD nickname ON probe_users TYPE string;   <- optionality lost
+  DEFINE FIELD groups ON probe_users TYPE any;        <- virtual field as a column
+  DEFINE FIELD follows ON probe_users TYPE any;
+
+The ``REFERENCE`` / ``ON DELETE`` half is deliberately **not** backported: record
+references are a SurrealDB 3.0 feature and ``ReferencesField`` does not exist on
+this branch. The ``ForeignKey`` -> ``record<T>`` typing depends on
+``_resolve_target_table``, which arrives with the #174 backport.
+"""
+
+from src.surreal_orm import BaseSurrealModel, SurrealConfigDict
+from src.surreal_orm.fields import ManyToMany, Relation
+from src.surreal_orm.migrations.introspector import ModelIntrospector
+from src.surreal_orm.migrations.operations import AddField, AlterField
+from src.surreal_orm.migrations.state import FieldState, SchemaState, TableState
+
+
+class TestVirtualFieldsExcluded:
+    """Graph edges live in their own tables, so they define no column."""
+
+    def test_many_to_many_is_not_a_column(self) -> None:
+        """A ManyToMany field never reaches the table state."""
+
+        class M2mUser(BaseSurrealModel):
+            model_config = SurrealConfigDict(table_name="m2m_users")
+            id: str | None = None
+            name: str
+            groups: ManyToMany("M2mUser")
+
+        fields = ModelIntrospector([M2mUser])._introspect_model(M2mUser).fields
+
+        assert "groups" not in fields
+        assert "name" in fields
+
+    def test_graph_relation_is_not_a_column(self) -> None:
+        """A Relation field never reaches the table state."""
+
+        class RelUser(BaseSurrealModel):
+            model_config = SurrealConfigDict(table_name="rel_users")
+            id: str | None = None
+            name: str
+            follows: Relation("f", "RelUser")
+
+        fields = ModelIntrospector([RelUser])._introspect_model(RelUser).fields
+
+        assert "follows" not in fields
+        assert "name" in fields
+
+
+class TestNullableReachesTheDdl:
+    """``FieldState.nullable`` stopped at the operation boundary."""
+
+    def test_add_field_wraps_a_nullable_type(self) -> None:
+        """``nullable=True`` produces an optional column."""
+        assert "TYPE option<string>" in AddField(table="t", name="f", field_type="string", nullable=True).forwards()
+
+    def test_add_field_leaves_a_required_type_alone(self) -> None:
+        """The default stays non-optional, as hand-written migrations expect."""
+        sql = AddField(table="t", name="f", field_type="string").forwards()
+
+        assert "TYPE string" in sql
+        assert "option<" not in sql
+
+    def test_add_field_does_not_double_wrap(self) -> None:
+        """An already-optional type is not wrapped twice."""
+        sql = AddField(table="t", name="f", field_type="option<string>", nullable=True).forwards()
+
+        assert "option<option<" not in sql
+
+    def test_a_union_without_none_is_still_wrapped(self) -> None:
+        """Only a union carrying ``none``/``null`` is already optional."""
+        assert "TYPE option<int | string>" in AddField(table="t", name="f", field_type="int | string", nullable=True).forwards()
+
+    def test_alter_field_rollback_restores_previous_nullability(self) -> None:
+        """A rollback must restore the optionality the column actually had."""
+        op = AlterField(
+            table="t",
+            name="f",
+            field_type="string",
+            nullable=False,
+            previous_type="string",
+            previous_nullable=True,
+        )
+
+        assert "TYPE option<string>" in op.backwards()
+        assert "TYPE string" in op.forwards()
+
+    def test_an_optional_model_field_reaches_the_ddl_as_optional(self) -> None:
+        """End to end: the model says optional, the DDL says option<>."""
+
+        class OptModel(BaseSurrealModel):
+            model_config = SurrealConfigDict(table_name="opt_models")
+            id: str | None = None
+            nickname: str | None = None
+
+        state = ModelIntrospector([OptModel]).introspect()
+        add = next(op for op in SchemaState().diff(state) if isinstance(op, AddField))
+
+        assert "TYPE option<string>" in add.forwards()
+
+
+class TestOperationsAreBuiltInOnePlace:
+    """The four hand-copied kwarg lists are what let attributes go missing."""
+
+    def test_add_field_is_built_from_a_field_state(self) -> None:
+        """``from_field_state`` carries the whole state, nullability included."""
+        state = FieldState(name="f", field_type="string", nullable=True, readonly=True)
+
+        sql = AddField.from_field_state("t", state).forwards()
+
+        assert "TYPE option<string>" in sql
+        assert "READONLY" in sql
+
+    def test_alter_field_carries_both_states(self) -> None:
+        """``from_field_states`` also wires the previous_* attributes."""
+        current = FieldState(name="f", field_type="string", nullable=True, flexible=True, readonly=True)
+        target = FieldState(name="f", field_type="int", nullable=False)
+
+        op = AlterField.from_field_states("t", current, target)
+        rollback = op.backwards()
+
+        assert "TYPE int" in op.forwards()
+        assert "TYPE option<string>" in rollback
+        assert "FLEXIBLE" in rollback
+        assert "READONLY" in rollback
+
+    def test_the_diff_forwards_every_previous_attribute(self) -> None:
+        """A real diff must produce a rollback that restores everything."""
+        current = SchemaState()
+        current.tables["t"] = TableState(
+            name="t",
+            fields={"f": FieldState(name="f", field_type="string", nullable=True, flexible=True, readonly=True)},
+        )
+        target = SchemaState()
+        target.tables["t"] = TableState(name="t", fields={"f": FieldState(name="f", field_type="int", nullable=False)})
+
+        alter = next(op for op in current.diff(target) if isinstance(op, AlterField))
+        rollback = alter.backwards()
+
+        assert "TYPE option<string>" in rollback
+        assert "FLEXIBLE" in rollback
+        assert "READONLY" in rollback


### PR DESCRIPTION
Partial backport of #170 / #179 from `main` onto the v2 LTS line. Backport 2 of 5.

### Reproduced here first

Not carried over on faith — the defects were reproduced against this branch before anything changed:

```
colonnes introspectées : ['name', 'nickname', 'groups', 'follows']

DEFINE FIELD name ON probe_users TYPE string;
DEFINE FIELD nickname ON probe_users TYPE string;   <- optional in Python, required in the DB
DEFINE FIELD groups ON probe_users TYPE any;        <- virtual field emitted as a column
DEFINE FIELD follows ON probe_users TYPE any;
```

### What is fixed

- **`ManyToMany` and `Relation` are virtual.** The edges live in their own tables, so the attribute has no column to define. They are excluded from DDL entirely instead of landing as `any` columns.
- **`FieldState.nullable` stopped at the operation boundary.** `AddField` / `AlterField` had no `nullable` parameter and nothing wrapped `option<>`, so an optional model field reached the database as a **required** column. Both take `nullable` now, defaulting to `False` so hand-written migrations are unaffected; `AlterField` also takes `previous_nullable` so a rollback restores the optionality the column actually had.

  The wrap is skipped when the type already carries its own optionality (`option<T>`, or a union with a `none`/`null` member), detection mirroring `parse_define_field` — the other side of the round-trip — so a union *without* one (`int | string`) is still wrapped rather than silently treated as optional.

- **`AddField.from_field_state()` / `AlterField.from_field_states()`** are now the single place a `FieldState` becomes operation keyword arguments. The hand-copied kwarg lists are what let `nullable` go missing from every branch at once, and **one instance was still live**: the alter branch never forwarded `previous_flexible` / `previous_readonly`, which `backwards()` honors — so those clauses were dropped from every generated rollback.

### Deliberately not backported

The **`REFERENCE` / `ON DELETE` half**. Record references are a SurrealDB 3.0 feature; `FieldState` and the operations on this branch carry no `reference` / `on_delete` at all, and `ReferencesField` is absent from `fields/__init__.py`. Emitting that clause against 2.6.x would produce DDL the server cannot use.

The **`ForeignKey` → `record<T>` typing** does apply in principle — record links exist in SurrealDB 2.x — but it needs `_resolve_target_table`, which is not on this branch either; it arrives with the #174 backport. Doing it there keeps each PR to code that actually exists.

`define_table()` needs no change: it does not exist on this branch.

### Verification

| Command | Result |
| --- | --- |
| `ruff format --check` / `ruff check` | clean |
| `mypy src/` | clean, 64 files |
| unit suite | exit 0, 0 failures |
| integration vs **SurrealDB 2.6.5** | exit 0, 0 failures |

`tests/test_issue_179_v2_unit.py` — 11 cases: virtual exclusion for both relation kinds, the `option<>` wrap and its three non-wrap cases, rollback restoring previous nullability, and the factories carrying the full state including the `previous_*` attributes a real diff must produce.

### Release notes required

The next `0.21.x` release PR needs:

- **Fixed** — `ManyToMany` / `Relation` were emitted as `any` columns in generated DDL; they are virtual and now define no column.
- **Fixed** — optional model fields (`str | None`) reached the database as required columns; `nullable` now travels into `AddField` / `AlterField` and wraps `option<>`.
- **Fixed** — generated rollbacks dropped `FLEXIBLE` and `READONLY`, because the diff never forwarded `previous_flexible` / `previous_readonly`.
- **New public API** — `AddField.from_field_state()`, `AlterField.from_field_states()`.

### Programme

**#168 ✅ → #179 (this) → #185 → #174 → #135.** #185 must land after this one: `makemigrations` would otherwise start diffing against the database while the model side still loses optionality, proposing a phantom `AlterField` on every run — the dependency #171 called out on `main`.