### PR TITLE
fix(cli): diff makemigrations against the live schema, not an empty one

### DIFF
--- a/src/surreal_orm/cli/commands.py
+++ b/src/surreal_orm/cli/commands.py
@@ -27,6 +27,32 @@ def run_async(coro: Any) -> Any:
     return asyncio.get_event_loop().run_until_complete(coro)
 
 
+async def _introspect_database(ctx: Any) -> Any:
+    """
+    Read the live database schema into a ``SchemaState``.
+
+    ``makemigrations`` needs to know what the database already has, otherwise it
+    diffs against nothing and re-emits the whole schema every run (#171).
+
+    Args:
+        ctx: The click context carrying the connection settings
+
+    Returns:
+        SchemaState describing the current database schema
+    """
+    from ..connection_manager import SurrealDBConnectionManager
+    from ..migrations.db_introspector import DatabaseIntrospector
+
+    SurrealDBConnectionManager.set_connection(
+        url=ctx.obj["url"],
+        user=ctx.obj["user"],
+        password=ctx.obj["password"],
+        namespace=ctx.obj["namespace"],
+        database=ctx.obj["database"],
+    )
+    return await DatabaseIntrospector().introspect()
+
+
 # Only define CLI if click is available
 if click is not None:
 
@@ -91,12 +117,18 @@ if click is not None:
     @click.option("--name", "-n", required=True, help="Migration name")  # type: ignore[untyped-decorator]
     @click.option("--empty", is_flag=True, help="Create empty migration for manual editing")  # type: ignore[untyped-decorator]
     @click.option("--models", "-m", multiple=True, help="Specific model modules to include")  # type: ignore[untyped-decorator]
+    @click.option(  # type: ignore[untyped-decorator]
+        "--from-db/--no-from-db",
+        default=True,
+        help="Diff against the live database schema (default) instead of an empty schema",
+    )
     @click.pass_context  # type: ignore[untyped-decorator]
     def makemigrations(
         ctx: click.Context,
         name: str,
         empty: bool,
         models: tuple[str, ...],
+        from_db: bool,
     ) -> None:
         """Generate migration files from model changes."""
         from ..migrations.generator import MigrationGenerator, generate_empty_migration
@@ -127,9 +159,22 @@ if click is not None:
             click.echo("No models found. Register models by importing them.")
             sys.exit(1)
 
-        # For now, assume current state is empty (first migration)
-        # In a full implementation, we'd load current state from database
-        current_state = SchemaState()
+        # The current state used to be an empty SchemaState, so every table was
+        # re-emitted on every run (#171). It comes from the live database now.
+        if from_db:
+            try:
+                current_state = run_async(_introspect_database(ctx))
+            except Exception as e:
+                # Falling back to an empty schema here would silently reintroduce
+                # the very bug this replaces, so fail and name the way out.
+                click.echo(f"Error reading the database schema: {e}", err=True)
+                click.echo(
+                    "Pass --no-from-db to generate against an empty schema instead (a first migration, or working offline).",
+                    err=True,
+                )
+                sys.exit(1)
+        else:
+            current_state = SchemaState()
 
         # Compute differences
         operations = current_state.diff(desired_state)

--- a/src/surreal_orm/migrations/state.py
+++ b/src/surreal_orm/migrations/state.py
@@ -12,6 +12,31 @@ if TYPE_CHECKING:
     from .operations import CreateIndex, Operation
 
 
