### PR TITLE
chore(release): bump version to 0.21.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,104 @@ and adheres to [SemVer](https://semver.org/) versioning.
 
 ---
 
+## [0.21.5] - 2026-09-05
+
+**Bug-fix maintenance release (V2 LTS).** Four correctness fixes backported from
+the 3.x `main` line. Each was reproduced against a live SurrealDB 2.6.5 on this
+branch before being ported — none was carried over on the assumption that a fix
+which mattered on 3.x also matters here.
+
+### Fixed
+
+- **`AlterField` never altered anything** (#162 on `main`). It emitted a plain
+  `DEFINE FIELD`, which SurrealDB 2.6.x rejects for an existing field:
+
+  ```
+  DEFINE FIELD a ON r TYPE string;   -> OK
+  DEFINE FIELD a ON r TYPE int;      -> ERR "The field 'a' already exists"
+  INFO FOR TABLE r;                  -> a is still TYPE string
+  ```
+
+  Every alter — and every rollback, which had the same defect — was a silent
+  no-op. Both emit `DEFINE FIELD OVERWRITE` now, which is create-or-redefine and
+  therefore still correct when the field is missing. `AddField` deliberately
+  keeps the plain form: adding a field that already exists should be an error the
+  operator sees.
+
+- **The executor treated a rejected statement as success** (#162). `client.query()`
+  raises only on an RPC-level failure; a statement SurrealDB rejects rides back
+  inside a *successful* RPC as `status: ERR` per statement — the probe above
+  returns HTTP 200. `migrate()`, `rollback()` and `upgrade()` now check every
+  statement and raise `MigrationStatementError`, which also stops `DataMigration`
+  and `RawSQL` bodies failing silently. Migrations are not transactional, so a
+  failure part-way through leaves a partial state.
+
+- **`ManyToMany` / `Relation` were emitted as `any` columns, and optional fields
+  lost their optionality** (#170). Graph relations are virtual — the edges live in
+  their own tables — and now define no column at all. `FieldState.nullable`
+  stopped at the operation boundary, so a `str | None` field reached the database
+  as a **required** column; `AddField` / `AlterField` carry `nullable` now, and
+  `AlterField` carries `previous_nullable` so a rollback restores the optionality
+  the column actually had.
+
+- **`ForeignKey` values never reached the database as record links** (#169). A
+  `ForeignKey` holds a `"table:id"` string in Python and nothing converted it at
+  the wire boundary:
+
+  ```python
+  # rejected: a record<> column will not take a string
+  await Article(title="Hello", author="authors:alice").save()
+
+  # the row exists, but the filter compares a string to a record value
+  await Article.objects().filter(author="authors:alice").exec()  # []
+  ```
+
+  The second is the dangerous one — a wrong answer rather than an error. Every
+  write path (`save`, `update`, `merge`) and every whole-record lookup (`exact`,
+  `in`, `not_in`, including inside `Q`) now converts. String lookups
+  (`contains`, `startswith`, `regex`, …) stay uncoerced by design. Four
+  interchangeable forms are accepted: the model instance, `"table:id"`, a bare ID,
+  and a `RecordId`.
+
+- **`makemigrations` diffed against an empty schema**, so it re-emitted every
+  table on every run. It reads the current schema from the database now, through
+  the same `DatabaseIntrospector` path `schemadiff` already used. A second route
+  produced the same symptom: 2.6.x reports `PERMISSIONS NONE` for a table defined
+  without the clause, which the parser expands into a per-action dict, so a
+  database-read state compared unequal to a model configuring nothing. Both sides
+  are normalised before comparison.
+
+### Changed
+
+- **`makemigrations` contacts the database by default** and fails with a clear
+  error when it cannot read the schema, rather than falling back to an empty one —
+  that fallback is the bug above. Pass `--no-from-db` for a genuine first
+  migration or when working offline:
+
+  ```bash
+  surreal-orm makemigrations --name initial --no-from-db
+  ```
+
+### Added
+
+- `to_record_id()`, `record_link_to_str()`, `instance.record_id` (the `Model.pk`
+  analog, for binding against `record<>` columns in `raw_query()`),
+  `get_foreign_key_targets()` and `get_foreign_key_columns()`.
+- `MigrationStatementError`, exported from `surreal_orm.migrations`.
+- `AddField.from_field_state()` / `AlterField.from_field_states()` — the single
+  place a `FieldState` becomes operation arguments. The hand-copied argument
+  lists they replace had already dropped `FLEXIBLE` and `READONLY` from every
+  generated rollback.
+
+### Notes
+
+- **Not backported:** the SurrealDB 3.0 `REFERENCE` / `ON DELETE` half of #170.
+  Record references are a 3.0 feature and `ReferencesField` does not exist on this
+  branch. The permission-denial fix (#135 on `main`) was already present here —
+  verified rather than assumed.
+- This line remains **security and bug fixes only**, until SurrealDB-ORM-lite
+  reaches v0.40.0.
+
 ## [0.21.2] - 2026-07-20
 
 **Bug-fix maintenance release (V2 LTS).** Two correctness fixes backported from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # SurrealDB-ORM - Development Context
 
-> Context document for Claude AI - Last updated: June 2026
+> Context document for Claude AI - Last updated: September 2026 (0.21.5)
 
 <!-- -->
 
@@ -19,7 +19,41 @@
 
 ---
 
-## Current Version: 0.21.1 (Beta — V2 LTS, deprecated)
+## Current Version: 0.21.5 (Beta — V2 LTS, deprecated)
+
+### What's New in 0.21.5
+
+Four correctness fixes backported from the 3.x `main` line. Each was **reproduced against a
+live SurrealDB 2.6.5 on this branch** before porting — the divergence between the lines is
+large enough that "it mattered on main" is not evidence it matters here.
+
+- **`AlterField` was a silent no-op** — it emitted a plain `DEFINE FIELD`, which 2.6.x
+  rejects for an existing field (`The field 'a' already exists`) while leaving the definition
+  untouched. `backwards()` had the same defect, so rollbacks did nothing either. Both emit
+  `DEFINE FIELD OVERWRITE` now; `AddField` deliberately keeps the plain form.
+- **The executor swallowed statement errors** — `client.query()` raises only on an RPC-level
+  failure, and the whole probe above returns HTTP 200 while carrying `status: ERR` per
+  statement. `migrate()` / `rollback()` / `upgrade()` raise `MigrationStatementError` now,
+  which also stops `DataMigration` and `RawSQL` bodies failing silently.
+- **`ManyToMany` / `Relation` produced `any` columns; optionality was lost** — graph
+  relations are virtual and now define no column, and `nullable` travels into
+  `AddField` / `AlterField` (plus `previous_nullable`, so rollbacks restore what the column
+  actually had). `AddField.from_field_state()` / `AlterField.from_field_states()` are now the
+  single wiring point; the hand-copied kwarg lists they replace had already dropped
+  `FLEXIBLE` and `READONLY` from every generated rollback.
+- **`ForeignKey` values never became record links** — writes to a `record<>` column were
+  rejected outright, and whole-record filters returned `[]` for rows that demonstrably
+  existed. The filter case is the dangerous one: a wrong answer, not an error.
+- **`makemigrations` diffed against an empty schema** — re-emitting every table every run.
+  It reads the database now. A second route gave the same symptom: 2.6.x reports
+  `PERMISSIONS NONE` for a table with no clause, which the parser expands into a per-action
+  dict, so a database-read state compared unequal to a model configuring nothing.
+- **BEHAVIOUR CHANGE** — `makemigrations` contacts the database by default and fails clearly
+  when it cannot; `--no-from-db` restores the old path.
+- **Not backported:** the 3.0 `REFERENCE` / `ON DELETE` half of #170 (`ReferencesField` does
+  not exist here). The permission-denial fix (#135) was already present — verified, not
+  assumed.
+
 
 > Maintenance line `0.2y.x` for SurrealDB 2.6.x. Tested against SurrealDB **v2.6.5**.
 > See the deprecation notice above and the [CHANGELOG](CHANGELOG) for details.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,45 @@ Tested with SurrealDB: v2.6.5
 
 ---
 
+## What's New in 0.21.5
+
+**Bug-fix maintenance release (V2 LTS).** Four correctness fixes backported from the 3.x
+`main` line, each reproduced against a live SurrealDB 2.6.5 on this branch before porting.
+
+- **`AlterField` never altered anything.** It emitted a plain `DEFINE FIELD`, which 2.6.x
+  rejects for an existing field (`The field 'a' already exists`), leaving the definition
+  untouched — every alter and every rollback was a silent no-op. Both emit
+  `DEFINE FIELD OVERWRITE` now.
+- **The executor treated a rejected statement as success.** `client.query()` raises only on
+  RPC-level failures; a rejected statement rides back inside a *successful* RPC as
+  `status: ERR`. `migrate()`, `rollback()` and `upgrade()` now raise `MigrationStatementError`.
+- **`ManyToMany` / `Relation` were emitted as `any` columns**, and a `str | None` field
+  reached the database as a **required** column. Graph relations are virtual and now define
+  no column; `nullable` travels into `AddField` / `AlterField`.
+- **`ForeignKey` values never became record links.** Writes to a `record<>` column were
+  rejected, and whole-record filters returned `[]` for rows that existed — a wrong answer,
+  not an error:
+
+  ```python
+  await Article.objects().filter(author="authors:alice").exec()  # was []
+  ```
+
+  Every write path and whole-record lookup converts now; the model instance, `"table:id"`,
+  a bare ID and a `RecordId` are interchangeable.
+- **`makemigrations` diffed against an empty schema**, re-emitting every table on every run.
+  It reads the current schema from the database now.
+
+> **Behaviour change.** `makemigrations` contacts the database by default and fails with a
+> clear error when it cannot read the schema. Use `--no-from-db` for a genuine first
+> migration or when working offline.
+
+**New:** `to_record_id()`, `record_link_to_str()`, `instance.record_id`,
+`get_foreign_key_targets()`, `get_foreign_key_columns()`, `MigrationStatementError`,
+`AddField.from_field_state()` / `AlterField.from_field_states()`.
+
+The SurrealDB 3.0 `REFERENCE` / `ON DELETE` work is **not** backported — record references
+are a 3.0 feature.
+
 ## What's New in 0.21.1
 
 > **Security maintenance release.** No library code changes vs 0.21.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surrealdb-orm"
-version = "0.21.4"
+version = "0.21.5"
 description = "SurrealDB ORM as 'DJango style' for Python with async support. Works with pydantic validation."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/surreal_orm/__init__.py
+++ b/src/surreal_orm/__init__.py
@@ -170,7 +170,7 @@ __all__ = [
     "retry_on_conflict",
 ]
 
-__version__ = "0.21.4"
+__version__ = "0.21.5"
 
 # ---------------------------------------------------------------------------
 # Deprecation notice (V2 LTS branch)

--- a/src/surreal_sdk/__init__.py
+++ b/src/surreal_sdk/__init__.py
@@ -74,7 +74,7 @@ from .types import (
     ResponseStatus,
 )
 
-__version__ = "0.21.4"
+__version__ = "0.21.5"
 __all__ = [
     # Connections
     "BaseSurrealConnection",

--- a/src/surreal_sdk/pyproject.toml
+++ b/src/surreal_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surreal-sdk"
-version = "0.21.4"
+version = "0.21.5"
 description = "Custom Python SDK for SurrealDB with HTTP and WebSocket support. No dependency on official surrealdb package."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -261,7 +261,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -1538,7 +1538,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb-orm"
-version = "0.21.4"
+version = "0.21.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
V2 LTS bug-fix release, carrying the four correctness fixes backported from `main`: #187, #189, #190, #191.

**Patch, not minor** — the line is documented as security and bug fixes only, and that is what these are. The new public API they bring (`to_record_id()`, `record_link_to_str()`, `instance.record_id`, `get_foreign_key_*`, `MigrationStatementError`, the `from_field_state` factories) is the surface those fixes needed, not new capability.

### What ships

| Fix | Symptom on 2.6.5 |
| --- | --- |
| #187 | `AlterField` emitted a plain `DEFINE FIELD`, which the server rejects for an existing field — every alter *and every rollback* was a silent no-op |
| #187 | A rejected statement rode back inside a **successful** RPC, so the executor reported success for migrations that changed nothing |
| #189 | `ManyToMany` / `Relation` emitted as `any` columns; a `str \| None` field reached the database as a **required** column |
| #191 | `ForeignKey` writes rejected by `record<>` columns, and whole-record filters returning `[]` for rows that existed — a wrong answer, not an error |
| #190 | `makemigrations` diffed against an empty schema, re-emitting every table every run; plus `PERMISSIONS NONE` reading as a configured value |

### Every fix was reproduced here first

The two lines have diverged far enough that "it mattered on `main`" is not evidence it matters on `v2`. Each backport opened with a probe against a live 2.6.5, and **two candidates were dropped on that basis**:

- the SurrealDB 3.0 **`REFERENCE` / `ON DELETE`** half of #170 — record references are a 3.0 feature and `ReferencesField` does not exist on this branch;
- **#135** (permission-denied updates no-opping silently) — already present here. My first grep-based audit had it wrong; the probe showed `merge()` on a missing record already raises `SurrealDbError`.

### Behaviour change

`makemigrations` contacts the database by default and fails with a clear error when it cannot read the schema, rather than falling back to an empty one — that fallback *is* the bug. `--no-from-db` restores the old path for a genuine first migration or offline use.

### Files updated (release checklist)

| File | Change |
| --- | --- |
| `pyproject.toml`, `src/surreal_sdk/pyproject.toml` | `version` → 0.21.5 |
| `src/surreal_orm/__init__.py`, `src/surreal_sdk/__init__.py` | `__version__` → 0.21.5 |
| `uv.lock` | relocked |
| `CHANGELOG` | new `[0.21.5]` entry |
| `README.md` | "What's New in 0.21.5" |
| `CLAUDE.md` | header date/version, `## Current Version`, "What's New" |

**Deliberately untouched:** `SECURITY.md` — its table already covers `0.21.x`, and per the checklist it only moves when the minor line or the SurrealDB floor does.

### Verification

`ruff format --check`, `ruff check`, `mypy src/` (64 files), the unit suite, the CLI suite (30 passed, with the `cli` extra), and the integration suite against **SurrealDB 2.6.5** — all clean.