### PR TITLE
fix(orm): coerce ForeignKey values to RecordId on write and in filters

### DIFF
--- a/src/surreal_orm/model_base.py
+++ b/src/surreal_orm/model_base.py
@@ -13,6 +13,8 @@ from typing import (
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr, model_validator
 
+from surreal_sdk.protocol.cbor import RecordId
+
 from . import signals as model_signals
 from .connection_manager import SurrealDBConnectionManager
 from .debug import _elapsed_ms, _log_query, _start_timer
@@ -137,6 +139,135 @@ def _is_datetime_field(field_type: Any) -> bool:
             return datetime in args
         return False
     return field_type is datetime
+
+
+def to_record_id(value: Any) -> Any:
+    """
+    Convert a full record-ID string (table:id) into a ``RecordId`` object.
+
+    A ``record<...>`` column rejects a bound string, so writes and filters on
+    record links must send a ``RecordId``.  Anything that is not a full
+    record-ID string is returned unchanged.
+
+    Args:
+        value: The value to convert
+
+    Returns:
+        A ``RecordId`` for a record-ID string, otherwise the original value
+
+    Examples:
+        to_record_id("users:abc123")   # RecordId(table="users", id="abc123")
+        to_record_id("users:`7abc`")   # RecordId(table="users", id="7abc")
+        to_record_id("abc123")         # "abc123"
+    """
+    if not isinstance(value, str):
+        return value
+
+    table, id_part = parse_record_id(value)
+    if table is None or not _SAFE_IDENTIFIER_RE.match(table):
+        return value
+
+    return RecordId(table=table, id=id_part)
+
+
+def record_link_to_str(value: Any) -> Any:
+    """
+    Render a model instance or ``RecordId`` as a ``"table:id"`` string.
+
+    Inverse of :func:`to_record_id`.  Values that are neither are returned
+    unchanged.
+
+    Args:
+        value: The value to convert
+
+    Returns:
+        The record link as a string, otherwise the original value
+
+    Raises:
+        ValueError: If a model instance has no ID yet.  An unsaved record
+            cannot be referenced, and reporting it here beats the string
+            schema's "Input should be a valid string".
+
+    Examples:
+        record_link_to_str(user_instance)                    # "users:alice"
+        record_link_to_str(RecordId(table="users", id="a"))  # "users:a"
+        record_link_to_str("users:alice")                    # "users:alice"
+    """
+    # Duck-typed like _convert_record_id_to_string: avoids import path
+    # issues between src.surreal_orm and surreal_orm. The isinstance guard
+    # keeps unrelated objects with a plain `record_id` attribute untouched.
+    record_id = getattr(value, "record_id", None)
+    if isinstance(record_id, RecordId):
+        return str(record_id)
+    if isinstance(value, RecordId):
+        return str(value)
+    if record_id is None and callable(getattr(value, "get_id", None)):
+        raise ValueError(f"cannot reference an unsaved {type(value).__name__}; save it first")
+    return value
+
+
+def _to_record_link(value: Any, table: str | None) -> Any:
+    """
+    Convert a foreign-key value into a record link.
+
+    Accepts the related model instance, a ``RecordId``, a full ``"table:id"``
+    string, or - when the target table is known - a bare ID.  Anything else is
+    returned unchanged.
+
+    Args:
+        value: The foreign-key value
+        table: The target table, used to qualify a bare ID
+
+    Returns:
+        A ``RecordId``, or the original value
+    """
+    if isinstance(value, RecordId):
+        return value
+
+    value = record_link_to_str(value)
+
+    # A bare ID is only resolvable against a known target table. "$var"
+    # references stay untouched — they are user-supplied query variables.
+    if isinstance(value, str) and table and not value.startswith("$"):
+        value_table, id_part = parse_record_id(value)
+        if value_table is None:
+            return RecordId(table=table, id=id_part)
+
+    return to_record_id(value)
+
+
+def _resolve_target_table(model_name: str) -> str | None:
+    """
+    Resolve a :func:`ForeignKey` target model name to its table name.
+
+    ``ForeignKey("Article")`` names the model, which may configure a different
+    ``table_name``.  The table name itself is accepted too.  Returns ``None``
+    when nothing matches, in which case a bare ID cannot be qualified.
+
+    Walks the subclass tree rather than ``_MODEL_REGISTRY``, which
+    :func:`clear_model_registry` empties.  The first match wins when two models
+    share a name.
+
+    Args:
+        model_name: The target model name given to ForeignKey
+
+    Returns:
+        The target table name, or ``None`` when the target is unknown
+    """
+    models: list[type[BaseSurrealModel]] = []
+    pending = BaseSurrealModel.__subclasses__()
+    while pending:
+        model = pending.pop()
+        models.append(model)
+        pending.extend(model.__subclasses__())
+
+    for model in models:
+        if model.__name__ == model_name:
+            return model.get_table_name()
+    for model in models:
+        if model.get_table_name() == model_name:
+            return model_name
+    return None
 
 
 def _convert_record_id_to_string(value: Any) -> Any:
@@ -468,6 +599,97 @@ class BaseSurrealModel(BaseModel):
             fields.update(computed.keys())
         return fields
 
+    @classmethod
+    def get_foreign_key_targets(cls) -> dict[str, str | None]:
+        """
+        Map each :func:`ForeignKey` field to the table it points at.
+
+        These fields hold record links, so their values must reach SurrealDB as
+        ``RecordId`` objects rather than strings.  The table is ``None`` when
+        the target model is not registered, in which case only fully-qualified
+        ``"table:id"`` values can be resolved.
+
+        Returns:
+            Dict mapping foreign-key field name to target table name.
+        """
+        # Local import: fields.relation imports record_link_to_str from this
+        # module at load time, so importing it at the top would be circular.
+        from .fields.relation import _ForeignKeyMarker
+
+        # Pydantic strips Annotated metadata off `annotation`, so the marker
+        # is read from FieldInfo.metadata instead.
+        targets: dict[str, str | None] = {}
+        for name, field_info in cls.model_fields.items():
+            for meta in field_info.metadata:
+                if isinstance(meta, _ForeignKeyMarker):
+                    targets[name] = _resolve_target_table(meta.to)
+                    break
+        return targets
+
+    @classmethod
+    def get_foreign_key_columns(cls) -> dict[str, str | None]:
+        """
+        Map each foreign-key *column* name to its target table.
+
+        Filters and bulk writes address database columns, so an aliased
+        :func:`ForeignKey` must be resolvable under its alias too.
+
+        Returns:
+            Dict mapping foreign-key column name — the field name and, when
+            declared, its alias — to the target table name.
+        """
+        columns: dict[str, str | None] = {}
+        for field_name, table in cls.get_foreign_key_targets().items():
+            columns[field_name] = table
+            alias = cls.model_fields[field_name].alias
+            if alias:
+                columns[alias] = table
+        return columns
+
+    @property
+    def record_id(self) -> RecordId | None:
+        """
+        This record's full identity as a ``RecordId`` — the ``Model.pk`` analog.
+
+        Use it wherever a value is bound against a ``record<...>`` column,
+        e.g. ``variables={"a": author.record_id}``; ``str(instance.record_id)``
+        gives the ``"table:id"`` string form.  Not a Pydantic field, so it is
+        never serialized; a model that declares its own ``record_id`` field
+        shadows it (Pydantic warns).
+
+        Returns:
+            The ``RecordId``, or ``None`` when the instance has no ID yet.
+        """
+        record_id = self.get_id()
+        if record_id is None:
+            return None
+        return RecordId(table=self.get_table_name(), id=record_id)
+
+    def _coerce_foreign_keys(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Wrap foreign-key values into record links before writing.
+
+        ``model_dump()`` renders a :func:`ForeignKey` as a ``"table:id"``
+        string, which a ``record<...>`` column rejects.  A bare ID is qualified
+        with the target model's table.
+
+        Handles aliased fields: when ``model_dump(by_alias=True)`` is used,
+        dict keys may be aliases rather than Python field names.
+
+        Returns:
+            A new dict with foreign-key values converted.
+        """
+        fk_targets = self.__class__.get_foreign_key_targets()
+        if not fk_targets:
+            return data
+
+        coerced = dict(data)
+        for field_name, table in fk_targets.items():
+            alias = self.__class__.model_fields[field_name].alias
+            key = alias if alias and alias in coerced else field_name
+            if key in coerced:
+                coerced[key] = _to_record_link(coerced[key], table)
+        return coerced
+
     def get_id(self) -> str | None:
         """
         Get the ID of the model instance.
@@ -725,6 +947,9 @@ class BaseSurrealModel(BaseModel):
         table = self.get_table_name()
         data = self.model_dump(exclude=exclude_fields, exclude_unset=True, by_alias=True)
         data = self._restore_datetime_fields(data)
+        # A ForeignKey renders as a "table:id" string, which a record<> column
+        # rejects outright — convert at the wire boundary (#169).
+        data = self._coerce_foreign_keys(data)
 
         # Merge server-side function values
         if server_values:
@@ -1023,6 +1248,7 @@ class BaseSurrealModel(BaseModel):
         exclude_fields = {"id"} | self.get_server_fields()
         data = self.model_dump(exclude=exclude_fields, exclude_unset=True, by_alias=True)
         data = self._restore_datetime_fields(data)
+        data = self._coerce_foreign_keys(data)
         record_id = self.get_id()
 
         if record_id is None:
@@ -1110,7 +1336,7 @@ class BaseSurrealModel(BaseModel):
         """
         self._check_not_view()
 
-        data_set = {key: value for key, value in data.items()}
+        data_set = self._coerce_foreign_keys({key: value for key, value in data.items()})
 
         record_id = self.get_id()
         if not record_id:

--- a/src/surreal_orm/query_set.py
+++ b/src/surreal_orm/query_set.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
 import logging
 
-from .model_base import SurrealDbError
+from .model_base import SurrealDbError, _to_record_link
 
 logger = logging.getLogger(__name__)
 
@@ -946,6 +946,41 @@ class QuerySet(Generic[T]):
                     related = grouped.get(thing, [])
                     object.__setattr__(inst, to_attr, related)
 
+    def _coerce_filter_value(self, field_name: str, lookup_name: str, value: Any) -> Any:
+        """
+        Convert a filter value on a :func:`ForeignKey` field to a record link.
+
+        SurrealDB never equates a bound string with a record, so
+        ``filter(author="users:abc")`` on a ``record<...>`` column returns an
+        empty result instead of raising.  The related instance and a bare ID
+        are accepted too, so all three of these are equivalent::
+
+            filter(author=alice)
+            filter(author="users:alice")
+            filter(author="alice")
+
+        Only lookups that compare whole records are converted — the string
+        lookups (``contains``, ``startswith``, ``regex``, ...) still match on
+        the raw value.  ``in`` values are converted element-wise.
+
+        Args:
+            field_name: The database field name being filtered on.
+            lookup_name: The lookup type (e.g. "exact", "in").
+            value: The filter value as supplied by the caller.
+
+        Returns:
+            The value with record references converted to ``RecordId`` objects.
+        """
+        targets = self.model.get_foreign_key_columns()
+        if field_name not in targets or lookup_name not in ("exact", "in", "not_in"):
+            return value
+
+        table = targets[field_name]
+        if isinstance(value, (list, tuple, set)):
+            # Always a list: RecordId is unhashable, and IN takes an array anyway
+            return [_to_record_link(item, table) for item in value]
+        return _to_record_link(value, table)
+
     @staticmethod
     def _render_condition(
         field_name: str,
@@ -1104,6 +1139,7 @@ class QuerySet(Generic[T]):
                     parts.append(rendered)
             else:
                 field_name, lookup_name, value = child
+                value = self._coerce_filter_value(field_name, lookup_name, value)
                 parts.append(self._render_condition(field_name, lookup_name, value, variables, counter))
 
         if not parts:
@@ -1135,6 +1171,7 @@ class QuerySet(Generic[T]):
 
         # Keyword-based filters (always AND-joined)
         for field_name, lookup_name, value in self._filters:
+            value = self._coerce_filter_value(field_name, lookup_name, value)
             parts.append(self._render_condition(field_name, lookup_name, value, variables, counter))
 
         # Q object filters

--- a/tests/test_issue_174_v2_unit.py
+++ b/tests/test_issue_174_v2_unit.py
@@ -1,0 +1,105 @@
+"""
+Unit tests for the #174 backport onto the v2 (SurrealDB 2.6.x) line.
+
+Reproduced against a live SurrealDB 2.6.5 before porting:
+
+  1) save() with a "table:id" string into a record<> column
+     -> QueryError: Found 'p174_authors:alice' for field `author`
+  2) filter by the same string
+     -> rows found = 0  (the row demonstrably exists)
+
+The second is the dangerous one: a wrong answer rather than an error. A
+``ForeignKey`` holds a ``"table:id"`` string in Python, and nothing converted it
+at the wire boundary, so a ``record<>`` column rejected the write and a filter
+compared a string against a record value.
+"""
+
+import pytest
+
+from src.surreal_orm import BaseSurrealModel, SurrealConfigDict
+from src.surreal_orm.fields import ForeignKey
+from src.surreal_orm.model_base import record_link_to_str, to_record_id
+from surreal_sdk.protocol.cbor import RecordId
+
+
+class FkTarget(BaseSurrealModel):
+    """Target model, whose table name differs from the class name."""
+
+    model_config = SurrealConfigDict(table_name="fk_targets")
+
+    id: str | None = None
+    name: str = "x"
+
+
+class FkHolder(BaseSurrealModel):
+    """Holds the foreign key, including an aliased one."""
+
+    model_config = SurrealConfigDict(table_name="fk_holders")
+
+    id: str | None = None
+    title: str = "t"
+    author: ForeignKey("FkTarget") = None
+
+
+class TestToRecordId:
+    """A ``record<>`` column rejects a bound string."""
+
+    def test_a_full_record_id_string_becomes_a_record_id(self) -> None:
+        """The conversion the wire boundary was missing."""
+        converted = to_record_id("fk_targets:alice")
+
+        assert isinstance(converted, RecordId)
+        assert converted.table == "fk_targets"
+        assert converted.id == "alice"
+
+    def test_a_bare_id_is_left_alone(self) -> None:
+        """Without a table there is nothing to qualify it with."""
+        assert to_record_id("alice") == "alice"
+
+    def test_a_non_string_is_left_alone(self) -> None:
+        """Only strings can be record-ID strings."""
+        assert to_record_id(42) == 42
+
+
+class TestRecordLinkToStr:
+    """The inverse, used when a model instance is passed as the value."""
+
+    def test_a_record_id_renders_as_table_colon_id(self) -> None:
+        """Inverse of to_record_id."""
+        assert record_link_to_str(RecordId(table="fk_targets", id="alice")) == "fk_targets:alice"
+
+    def test_an_unsaved_instance_raises_a_clear_error(self) -> None:
+        """Referencing an unsaved record cannot work; say so plainly."""
+        with pytest.raises(ValueError, match="unsaved"):
+            record_link_to_str(FkTarget(name="nobody"))
+
+    def test_a_plain_string_is_left_alone(self) -> None:
+        """Already a record link."""
+        assert record_link_to_str("fk_targets:alice") == "fk_targets:alice"
+
+
+class TestForeignKeyTargets:
+    """Resolving where a foreign key points, including under an alias."""
+
+    def test_targets_map_the_field_to_its_table(self) -> None:
+        """``ForeignKey("FkTarget")`` names the model, not the table."""
+        assert FkHolder.get_foreign_key_targets() == {"author": "fk_targets"}
+
+    def test_columns_include_the_field_name(self) -> None:
+        """Filters and bulk writes address database columns."""
+        assert FkHolder.get_foreign_key_columns()["author"] == "fk_targets"
+
+
+class TestRecordIdProperty:
+    """``instance.record_id`` is the ``Model.pk`` analog."""
+
+    def test_a_saved_instance_exposes_its_record_id(self) -> None:
+        """Bindable against a record<> column in a raw query."""
+        rid = FkTarget(id="alice", name="Alice").record_id
+
+        assert isinstance(rid, RecordId)
+        assert str(rid) == "fk_targets:alice"
+
+    def test_an_unsaved_instance_has_none(self) -> None:
+        """No id, no identity."""
+        assert FkTarget(name="Alice").record_id is None


### PR DESCRIPTION
Backport of #169 / #174 from `main` onto the v2 LTS line. Backport 4 of 5.

### Reproduced on 2.6.5 first

```
1) save() with a "table:id" string into a record<> column
   -> QueryError: Found 'p174_authors:alice' for field `author`
2) filter by the same string
   -> rows found = 0   (the row demonstrably existed)
```

**The second is the dangerous one** — a wrong answer rather than an error. A `ForeignKey` holds a `"table:id"` string in Python, and nothing converted it at the wire boundary, so a `record<>` column rejected the write outright and a filter compared a string against a record value and silently returned nothing.

The same probe after the fix:

```
1) save() OK
2) rows found = 2
```

### What changed

- **Write paths** (`save`, `update`, `merge`) convert through `_coerce_foreign_keys()`, which resolves aliases so an aliased `ForeignKey` is written under its database column rather than its Python field name.
- **Whole-record lookups** (`exact`, `in`, `not_in`, including inside `Q` objects) convert through `_coerce_filter_value()`. String lookups (`contains`, `startswith`, `regex`, …) deliberately stay uncoerced so they still match on the raw value.
- **Four interchangeable forms** are accepted: the related model instance, `"table:id"`, a bare ID (qualified with the target table), and a `RecordId`. Referencing an **unsaved** instance raises a clear error instead of binding a model object into the query.

### New public API

`to_record_id()`, `record_link_to_str()`, `instance.record_id` (the `Model.pk` analog, for binding against `record<>` columns in `raw_query()`), `get_foreign_key_targets()` and `get_foreign_key_columns()`.

### One thing worth knowing for future ports

`RecordId` is imported as `from surreal_sdk.protocol.cbor import RecordId`, matching every other SDK import in this package. The `src.`-prefixed path yields a *different class object*, so `isinstance` silently fails — my first test run failed exactly that way before the import was corrected.

### Verification

| Command | Result |
| --- | --- |
| `ruff format --check` / `ruff check` | clean |
| `mypy src/` | clean, 64 files |
| unit suite | exit 0, 0 failures |
| integration vs **SurrealDB 2.6.5** | exit 0, 0 failures |

`tests/test_issue_174_v2_unit.py` — 10 cases covering both conversion directions, the unsaved-instance error, target/column resolution, and the `record_id` property.

### Release notes required

- **Fixed** — `ForeignKey` values were never converted to record links, so writes to a `record<>` column were rejected and whole-record filters returned `[]` for rows that existed. Every write path and whole-record lookup now converts.
- **New public API** — `to_record_id()`, `record_link_to_str()`, `instance.record_id`, `get_foreign_key_targets()`, `get_foreign_key_columns()`.

### Programme

**#168 ✅ → #179 ✅ → #185 ✅ → #174 (this) → #135.**