### PR TITLE
fix(orm): stop re.sub parsing inlined JSON as a replacement pattern

### DIFF
--- a/src/surreal_orm/utils.py
+++ b/src/surreal_orm/utils.py
@@ -227,6 +227,30 @@ def _extract_datetime_values(
     return value
 
 
+def _literal_replacement(literal: str) -> Callable[[re.Match[str]], str]:
+    """
+    Build a ``re.sub`` replacement that inserts *literal* verbatim.
+
+    ``re.sub`` reads a replacement **string** as a mini-pattern: ``\\1`` is a
+    backreference, ``\\g<0>`` a group reference, and an unknown escape is an error.
+    JSON is full of both — ``json.dumps`` emits ``\\uXXXX`` for every non-ASCII
+    character and doubles every literal backslash — so passing it directly raises
+    ``bad escape \\u`` on any accented text and silently collapses the backslashes
+    in a Windows path.
+
+    A callable replacement is exempt from that parsing: its return value is used
+    as-is. Taking the text as a parameter (rather than closing over a loop
+    variable) keeps the binding unambiguous.
+
+    Args:
+        literal: The exact text to substitute
+
+    Returns:
+        A replacement callable suitable for :func:`re.sub`
+    """
+    return lambda _match: literal
+
+
 def inline_dict_variables(
     query: str,
     variables: dict[str, Any],
@@ -271,7 +295,7 @@ def inline_dict_variables(
                 json_str = json_str.replace(f'"{marker}"', literal)
 
             # Replace $key with inline JSON (word-boundary to avoid partial matches)
-            query = re.sub(rf"\${re.escape(key)}\b", json_str, query)
+            query = re.sub(rf"\${re.escape(key)}\b", _literal_replacement(json_str), query)
         else:
             remaining[key] = value
     return query, remaining

--- a/src/surreal_orm/utils.py
+++ b/src/surreal_orm/utils.py
@@ -4,10 +4,10 @@ import json
 import logging
 import random
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any, TypeVar
 
-from surreal_sdk.utils import substitute_params
+from surreal_sdk.utils import find_param_references, substitute_params
 
 logger = logging.getLogger(__name__)
 
@@ -199,6 +199,10 @@ class _SurrealJSONEncoder(json.JSONEncoder):
         return super().default(o)
 
 
+#: A ``__SURQL_DT_N__`` placeholder, including the JSON quotes around it.
+_DATETIME_MARKER = re.compile(r'"(__SURQL_DT_\d+__)"')
+
+
 def _extract_datetime_values(
     value: Any,
     markers: dict[str, str],
@@ -229,6 +233,16 @@ def _extract_datetime_values(
     return value
 
 
+def _expand_datetime_markers(json_str: str, markers: Mapping[str, str]) -> str:
+    """Swap each quoted ``__SURQL_DT_N__`` placeholder for its ``d"..."`` literal.
+
+    Takes *markers* as a parameter rather than closing over the caller's loop
+    variable, which ruff flags (B023) and which would be a real bug if the
+    callable outlived the iteration.
+    """
+    return _DATETIME_MARKER.sub(lambda match: markers[match.group(1)], json_str)
+
+
 def inline_dict_variables(
     query: str,
     variables: dict[str, Any],
@@ -253,11 +267,20 @@ def inline_dict_variables(
 
     Returns:
         ``(modified_query, remaining_variables)`` tuple.
+
+    Raises:
+        ValueError: If a referenced complex value cannot be serialized.
     """
+    # Which names the query actually uses. Without this a complex value whose
+    # reference is absent — or not a valid identifier, such as ``$my-var`` —
+    # would be serialized for nothing and then dropped from both the query and
+    # the returned bindings, silently.
+    referenced = find_param_references(query)
+
     inlined: dict[str, str] = {}
     remaining: dict[str, Any] = {}
     for key, value in variables.items():
-        if not _is_complex_value(value):
+        if key not in referenced or not _is_complex_value(value):
             remaining[key] = value
             continue
 
@@ -271,13 +294,19 @@ def inline_dict_variables(
             # them as UTF-16 surrogate pairs (\ud83d\ude42), which SurrealDB 3.x
             # rejects at parse time: "String contains invalid escape sequence".
             json_str = json.dumps(processed, cls=_SurrealJSONEncoder, ensure_ascii=False)
-        except (TypeError, ValueError) as e:
+            # ensure_ascii=False also lets a lone surrogate through json.dumps;
+            # encoding here keeps the failure inside the promised ValueError
+            # instead of surfacing as a UnicodeEncodeError in the CBOR encoder.
+            json_str.encode("utf-8")
+        except (TypeError, ValueError, UnicodeEncodeError) as e:
             raise ValueError(f"Failed to serialize variable '{key}' to JSON for inlining: {e}") from e
 
-        # Replace datetime marker strings (with JSON quotes) with
-        # unwrapped SurrealQL d"..." literals.
-        for marker, literal in dt_markers.items():
-            json_str = json_str.replace(f'"{marker}"', literal)
+        # Replace datetime marker strings (with JSON quotes) with unwrapped
+        # SurrealQL d"..." literals — one pass, for the same reason the query
+        # substitution is one pass: a str.replace per marker rescans the whole
+        # payload, which is quadratic in the number of datetimes.
+        if dt_markers:
+            json_str = _expand_datetime_markers(json_str, dt_markers)
 
         inlined[key] = json_str
 

--- a/src/surreal_orm/utils.py
+++ b/src/surreal_orm/utils.py
@@ -7,6 +7,8 @@ import re
 from collections.abc import Callable
 from typing import Any, TypeVar
 
+from surreal_sdk.utils import substitute_params
+
 logger = logging.getLogger(__name__)
 
 F = TypeVar("F", bound=Callable[..., Any])
@@ -227,30 +229,6 @@ def _extract_datetime_values(
     return value
 
 
-def _literal_replacement(literal: str) -> Callable[[re.Match[str]], str]:
-    """
-    Build a ``re.sub`` replacement that inserts *literal* verbatim.
-
-    ``re.sub`` reads a replacement **string** as a mini-pattern: ``\\1`` is a
-    backreference, ``\\g<0>`` a group reference, and an unknown escape is an error.
-    JSON is full of both — ``json.dumps`` emits ``\\uXXXX`` for every non-ASCII
-    character and doubles every literal backslash — so passing it directly raises
-    ``bad escape \\u`` on any accented text and silently collapses the backslashes
-    in a Windows path.
-
-    A callable replacement is exempt from that parsing: its return value is used
-    as-is. Taking the text as a parameter (rather than closing over a loop
-    variable) keeps the binding unambiguous.
-
-    Args:
-        literal: The exact text to substitute
-
-    Returns:
-        A replacement callable suitable for :func:`re.sub`
-    """
-    return lambda _match: literal
-
-
 def inline_dict_variables(
     query: str,
     variables: dict[str, Any],
@@ -276,29 +254,37 @@ def inline_dict_variables(
     Returns:
         ``(modified_query, remaining_variables)`` tuple.
     """
+    inlined: dict[str, str] = {}
     remaining: dict[str, Any] = {}
     for key, value in variables.items():
-        if _is_complex_value(value):
-            # Extract datetime objects as markers so they become d"..." literals
-            dt_markers: dict[str, str] = {}
-            counter = [0]
-            processed = _extract_datetime_values(value, dt_markers, counter)
-
-            try:
-                json_str = json.dumps(processed, cls=_SurrealJSONEncoder)
-            except (TypeError, ValueError) as e:
-                raise ValueError(f"Failed to serialize variable '{key}' to JSON for inlining: {e}") from e
-
-            # Replace datetime marker strings (with JSON quotes) with
-            # unwrapped SurrealQL d"..." literals.
-            for marker, literal in dt_markers.items():
-                json_str = json_str.replace(f'"{marker}"', literal)
-
-            # Replace $key with inline JSON (word-boundary to avoid partial matches)
-            query = re.sub(rf"\${re.escape(key)}\b", _literal_replacement(json_str), query)
-        else:
+        if not _is_complex_value(value):
             remaining[key] = value
-    return query, remaining
+            continue
+
+        # Extract datetime objects as markers so they become d"..." literals
+        dt_markers: dict[str, str] = {}
+        counter = [0]
+        processed = _extract_datetime_values(value, dt_markers, counter)
+
+        try:
+            # ensure_ascii=False keeps astral characters raw. The default emits
+            # them as UTF-16 surrogate pairs (\ud83d\ude42), which SurrealDB 3.x
+            # rejects at parse time: "String contains invalid escape sequence".
+            json_str = json.dumps(processed, cls=_SurrealJSONEncoder, ensure_ascii=False)
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"Failed to serialize variable '{key}' to JSON for inlining: {e}") from e
+
+        # Replace datetime marker strings (with JSON quotes) with
+        # unwrapped SurrealQL d"..." literals.
+        for marker, literal in dt_markers.items():
+            json_str = json_str.replace(f'"{marker}"', literal)
+
+        inlined[key] = json_str
+
+    # One pass over the original query: substituting key by key would re-scan
+    # the JSON just inserted, so a "$b" inside a string value of $a would be
+    # replaced too, with the outcome depending on dict order.
+    return substitute_params(query, inlined), remaining
 
 
 def retry_on_conflict(

--- a/src/surreal_sdk/__init__.py
+++ b/src/surreal_sdk/__init__.py
@@ -74,6 +74,7 @@ from .types import (
     RecordsResponse,
     ResponseStatus,
 )
+from .utils import find_param_references, substitute_params
 
 __version__ = "0.33.2"
 __all__ = [
@@ -135,6 +136,9 @@ __all__ = [
     "TimeoutError",
     "TransactionError",
     "TransactionConflictError",
+    # Query-string helpers
+    "find_param_references",
+    "substitute_params",
 ]
 
 

--- a/src/surreal_sdk/streaming/live_select.py
+++ b/src/surreal_sdk/streaming/live_select.py
@@ -13,6 +13,7 @@ from typing import Any, Self
 
 from ..connection.websocket import WebSocketConnection
 from ..exceptions import LiveQueryError
+from ..utils import substitute_params
 
 _SAFE_TABLE_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
@@ -205,15 +206,16 @@ class LiveSelectStream:
     def _inline_params_static(sql: str, params: dict[str, Any]) -> str:
         """Replace $param references with inline values in the SQL string.
 
-        Uses regex word-boundary matching to avoid substituting partial
-        tokens or occurrences inside string literals.
+        Substitution goes through :func:`substitute_params`, which inserts each
+        rendered value verbatim and in a single pass. Verbatim matters here
+        because ``_format_value`` deliberately doubles backslashes: the previous
+        ``re.sub`` collapsed them straight back, SurrealQL read ``\t`` as a tab,
+        and the live filter silently matched nothing. Sorting keys by length is
+        no longer needed — the reference pattern is greedy, so ``$_f1`` cannot
+        match inside ``$_f10``.
         """
-        result = sql
-        for key in sorted(params, key=len, reverse=True):
-            # Match $key only when followed by a non-identifier character (or end of string)
-            pattern = re.escape(f"${key}") + r"(?![a-zA-Z0-9_])"
-            result = re.sub(pattern, LiveSelectStream._format_value(params[key]), result)
-        return result
+        rendered = {key: LiveSelectStream._format_value(value) for key, value in params.items()}
+        return substitute_params(sql, rendered)
 
     async def start(self) -> str:
         """

--- a/src/surreal_sdk/streaming/live_select.py
+++ b/src/surreal_sdk/streaming/live_select.py
@@ -204,15 +204,13 @@ class LiveSelectStream:
 
     @staticmethod
     def _inline_params_static(sql: str, params: dict[str, Any]) -> str:
-        """Replace $param references with inline values in the SQL string.
+        r"""Replace $param references with inline values in the SQL string.
 
-        Substitution goes through :func:`substitute_params`, which inserts each
-        rendered value verbatim and in a single pass. Verbatim matters here
-        because ``_format_value`` deliberately doubles backslashes: the previous
-        ``re.sub`` collapsed them straight back, SurrealQL read ``\t`` as a tab,
-        and the live filter silently matched nothing. Sorting keys by length is
-        no longer needed — the reference pattern is greedy, so ``$_f1`` cannot
-        match inside ``$_f10``.
+        Verbatim insertion is what matters here: ``_format_value`` deliberately
+        doubles backslashes, and the previous ``re.sub`` replacement-string
+        parsing collapsed them straight back, so SurrealQL read ``\t`` as a tab
+        and the live filter silently matched nothing. See
+        :func:`~surreal_sdk.utils.substitute_params`.
         """
         rendered = {key: LiveSelectStream._format_value(value) for key, value in params.items()}
         return substitute_params(sql, rendered)

--- a/src/surreal_sdk/utils.py
+++ b/src/surreal_sdk/utils.py
@@ -1,0 +1,54 @@
+"""
+Shared helpers for building SurrealQL query strings.
+
+Lives in the SDK because both layers need it and the dependency only runs one
+way: ``surreal_orm`` imports from ``surreal_sdk``, never the reverse.
+"""
+
+import re
+from collections.abc import Mapping
+
+__all__ = ["substitute_params"]
+
+#: A ``$name`` reference. ``\w+`` is greedy on purpose: it captures the whole
+#: identifier, so ``$state`` cannot match the prefix of ``$state_backup``.
+_PARAM_REFERENCE = re.compile(r"\$(\w+)")
+
+
+def substitute_params(query: str, replacements: Mapping[str, str]) -> str:
+    """
+    Replace ``$name`` references with pre-rendered text, in a single pass.
+
+    Two properties matter, and both are easy to lose by hand:
+
+    **The text is inserted verbatim.** ``re.sub`` reads a replacement *string*
+    as a mini-pattern — ``\\1`` is a backreference, ``\\g<0>`` a group
+    reference, and an unknown escape is an error. Rendered SurrealQL is full of
+    backslashes (JSON doubles every literal one; ``_format_value`` escapes
+    quotes), so passing it as a string raises on some inputs and silently
+    collapses backslashes on others. A *callable* replacement is exempt from
+    that parsing.
+
+    **It is one pass over the original query.** Substituting one key at a time
+    re-scans text that was just inserted, so a ``$b`` occurring inside a string
+    value of ``$a`` gets replaced too — and which one wins depends on mapping
+    order.
+
+    A reference with no entry in *replacements* is left as it was, so callers
+    can inline some parameters and leave the rest as bindings.
+
+    Args:
+        query: SurrealQL containing ``$name`` references
+        replacements: Reference name to the exact text that replaces it
+
+    Returns:
+        The query with every known reference substituted
+
+    Examples:
+        substitute_params("SET a = $a", {"a": '{"x": 1}'})   # 'SET a = {"x": 1}'
+        substitute_params("SET a = $a", {})                  # 'SET a = $a'
+    """
+    if not replacements:
+        return query
+
+    return _PARAM_REFERENCE.sub(lambda match: replacements.get(match.group(1), match.group(0)), query)

--- a/src/surreal_sdk/utils.py
+++ b/src/surreal_sdk/utils.py
@@ -8,22 +8,39 @@ way: ``surreal_orm`` imports from ``surreal_sdk``, never the reverse.
 import re
 from collections.abc import Mapping
 
-__all__ = ["substitute_params"]
+__all__ = ["find_param_references", "substitute_params"]
 
 #: A ``$name`` reference. ``\w+`` is greedy on purpose: it captures the whole
 #: identifier, so ``$state`` cannot match the prefix of ``$state_backup``.
-_PARAM_REFERENCE = re.compile(r"\$(\w+)")
+#: ``re.ASCII`` matches SurrealDB's own identifier lexer, which is ASCII — an
+#: accented name is not a reference the server would bind either.
+_PARAM_REFERENCE = re.compile(r"\$(\w+)", re.ASCII)
+
+
+def find_param_references(query: str) -> set[str]:
+    """Return the ``$name`` references that appear in *query*.
+
+    Lets a caller tell "this parameter is used" from "this parameter is not",
+    which :func:`substitute_params` alone cannot: an unmatched entry in its
+    replacements is indistinguishable from one that matched.
+
+    Args:
+        query: SurrealQL possibly containing ``$name`` references
+
+    Returns:
+        The referenced names, without the leading ``$``
+    """
+    return set(_PARAM_REFERENCE.findall(query))
 
 
 def substitute_params(query: str, replacements: Mapping[str, str]) -> str:
-    """
-    Replace ``$name`` references with pre-rendered text, in a single pass.
+    r"""Replace ``$name`` references with pre-rendered text, in a single pass.
 
     Two properties matter, and both are easy to lose by hand:
 
     **The text is inserted verbatim.** ``re.sub`` reads a replacement *string*
-    as a mini-pattern — ``\\1`` is a backreference, ``\\g<0>`` a group
-    reference, and an unknown escape is an error. Rendered SurrealQL is full of
+    as a mini-pattern — ``\1`` is a backreference, ``\g<0>`` a group reference,
+    and an unknown escape is an error. Rendered SurrealQL is full of
     backslashes (JSON doubles every literal one; ``_format_value`` escapes
     quotes), so passing it as a string raises on some inputs and silently
     collapses backslashes on others. A *callable* replacement is exempt from
@@ -37,6 +54,11 @@ def substitute_params(query: str, replacements: Mapping[str, str]) -> str:
     A reference with no entry in *replacements* is left as it was, so callers
     can inline some parameters and leave the rest as bindings.
 
+    .. note::
+
+        The scan is textual: a ``$name`` written inside a quoted SurrealQL
+        string literal is substituted like any other reference.
+
     Args:
         query: SurrealQL containing ``$name`` references
         replacements: Reference name to the exact text that replaces it
@@ -48,7 +70,4 @@ def substitute_params(query: str, replacements: Mapping[str, str]) -> str:
         substitute_params("SET a = $a", {"a": '{"x": 1}'})   # 'SET a = {"x": 1}'
         substitute_params("SET a = $a", {})                  # 'SET a = $a'
     """
-    if not replacements:
-        return query
-
     return _PARAM_REFERENCE.sub(lambda match: replacements.get(match.group(1), match.group(0)), query)

--- a/tests/sdk/test_utils.py
+++ b/tests/sdk/test_utils.py
@@ -1,0 +1,66 @@
+"""Tests for the shared SurrealQL query-string helpers."""
+
+import re
+
+import pytest
+
+from surreal_sdk.utils import find_param_references, substitute_params
+
+
+class TestSubstituteParams:
+    """Tests for substitute_params()."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            pytest.param("\\1", id="backreference"),
+            pytest.param("\\g<0>", id="group-reference"),
+            pytest.param("C:\\temp\\x", id="backslashes"),
+            pytest.param('{"nom": "caf\\u00e9"}', id="unicode-escape"),
+        ],
+    )
+    def test_replacement_text_is_inserted_verbatim(self, text: str) -> None:
+        """A replacement *string* would be parsed as a mini-pattern.
+
+        ``\\1`` is a backreference, ``\\g<0>`` a group reference, and ``\\u`` an
+        unknown escape that raises ``re.error``. The callable form is exempt.
+        """
+        assert substitute_params("SET a = $a", {"a": text}) == f"SET a = {text}"
+
+    def test_a_bad_escape_would_have_raised_as_a_replacement_string(self) -> None:
+        """Pin the failure mode this helper exists to avoid."""
+        with pytest.raises(re.error):
+            re.sub(r"\$a", '{"nom": "caf\\u00e9"}', "SET a = $a")
+
+    def test_substitution_is_a_single_pass_over_the_original(self) -> None:
+        """A ``$b`` inside the text inserted for ``$a`` must not be substituted."""
+        result = substitute_params("SET a = $a, b = $b", {"a": "cost $b here", "b": "X"})
+
+        assert result == "SET a = cost $b here, b = X"
+
+    def test_a_longer_reference_is_not_matched_by_a_shorter_key(self) -> None:
+        """``\\w+`` is greedy, so ``$_f1`` cannot match inside ``$_f10``."""
+        result = substitute_params("x = $_f1 AND y = $_f10", {"_f1": "a", "_f10": "b"})
+
+        assert result == "x = a AND y = b"
+
+    def test_an_unknown_reference_is_left_alone(self) -> None:
+        assert substitute_params("SET a = $a", {}) == "SET a = $a"
+
+    def test_a_non_ascii_reference_is_not_a_reference(self) -> None:
+        """SurrealDB's identifier lexer is ASCII; the pattern matches it."""
+        assert substitute_params("SET a = $pé", {"pé": "X"}) == "SET a = $pé"
+
+
+class TestFindParamReferences:
+    """Tests for find_param_references()."""
+
+    def test_returns_the_referenced_names(self) -> None:
+        assert find_param_references("SET a = $a, b = $b_2") == {"a", "b_2"}
+
+    def test_a_name_that_is_not_an_identifier_is_not_referenced(self) -> None:
+        """``$my-var`` references ``my``; the caller must not treat it as ``my-var``."""
+        assert find_param_references("SET a = $my-var") == {"my"}
+
+    def test_no_references(self) -> None:
+        assert find_param_references("SELECT * FROM users") == set()

--- a/tests/test_issue_55_unit.py
+++ b/tests/test_issue_55_unit.py
@@ -371,3 +371,54 @@ class TestConnectionCacheInvalidation:
         # Cleanup
         SurrealDBConnectionManager._configs.pop("test_cache2", None)
         SurrealDBConnectionManager._clients.pop("test_cache2", None)
+
+
+class TestInlineDictVariablesEscapes:
+    """``re.sub`` reads its *replacement* as a pattern, not as literal text.
+
+    ``json.dumps`` emits ``\\uXXXX`` for any non-ASCII character and doubles every
+    backslash, and ``re.sub`` then tries to interpret those sequences:
+
+        {"nom": "café"}          -> PatternError: bad escape \\u
+        {"path": "C:\\temp"}      -> the doubled backslash is collapsed, silently
+                                    corrupting the value
+
+    So the crash hits any accented text and the corruption hits any Windows path
+    or regex-ish string. Both go through the inlining path added for #55, which
+    exists precisely to carry complex nested data.
+    """
+
+    def test_non_ascii_content_does_not_raise(self) -> None:
+        """An accent used to abort the whole query with a regex PatternError."""
+        variables = {"state": {"joueur": {"nom": "café"}}}
+
+        new_query, _ = inline_dict_variables("UPDATE t:1 SET state = $state", variables)
+
+        assert "$state" not in new_query
+
+    def test_non_ascii_content_round_trips(self) -> None:
+        """And the value survives, rather than merely not crashing."""
+        state = {"joueur": {"nom": "café", "ville": "Montréal"}}
+
+        new_query, _ = inline_dict_variables("UPDATE t:1 SET state = $state", {"state": state})
+        parsed = json.loads(new_query[len("UPDATE t:1 SET state = ") :])
+
+        assert parsed == state
+
+    def test_backslashes_are_not_collapsed(self) -> None:
+        """A Windows path used to lose one backslash per pair, silently."""
+        state = {"cfg": {"path": "C:\\temp\\x"}}
+
+        new_query, _ = inline_dict_variables("UPDATE t:1 SET state = $state", {"state": state})
+        parsed = json.loads(new_query[len("UPDATE t:1 SET state = ") :])
+
+        assert parsed == state
+
+    def test_regex_backreferences_are_literal(self) -> None:
+        """``\\1`` and ``\\g<0>`` are replacement syntax — they must stay data."""
+        state = {"tpl": {"group": "\\g<0>", "backref": "\\1"}}
+
+        new_query, _ = inline_dict_variables("UPDATE t:1 SET state = $state", {"state": state})
+        parsed = json.loads(new_query[len("UPDATE t:1 SET state = ") :])
+
+        assert parsed == state

--- a/tests/test_issue_55_unit.py
+++ b/tests/test_issue_55_unit.py
@@ -374,16 +374,16 @@ class TestConnectionCacheInvalidation:
 
 
 @pytest.mark.parametrize(
-    ("label", "value"),
+    "value",
     [
-        ("bmp", {"joueur": {"nom": "café", "ville": "Montréal"}}),
-        ("astral", {"joueur": {"nom": "Zoé 🙂", "emoji": "👨‍👩‍👧"}}),
-        ("backslashes", {"cfg": {"path": "C:\\temp\\x"}}),
-        ("backreferences", {"tpl": {"group": "\\g<0>", "backref": "\\1"}}),
-        ("quotes", {"txt": {"q": 'he said "hi"', "a": "it's"}}),
+        pytest.param({"joueur": {"nom": "café", "ville": "Montréal"}}, id="bmp"),
+        pytest.param({"joueur": {"nom": "Zoé 🙂", "emoji": "👨‍👩‍👧"}}, id="astral"),
+        pytest.param({"cfg": {"path": "C:\\temp\\x"}}, id="backslashes"),
+        pytest.param({"tpl": {"group": "\\g<0>", "backref": "\\1"}}, id="backreferences"),
+        pytest.param({"txt": {"q": 'he said "hi"', "a": "it's"}}, id="quotes"),
     ],
 )
-def test_inlined_json_survives_re_sub_replacement_syntax(label: str, value: dict) -> None:
+def test_inlined_json_survives_re_sub_replacement_syntax(value: dict) -> None:
     """The JSON reaches the query verbatim, whatever it contains.
 
     Passing it to ``re.sub`` as a replacement *string* raised ``re.error`` on
@@ -427,17 +427,6 @@ def test_a_later_key_does_not_rewrite_earlier_inlined_json() -> None:
     assert '"cost $b here"' in new_query, new_query
 
 
-def test_a_longer_key_is_not_matched_by_a_shorter_one() -> None:
-    """``$state`` must not match inside ``$state_backup`` (pre-existing guarantee)."""
-    query = "UPDATE t:1 SET a = $state, b = $state_backup"
-    variables = {"state": {"x": {"y": 1}}, "state_backup": {"z": {"w": 2}}}
-
-    new_query, _ = inline_dict_variables(query, variables)
-
-    assert '"y": 1' in new_query
-    assert '"w": 2' in new_query
-
-
 def test_an_unknown_reference_is_left_alone() -> None:
     """A ``$name`` with no matching variable stays a binding reference."""
     new_query, remaining = inline_dict_variables(
@@ -446,3 +435,50 @@ def test_an_unknown_reference_is_left_alone() -> None:
 
     assert "$untouched" in new_query
     assert remaining == {"untouched": "simple"}
+
+
+def test_an_unreferenced_complex_variable_stays_a_binding() -> None:
+    """A complex value the query never mentions must not vanish.
+
+    It used to be serialized, matched against nothing, and then dropped from
+    both the query and the returned bindings — silently, and after paying for
+    the serialization.
+    """
+    query = "UPDATE t:1 SET a = 1"
+    variables = {"state": {"x": {"y": 1}}}
+
+    new_query, remaining = inline_dict_variables(query, variables)
+
+    assert new_query == query
+    assert remaining == variables
+
+
+def test_a_key_that_is_not_an_identifier_stays_a_binding() -> None:
+    """``$my-var`` is ``$my`` followed by ``-var`` to SurrealDB's lexer."""
+    new_query, remaining = inline_dict_variables("UPDATE t:1 SET a = $my-var", {"my-var": {"x": {"y": 1}}})
+
+    assert new_query == "UPDATE t:1 SET a = $my-var"
+    assert remaining == {"my-var": {"x": {"y": 1}}}
+
+
+def test_a_lone_surrogate_raises_the_documented_error() -> None:
+    """``ensure_ascii=False`` lets it past ``json.dumps``.
+
+    Without the explicit encode it surfaced much later, as a
+    ``UnicodeEncodeError`` from inside the CBOR encoder, instead of the
+    ``ValueError`` this function documents.
+    """
+    with pytest.raises(ValueError, match="Failed to serialize variable 'state'"):
+        inline_dict_variables("UPDATE t:1 SET state = $state", {"state": {"x": {"s": "ab\udcff"}}})
+
+
+def test_datetimes_become_surql_literals() -> None:
+    """Every marker is expanded, in one pass over the payload."""
+    from datetime import UTC, datetime
+
+    value = {"rows": [{"at": datetime(2026, 1, 2, 3, 4, tzinfo=UTC)} for _ in range(3)]}
+
+    new_query, _ = inline_dict_variables("UPDATE t:1 SET state = $state", {"state": value})
+
+    assert new_query.count('d"2026-01-02T03:04:00+00:00"') == 3
+    assert "__SURQL_DT_" not in new_query

--- a/tests/test_issue_55_unit.py
+++ b/tests/test_issue_55_unit.py
@@ -373,52 +373,76 @@ class TestConnectionCacheInvalidation:
         SurrealDBConnectionManager._clients.pop("test_cache2", None)
 
 
-class TestInlineDictVariablesEscapes:
-    """``re.sub`` reads its *replacement* as a pattern, not as literal text.
+@pytest.mark.parametrize(
+    ("label", "value"),
+    [
+        ("bmp", {"joueur": {"nom": "café", "ville": "Montréal"}}),
+        ("astral", {"joueur": {"nom": "Zoé 🙂", "emoji": "👨‍👩‍👧"}}),
+        ("backslashes", {"cfg": {"path": "C:\\temp\\x"}}),
+        ("backreferences", {"tpl": {"group": "\\g<0>", "backref": "\\1"}}),
+        ("quotes", {"txt": {"q": 'he said "hi"', "a": "it's"}}),
+    ],
+)
+def test_inlined_json_survives_re_sub_replacement_syntax(label: str, value: dict) -> None:
+    """The JSON reaches the query verbatim, whatever it contains.
 
-    ``json.dumps`` emits ``\\uXXXX`` for any non-ASCII character and doubles every
-    backslash, and ``re.sub`` then tries to interpret those sequences:
-
-        {"nom": "café"}          -> PatternError: bad escape \\u
-        {"path": "C:\\temp"}      -> the doubled backslash is collapsed, silently
-                                    corrupting the value
-
-    So the crash hits any accented text and the corruption hits any Windows path
-    or regex-ish string. Both go through the inlining path added for #55, which
-    exists precisely to carry complex nested data.
+    Passing it to ``re.sub`` as a replacement *string* raised ``re.error`` on
+    accented text and silently collapsed backslashes elsewhere; see
+    :func:`surreal_sdk.utils.substitute_params` for why.
     """
+    prefix = "UPDATE t:1 SET state = "
+    new_query, remaining = inline_dict_variables(f"{prefix}$state", {"state": value})
 
-    def test_non_ascii_content_does_not_raise(self) -> None:
-        """An accent used to abort the whole query with a regex PatternError."""
-        variables = {"state": {"joueur": {"nom": "café"}}}
+    assert new_query.startswith(prefix), new_query
+    assert json.loads(new_query.removeprefix(prefix)) == value
+    assert remaining == {}
 
-        new_query, _ = inline_dict_variables("UPDATE t:1 SET state = $state", variables)
 
-        assert "$state" not in new_query
+def test_astral_characters_are_not_escaped_as_surrogate_pairs() -> None:
+    """Emoji must go out raw, not as ``\\ud83d\\ude42``.
 
-    def test_non_ascii_content_round_trips(self) -> None:
-        """And the value survives, rather than merely not crashing."""
-        state = {"joueur": {"nom": "café", "ville": "Montréal"}}
+    ``json.loads`` accepts a surrogate pair, so a round-trip assertion cannot
+    see this — but SurrealDB 3.x rejects the escape at parse time:
+    ``String contains invalid escape sequence, unicode escape character is not
+    a valid unicode character``. Assert on the emitted text instead.
+    """
+    new_query, _ = inline_dict_variables("UPDATE t:1 SET state = $state", {"state": {"a": {"s": "🙂"}}})
 
-        new_query, _ = inline_dict_variables("UPDATE t:1 SET state = $state", {"state": state})
-        parsed = json.loads(new_query[len("UPDATE t:1 SET state = ") :])
+    assert "🙂" in new_query
+    assert "\\ud83d" not in new_query
 
-        assert parsed == state
 
-    def test_backslashes_are_not_collapsed(self) -> None:
-        """A Windows path used to lose one backslash per pair, silently."""
-        state = {"cfg": {"path": "C:\\temp\\x"}}
+def test_a_later_key_does_not_rewrite_earlier_inlined_json() -> None:
+    """Substitution is a single pass over the original query.
 
-        new_query, _ = inline_dict_variables("UPDATE t:1 SET state = $state", {"state": state})
-        parsed = json.loads(new_query[len("UPDATE t:1 SET state = ") :])
+    Replacing one key at a time re-scanned the text already inserted, so a
+    ``$b`` appearing inside a *string value* of ``$a`` was substituted too — and
+    which one won depended on dict insertion order.
+    """
+    query = "UPDATE t:1 SET a = $a, b = $b"
+    variables = {"a": {"x": {"s": "cost $b here"}}, "b": {"y": [1]}}
 
-        assert parsed == state
+    new_query, _ = inline_dict_variables(query, variables)
 
-    def test_regex_backreferences_are_literal(self) -> None:
-        """``\\1`` and ``\\g<0>`` are replacement syntax — they must stay data."""
-        state = {"tpl": {"group": "\\g<0>", "backref": "\\1"}}
+    assert '"cost $b here"' in new_query, new_query
 
-        new_query, _ = inline_dict_variables("UPDATE t:1 SET state = $state", {"state": state})
-        parsed = json.loads(new_query[len("UPDATE t:1 SET state = ") :])
 
-        assert parsed == state
+def test_a_longer_key_is_not_matched_by_a_shorter_one() -> None:
+    """``$state`` must not match inside ``$state_backup`` (pre-existing guarantee)."""
+    query = "UPDATE t:1 SET a = $state, b = $state_backup"
+    variables = {"state": {"x": {"y": 1}}, "state_backup": {"z": {"w": 2}}}
+
+    new_query, _ = inline_dict_variables(query, variables)
+
+    assert '"y": 1' in new_query
+    assert '"w": 2' in new_query
+
+
+def test_an_unknown_reference_is_left_alone() -> None:
+    """A ``$name`` with no matching variable stays a binding reference."""
+    new_query, remaining = inline_dict_variables(
+        "UPDATE t:1 SET a = $a, b = $untouched", {"a": {"x": {"y": 1}}, "untouched": "simple"}
+    )
+
+    assert "$untouched" in new_query
+    assert remaining == {"untouched": "simple"}

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -842,6 +842,36 @@ class TestInlineParams:
         result = LiveSelectStream._inline_params_static(sql, {"_f0": "admin", "_f1": 18})
         assert result == "LIVE SELECT * FROM users WHERE role = 'admin' AND age >= 18"
 
+    def test_escaped_backslashes_survive_substitution(self) -> None:
+        """``_format_value`` doubles backslashes; ``re.sub`` used to undo that.
+
+        The formatted value went to ``re.sub`` as a *replacement string*, which
+        parses escapes — so ``'C:\\\\temp'`` came back out as ``'C:\\temp'``.
+        SurrealQL then reads ``\\t`` as a tab and the live filter silently
+        matches nothing. ``QuerySet.live()`` feeds user filter values here.
+        """
+        from src.surreal_sdk.streaming.live_select import LiveSelectStream
+
+        result = LiveSelectStream._inline_params_static("WHERE p = $p", {"p": "C:\\temp\\x"})
+
+        assert result == "WHERE p = 'C:\\\\temp\\\\x'", result
+
+    def test_regex_backreferences_in_a_value_are_literal(self) -> None:
+        """``\\1`` and ``\\g<0>`` are replacement syntax — they must stay data."""
+        from src.surreal_sdk.streaming.live_select import LiveSelectStream
+
+        result = LiveSelectStream._inline_params_static("WHERE p = $p", {"p": "\\g<0>"})
+
+        assert result == "WHERE p = '\\\\g<0>'", result
+
+    def test_a_later_key_does_not_rewrite_an_earlier_value(self) -> None:
+        """Substitution is a single pass over the original SQL."""
+        from src.surreal_sdk.streaming.live_select import LiveSelectStream
+
+        result = LiveSelectStream._inline_params_static("WHERE a = $a AND b = $b", {"a": "cost $b here", "b": "x"})
+
+        assert result == "WHERE a = 'cost $b here' AND b = 'x'", result
+
     def test_longer_key_first(self) -> None:
         """$_f10 should be replaced before $_f1 to avoid partial replacement."""
         from src.surreal_sdk.streaming.live_select import LiveSelectStream

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -872,8 +872,13 @@ class TestInlineParams:
 
         assert result == "WHERE a = 'cost $b here' AND b = 'x'", result
 
-    def test_longer_key_first(self) -> None:
-        """$_f10 should be replaced before $_f1 to avoid partial replacement."""
+    def test_a_shorter_key_does_not_match_inside_a_longer_reference(self) -> None:
+        r"""``$_f1`` must not match the prefix of ``$_f10``.
+
+        This used to be guaranteed by sorting the keys longest-first. It now
+        falls out of the greedy ``\w+`` in the shared reference pattern, which
+        captures the whole identifier — do not reintroduce the sort.
+        """
         from src.surreal_sdk.streaming.live_select import LiveSelectStream
 
         sql = "WHERE x = $_f1 AND y = $_f10"


### PR DESCRIPTION
No issue — this surfaced from a six-month-old `git stash` on `main` ("unknown utils.py change - re.sub lambda fix", 2026-03-09). The buggy line had not moved since, so the fix still applied verbatim. Rather than dropping the stash, I verified the bug is live and turned it into a real change with tests.

### The bug

`inline_dict_variables()` passed the serialised JSON straight to `re.sub` as a **replacement string**. `re.sub` reads that as a mini-pattern: `\1` is a backreference, `\g<0>` a group reference, and an unknown escape is an error. JSON is full of both.

Reproduced against the current `main`:

| Value in a nested dict | Before | After |
| --- | --- | --- |
| `{"nom": "café"}` | **`re.PatternError: bad escape \u`** — the whole query aborts | `"caf\u00e9"`, correct |
| `{"path": "C:\temp\x"}` | `C:\temp\x` — one backslash lost per pair | `C:\\temp\\x`, correct |
| `{"v": "\g<0>"}` | silently corrupted | preserved |
| `{"v": "\1"}` | silently corrupted | preserved |

`json.dumps` emits `\uXXXX` for **every non-ASCII character**, so any accented text crashes the call outright; and it doubles every literal backslash, which `re.sub` then collapses — quietly changing the data that reaches the database.

Two things make this worse than the line count suggests:

- This is the inlining path added in **0.14.3** specifically to carry *complex nested data* past the CBOR variable-binding limits of #55 — precisely the data most likely to contain an accent or a path.
- The backslash cases fail **silently**. The crash is loud and gets noticed; the corruption does not.

### The fix

A **callable** replacement is exempt from that parsing — `re.sub` uses its return value as-is.

```python
query = re.sub(rf"\${re.escape(key)}\b", _literal_replacement(json_str), query)
```

`_literal_replacement()` takes the text as a parameter rather than closing over the loop variable. That is not cosmetic: the stashed version used a bare `lambda _: json_str`, which trips ruff **B023** (closure over a loop variable), and the obvious workaround — `lambda _, v=json_str: v` — then fails mypy with `Cannot infer type of lambda`. A named, annotated helper satisfies both and gives the *why* one place to live.

### Verification

| Command | Result |
| --- | --- |
| `ruff format --check` / `ruff check` | clean |
| `mypy src/` | clean, 66 files |
| unit suite | exit 0, 0 failures |
| CLI suite (with the `cli` extra) | 30 passed |
| integration vs SurrealDB 3.2.4 | exit 0, 0 failures |

Four regression cases added to `tests/test_issue_55_unit.py`, next to the inlining tests they belong with. Each parses the emitted JSON back and compares it to the input, which is the assertion that actually catches this — two of them failed with `PatternError` before the fix, the other two with `JSONDecodeError` from the collapsed backslashes.

> A note on the mypy gate while working on this: running the CLI tests first installs the `cli` extra, after which `mypy` reports 38 spurious `unused-ignore` errors in `cli/commands.py`. `CLAUDE.md` documents this; `uv sync --group lint --exact` restores a CI-equivalent environment. Worth running the CLI suite *after* the gates, not before.

### Release notes required

Docs are not touched here, per the release-checklist convention. The release PR needs:

- **Fixed** — `raw_query(inline_dicts=True)` crashed with `re.error` on accented text and silently dropped backslashes from strings such as Windows paths; astral characters (emoji) were then rejected by SurrealDB 3.x as invalid escape sequences. Inlined JSON is now substituted verbatim, with `ensure_ascii=False`.
- **Fixed** — live queries inlined their filter values through the same defective path, so a backslash in a `QuerySet.live()` filter silently matched nothing.
- **Fixed** — inlining two complex variables in one query could rewrite text inside the first one's JSON, with the result depending on dict order.

### Backport

The same line exists verbatim on `v2` (`utils.py:274`), and it is a correctness bug, so it qualifies. I have **not** opened that PR — say the word and I will.


---

## Review round

Every point was reproduced before changing anything. Three defects were real and are fixed; the release note above is corrected.

**1. Astral characters still failed, server-side.** `json.dumps` defaults to `ensure_ascii=True`, emitting a UTF-16 surrogate pair for anything outside the BMP, which SurrealDB 3.2.4 rejects:

```
RETURN {"x": {"s": "\ud83d\ude42"}};
Parse error: String contains invalid escape sequence, unicode escape character is not a valid unicode character.
```

BMP text (`caf\u00e9`) does decode, so my original "any non-ASCII content" was too broad — corrected in the release note. `ensure_ascii=False` sends the character raw. Verified end to end through `raw_query`: an emoji, a ZWJ family sequence and a Windows path all come back from a live 3.2.4 identical to the input. The point about the tests not seeing this is right and worth keeping: `json.loads` accepts surrogate pairs, so the new test asserts on the emitted text instead of round-tripping.

**2. The second site was live.** `LiveSelectStream._inline_params_static` reproduced exactly:

```python
_inline_params_static('WHERE p = $p', {'p': 'C:\\temp\\x'})  # -> WHERE p = 'C:\temp\x'
```

**3. Cross-key rewriting reproduced verbatim**, including the order dependence.

All three now go through **`surreal_sdk.utils.substitute_params()`** — in the SDK, since the dependency only runs one way. It substitutes verbatim and in a single pass, which removes `_literal_replacement` and with it the B023 / mypy-inference workarounds, and lets `live_select` stop sorting keys by length (greedy `\w+` already prevents `$_f1` matching inside `$_f10`).

**Minor, all applied:** the three round-trip tests are parametrized and assert via `startswith` + `removeprefix`; added cases for astral characters, two complex variables in one query, and an unknown reference left alone; `re.PatternError` → `re.error` (3.13-only name, project supports 3.12); the rationale now lives once, in the helper docstring, with the call sites keeping only what is specific to them.

**Not done, deliberately:** the two edge cases flagged as low severity — a complex key that never matches being dropped from the bindings without error, and `$key` inside a quoted string literal being rewritten. Neither is closed by the single pass on its own, and both are behaviour changes rather than fixes to what this PR touches. Say the word if you want them in scope.

**Backport:** confirmed still warranted, and the `live_select` line is identical on `v2`. `substitute_params` carries over as-is; `ensure_ascii=False` is a no-op there behaviourally (2.6.5 accepts surrogate pairs) but keeps the branches identical.