+def _effective_permissions(permissions: dict[str, str] | None) -> dict[str, str]:
+    """
+    Drop permission entries that only restate SurrealDB's default.
+
+    A table defined without a ``PERMISSIONS`` clause is reported back as
+    ``PERMISSIONS NONE``, which the parser expands to
+    ``{"select": "NONE", "create": "NONE", ...}`` — the server's defaults, not a
+    configured value. Comparing the raw dicts made a database-read state differ
+    from a model state that configures nothing, so the diff re-emitted
+    ``CreateTable`` for every table on every run (#171).
+
+    Normalising both sides also makes an explicit ``NONE`` equal to omitting the
+    clause, which is what it means.
+
+    Args:
+        permissions: The permissions mapping, or None
+
+    Returns:
+        The mapping without its default-valued entries
+    """
+    if not permissions:
+        return {}
+    return {action: rule for action, rule in permissions.items() if str(rule).strip().upper() != "NONE"}
+
+
 @dataclass
 class FieldState:
     """
@@ -370,7 +395,7 @@ class SchemaState:
                 if (
                     current_table.schema_mode != target_table.schema_mode
                     or current_table.changefeed != target_table.changefeed
-                    or current_table.permissions != target_table.permissions
+                    or _effective_permissions(current_table.permissions) != _effective_permissions(target_table.permissions)
                     or current_table.view_query != target_table.view_query
                     or current_table.relation_in != target_table.relation_in
                     or current_table.relation_out != target_table.relation_out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -143,7 +143,12 @@ class TestMakeMigrationsCommand:
         assert "No models found" in result.output or result.exit_code != 0
 
     def test_makemigrations_with_model(self, runner: "CliRunner", cli_command, temp_migrations_dir: Path) -> None:
-        """Test makemigrations detects model changes."""
+        """Test makemigrations detects model changes.
+
+        Uses ``--no-from-db`` because this is a unit test with no database: since
+        #171 the default reads the current schema from the live server, and the
+        point here is only that a model turns into operations.
+        """
         from src.surreal_orm.model_base import BaseSurrealModel, clear_model_registry
 
         clear_model_registry()
@@ -162,6 +167,7 @@ class TestMakeMigrationsCommand:
                 "makemigrations",
                 "--name",
                 "create_user",
+                "--no-from-db",
             ],
         )
         assert result.exit_code == 0
@@ -170,6 +176,121 @@ class TestMakeMigrationsCommand:
 
         # Clean up
         clear_model_registry()
+
+
+class TestMakeMigrationsAgainstDatabase:
+    """#171/#185 — makemigrations diffed against an empty SchemaState.
+
+    It re-emitted every table on every run. The current state now comes from the
+    live database, so an already-migrated schema produces no operations.
+    """
+
+    @patch("src.surreal_orm.cli.commands.run_async")
+    def test_an_already_migrated_schema_produces_no_operations(
+        self, mock_run_async, runner: "CliRunner", cli_command, temp_migrations_dir: Path
+    ) -> None:
+        """A table the database already has is not re-emitted."""
+        from src.surreal_orm.migrations.introspector import introspect_models
+        from src.surreal_orm.model_base import BaseSurrealModel, clear_model_registry
+
+        clear_model_registry()
+
+        class MigratedUser(BaseSurrealModel):
+            id: str | None = None
+            name: str
+
+        # The database reports exactly what the models describe.
+        mock_run_async.side_effect = mock_run_async_factory(introspect_models())
+
+        result = runner.invoke(
+            cli_command,
+            ["--migrations-dir", str(temp_migrations_dir), "makemigrations", "--name", "noop"],
+        )
+
+        clear_model_registry()
+        assert result.exit_code == 0
+        assert "No changes detected" in result.output
+
+    @patch("src.surreal_orm.cli.commands.run_async")
+    def test_a_new_model_is_still_emitted(
+        self, mock_run_async, runner: "CliRunner", cli_command, temp_migrations_dir: Path
+    ) -> None:
+        """A model the database does not have still generates a migration."""
+        from src.surreal_orm.migrations.state import SchemaState
+        from src.surreal_orm.model_base import BaseSurrealModel, clear_model_registry
+
+        clear_model_registry()
+
+        class BrandNewThing(BaseSurrealModel):
+            id: str | None = None
+            label: str
+
+        mock_run_async.side_effect = mock_run_async_factory(SchemaState())  # empty database
+
+        result = runner.invoke(
+            cli_command,
+            ["--migrations-dir", str(temp_migrations_dir), "makemigrations", "--name", "create_thing"],
+        )
+
+        clear_model_registry()
+        assert result.exit_code == 0
+        assert "Created migration" in result.output
+
+    def test_no_from_db_skips_the_database_entirely(self, runner: "CliRunner", cli_command, temp_migrations_dir: Path) -> None:
+        """``--no-from-db`` restores the empty-state behaviour, with no connection.
+
+        This is the escape hatch for a true first migration and for offline use —
+        Django does not need a database to generate migrations either.
+        """
+        from src.surreal_orm.model_base import BaseSurrealModel, clear_model_registry
+
+        clear_model_registry()
+
+        class OfflineModel(BaseSurrealModel):
+            id: str | None = None
+            title: str
+
+        # No run_async patch: reaching the database at all would fail here.
+        result = runner.invoke(
+            cli_command,
+            [
+                "--migrations-dir",
+                str(temp_migrations_dir),
+                "makemigrations",
+                "--name",
+                "offline",
+                "--no-from-db",
+            ],
+        )
+
+        clear_model_registry()
+        assert result.exit_code == 0
+        assert "Created migration" in result.output
+
+    @patch("src.surreal_orm.cli.commands.run_async")
+    def test_an_unreachable_database_fails_loudly_and_names_the_escape_hatch(
+        self, mock_run_async, runner: "CliRunner", cli_command, temp_migrations_dir: Path
+    ) -> None:
+        """Falling back to an empty schema silently would be the bug itself."""
+        from src.surreal_orm.model_base import BaseSurrealModel, clear_model_registry
+
+        clear_model_registry()
+
+        class UnreachableModel(BaseSurrealModel):
+            id: str | None = None
+            name: str
+
+        mock_run_async.side_effect = mock_run_async_factory(exception=ConnectionError("refused"))
+
+        result = runner.invoke(
+            cli_command,
+            ["--migrations-dir", str(temp_migrations_dir), "makemigrations", "--name", "boom"],
+        )
+
+        clear_model_registry()
+        assert result.exit_code != 0
+        assert "--no-from-db" in result.output
+        assert "Created migration" not in result.output
 
 
 class TestMigrateCommand:

--- a/tests/test_issue_185_v2_unit.py
+++ b/tests/test_issue_185_v2_unit.py
@@ -1,0 +1,62 @@
+"""
+Unit tests for the #185 backport onto the v2 (SurrealDB 2.6.x) line.
+
+Both defects were reproduced against a live SurrealDB 2.6.5 before porting.
+
+``makemigrations`` built its current state as a bare ``SchemaState()``, so it
+re-emitted every table on every run. And even once it read the database, a second
+route produced the same symptom: 2.6.x reports ``PERMISSIONS NONE`` for a table
+defined without a ``PERMISSIONS`` clause, which the parser expands to
+``{"select": "NONE", "create": "NONE", "update": "NONE", "delete": "NONE"}`` —
+a state that compares unequal to a model configuring nothing::
+
+    db.permissions    = {'select': 'NONE', 'create': 'NONE', 'update': 'NONE', 'delete': 'NONE'}
+    model.permissions = {}
+    -> ['CreateTable']
+
+This lands after the #179 backport on purpose: diffing against the database while
+the model side still lost optionality would have proposed a phantom ``AlterField``
+on every run.
+"""
+
+from src.surreal_orm.migrations.operations import CreateTable
+from src.surreal_orm.migrations.state import SchemaState, TableState
+
+#: What SurrealDB 2.6.x reports for a table defined with no PERMISSIONS clause.
+SURREAL_DEFAULT_PERMISSIONS = {"select": "NONE", "create": "NONE", "update": "NONE", "delete": "NONE"}
+
+
+def _states(current_permissions, target_permissions):
+    current = SchemaState()
+    current.tables["articles"] = TableState(name="articles", permissions=current_permissions)
+    target = SchemaState()
+    target.tables["articles"] = TableState(name="articles", permissions=target_permissions)
+    return current, target
+
+
+class TestDefaultPermissionsAreNotAChange:
+    """SurrealDB's implicit NONE block must not read as a configured value."""
+
+    def test_default_permissions_do_not_diff_against_none_configured(self) -> None:
+        """The database's default block equals a model that configures nothing."""
+        current, target = _states(SURREAL_DEFAULT_PERMISSIONS, {})
+
+        assert [op for op in current.diff(target) if isinstance(op, CreateTable)] == []
+
+    def test_explicitly_setting_none_is_also_the_default(self) -> None:
+        """Spelling out NONE is the same schema, so it is not a change either."""
+        current, target = _states(SURREAL_DEFAULT_PERMISSIONS, {"select": "NONE"})
+
+        assert [op for op in current.diff(target) if isinstance(op, CreateTable)] == []
+
+    def test_a_real_permission_still_diffs(self) -> None:
+        """A configured rule must still be detected against the default block."""
+        current, target = _states(SURREAL_DEFAULT_PERMISSIONS, {"select": "$auth.id = id"})
+
+        assert [op for op in current.diff(target) if isinstance(op, CreateTable)]
+
+    def test_removing_a_permission_still_diffs(self) -> None:
+        """Dropping a configured rule is a change in the other direction."""
+        current, target = _states({"select": "$auth.id = id"}, {})
+
+        assert [op for op in current.diff(target) if isinstance(op, CreateTable)]


### PR DESCRIPTION
Backport of #171 / #185 from `main` onto the v2 LTS line. Backport 3 of 5.

`makemigrations` built its current state as a bare `SchemaState()` — the code said so outright — so it re-emitted every table on every run. It now reads the current schema through `DatabaseIntrospector`, the same path `schemadiff` already uses. No new machinery.

`--no-from-db` restores the previous behaviour explicitly, for a genuine first migration or offline use. An unreachable database **fails loudly and names that flag** rather than falling back to an empty schema — that fallback *is* the bug.

### Second defect, reproduced on 2.6.5

```
db.permissions    = {'select': 'NONE', 'create': 'NONE', 'update': 'NONE', 'delete': 'NONE'}
model.permissions = {}
-> ['CreateTable']
```

SurrealDB 2.6.x reports `PERMISSIONS NONE` for a table defined without the clause, and the parser expands that into the per-action dict above. Those are the server's defaults, not a configured value — so a database-read state compared unequal to a model configuring nothing, and the diff emitted a redundant `CreateTable` for every table. Fixing the state source alone would have left this half-fixed.

Both sides are normalised before comparison, which also makes an explicit `NONE` equal to omitting the clause. A real rule (`$auth.id = id`) still diffs, in both directions.

### Ordering

This lands **after** the virtual-fields/nullability backport (#189) on purpose. Diffing against the database while the model side still lost optionality would have proposed a phantom `AlterField` on every run — the dependency #171 called out on `main`. The probe confirms it now round-trips:

```
title     db=('string',null=False)  model=('string',null=False)
subtitle  db=('string',null=True)   model=('string',null=True)
```

### A test that had quietly become database-dependent

`test_makemigrations_with_model` passed after the change — but only because a SurrealDB happened to be listening on 8000. Pointed at a dead port it failed with `SystemExit(1)`. The unit suite is documented as needing no SurrealDB (`make test-unit`), so it now passes `--no-from-db`, which is what its intent ("detects model changes") means with no server present.

The whole CLI suite is verified to pass with `SURREAL_URL=http://localhost:9` — a dead endpoint — so the independence is proven rather than assumed.

### Verification

| Command | Result |
| --- | --- |
| `ruff format --check` / `ruff check` | clean |
| `mypy src/` | clean, 64 files |
| unit suite | exit 0, 0 failures |
| CLI suite (with the `cli` extra) | 30 passed, also against a dead endpoint |
| integration vs **SurrealDB 2.6.5** | exit 0, 0 failures |

### Release notes required

- **Fixed** — `makemigrations` diffed against an empty schema and re-emitted every table on every run; it now reads the current schema from the database.
- **Fixed** — a table's default `PERMISSIONS NONE` read as a configured value, so every table diffed as changed.
- **Behaviour change** — `makemigrations` contacts the database by default and fails with a clear error when it cannot; `--no-from-db` generates against an empty schema.

### Programme

**#168 ✅ → #179 ✅ → #185 (this) → #174 → #135.**