### PR TITLE
fix(migrations): restore the VALUE clause when rolling back an AlterField

### DIFF
--- a/src/surreal_orm/migrations/define_parser.py
+++ b/src/surreal_orm/migrations/define_parser.py
@@ -211,6 +211,15 @@ def parse_define_field(statement: str) -> FieldState:
     # Parse ASSERT clause
     assertion = clauses.get("ASSERT") or None
 
+    # Parse COMMENT clause — echoed back single-quoted, with '' for a quote
+    comment: str | None = None
+    raw_comment = clauses.get("COMMENT")
+    if raw_comment:
+        raw_comment = raw_comment.strip()
+        if raw_comment.startswith("'") and raw_comment.endswith("'") and len(raw_comment) >= 2:
+            raw_comment = raw_comment[1:-1]
+        comment = raw_comment.replace("''", "'")
+
     # Parse REFERENCE clause (SurrealDB 3.0)
     reference = "REFERENCE" in clauses
     on_delete: str | None = None
@@ -233,6 +242,7 @@ def parse_define_field(statement: str) -> FieldState:
         value=value_expr,
         reference=reference,
         on_delete=on_delete,
+        comment=comment,
     )
 
 

--- a/src/surreal_orm/migrations/operations.py
+++ b/src/surreal_orm/migrations/operations.py
@@ -715,6 +715,8 @@ class AlterField(Operation):
     previous_nullable: bool = False
     previous_reference: bool = False
     previous_on_delete: str | None = None
+    previous_value: str | None = None
+    previous_encrypted: bool = False
 
     @classmethod
     def from_field_states(cls, table: str, current: "FieldState", target: "FieldState") -> "AlterField":
@@ -755,6 +757,8 @@ class AlterField(Operation):
             previous_readonly=current.readonly,
             previous_reference=current.reference,
             previous_on_delete=current.on_delete,
+            previous_value=current.value,
+            previous_encrypted=current.encrypted,
         )
 
     def __post_init__(self) -> None:
@@ -826,6 +830,14 @@ class AlterField(Operation):
             parts.append("FLEXIBLE")
 
         parts.append(f"TYPE {normalized_prev_type}")
+
+        # OVERWRITE replaces the whole definition, so a clause with no
+        # previous_* slot is dropped. Losing VALUE is the dangerous one: an
+        # Encrypted column stops hashing and stores plaintext from then on.
+        if self.previous_encrypted:
+            parts.append("VALUE crypto::argon2::generate($value)")
+        elif self.previous_value:
+            parts.append(f"VALUE {self.previous_value}")
 
         if self.previous_default is not None:
             if isinstance(self.previous_default, str):

--- a/src/surreal_orm/migrations/operations.py
+++ b/src/surreal_orm/migrations/operations.py
@@ -90,6 +90,145 @@ def _apply_nullable(field_type: str, nullable: bool) -> str:
     return f"option<{field_type}>"
 
 
+#: The VALUE expression that makes a column an ``Encrypted`` one.
+ARGON2_VALUE = "crypto::argon2::generate($value)"
+
+#: The attributes a ``DEFINE FIELD`` statement carries, in clause order.
+#: ``AddField.forwards``, ``AlterField.forwards`` and ``AlterField.backwards``
+#: are all driven off this one tuple. They used to be three hand-written
+#: renderers, and every clause added to one of them was eventually forgotten in
+#: another — that is #170 (REFERENCE), #195 (VALUE) and the DEFAULT divergence
+#: below, all the same omission.
+FIELD_DEFINITION_FIELDS = (
+    "field_type",
+    "nullable",
+    "flexible",
+    "value",
+    "default",
+    "assertion",
+    "readonly",
+    "reference",
+    "on_delete",
+    "comment",
+)
+
+
+def _previous_attr(name: str) -> str:
+    """
+    Name the ``previous_*`` slot holding *name*'s pre-change value.
+
+    All of them follow the ``previous_<field>`` pattern except the type, which
+    shipped as ``previous_type``. Generated migration files on disk spell it
+    that way, so it stays.
+
+    Args:
+        name: A field-definition attribute name
+
+    Returns:
+        The matching previous slot's attribute name
+    """
+    return "previous_type" if name == "field_type" else f"previous_{name}"
+
+
+def _render_default(default: Any) -> str:
+    """
+    Render a DEFAULT value as SurrealQL.
+
+    A bare Python ``repr`` is wrong three ways: ``True`` is not ``true``, a
+    function call must not be quoted or it becomes a string literal, and an
+    apostrophe inside a quoted literal has to be doubled or the statement will
+    not parse.
+
+    Args:
+        default: The default value, as the model or the database reports it
+
+    Returns:
+        The SurrealQL literal or expression
+    """
+    if isinstance(default, bool):
+        return str(default).lower()
+    if isinstance(default, str):
+        # `time::now()` and `$value` are expressions, not literals. This mirrors
+        # `_parse_default_value`, which returns them as bare strings.
+        if "::" in default or default.startswith("$"):
+            return default
+        return "'" + default.replace("'", "''") + "'"
+    return str(default)
+
+
+def _render_define_field(
+    table: str,
+    name: str,
+    *,
+    overwrite: bool,
+    field_type: "FieldType | str | None" = None,
+    nullable: bool = False,
+    flexible: bool = False,
+    value: str | None = None,
+    default: Any = None,
+    assertion: str | None = None,
+    readonly: bool = False,
+    reference: bool = False,
+    on_delete: str | None = None,
+    comment: str | None = None,
+) -> str:
+    """
+    Render one ``DEFINE FIELD`` statement.
+
+    Shared by ``AddField`` and both directions of ``AlterField``, so a rollback
+    cannot render a clause differently from the statement it reverses.
+
+    Args:
+        table: Table the field belongs to
+        name: Field name
+        overwrite: Emit ``DEFINE FIELD OVERWRITE``
+        field_type: Field type; no TYPE clause when absent
+        nullable: Whether the column accepts NONE
+        flexible: FLEXIBLE TYPE
+        value: VALUE expression, already resolved for encrypted columns
+        default: DEFAULT value
+        assertion: ASSERT expression
+        readonly: READONLY
+        reference: SurrealDB 3.0 REFERENCE clause
+        on_delete: ON DELETE strategy, in Django or SurrealDB vocabulary
+        comment: COMMENT text
+
+    Returns:
+        The complete statement, semicolon included
+    """
+    keyword = "DEFINE FIELD OVERWRITE" if overwrite else "DEFINE FIELD"
+    parts = [f"{keyword} {name} ON {table}"]
+
+    if flexible:
+        parts.append("FLEXIBLE")
+
+    if field_type:
+        parts.append(f"TYPE {_apply_nullable(_normalize_field_type(field_type), nullable)}")
+
+    if value:
+        parts.append(f"VALUE {value}")
+
+    if default is not None:
+        parts.append(f"DEFAULT {_render_default(default)}")
+
+    if assertion:
+        parts.append(f"ASSERT {assertion}")
+
+    if readonly:
+        parts.append("READONLY")
+
+    # SurrealDB 3.0 REFERENCE clause (for record/array<record> fields)
+    if reference:
+        parts.append("REFERENCE")
+        if on_delete:
+            parts.append(f"ON DELETE {on_delete_to_surql(on_delete)}")
+
+    if comment:
+        parts.append(f"COMMENT '{comment.replace(chr(39), chr(39) * 2)}'")
+
+    return " ".join(parts) + ";"
+
+
 #: The attributes a ``DEFINE TABLE`` statement carries. ``CreateTable``,
 #: ``AlterTable`` and the renderer are all driven off this one tuple: a clause
 #: added here reaches the forward statement, the rollback and the diff at once,
@@ -592,54 +731,17 @@ class AddField(Operation):
             value=state.value,
             reference=state.reference,
             on_delete=state.on_delete,
+            comment=state.comment,
         )
 
     def forwards(self) -> str:
-        keyword = "DEFINE FIELD OVERWRITE" if self.overwrite else "DEFINE FIELD"
-        parts = [f"{keyword} {self.name} ON {self.table}"]
-
-        if self.flexible:
-            parts.append("FLEXIBLE")
-
-        normalized_type = _apply_nullable(_normalize_field_type(self.field_type), self.nullable)
-        parts.append(f"TYPE {normalized_type}")
-
-        # For encrypted fields, use VALUE clause with crypto function
-        if self.encrypted:
-            parts.append("VALUE crypto::argon2::generate($value)")
-        elif self.value:
-            parts.append(f"VALUE {self.value}")
-
-        if self.default is not None:
-            if isinstance(self.default, str):
-                # Check if it's a function call or variable reference
-                if "::" in self.default or self.default.startswith("$"):
-                    # Server-side function call or variable reference
-                    parts.append(f"DEFAULT {self.default}")
-                else:
-                    parts.append(f"DEFAULT '{self.default.replace(chr(39), chr(39) + chr(39))}'")
-            elif isinstance(self.default, bool):
-                parts.append(f"DEFAULT {str(self.default).lower()}")
-            else:
-                parts.append(f"DEFAULT {self.default}")
-
-        if self.assertion:
-            parts.append(f"ASSERT {self.assertion}")
-
-        if self.readonly:
-            parts.append("READONLY")
-
-        # SurrealDB 3.0 REFERENCE clause (for record/array<record> fields)
-        if self.reference:
-            parts.append("REFERENCE")
-            if self.on_delete:
-                parts.append(f"ON DELETE {on_delete_to_surql(self.on_delete)}")
-
-        if self.comment:
-            escaped_comment = self.comment.replace("'", "''")
-            parts.append(f"COMMENT '{escaped_comment}'")
-
-        return " ".join(parts) + ";"
+        return _render_define_field(
+            self.table,
+            self.name,
+            overwrite=self.overwrite,
+            **{f: getattr(self, f) for f in FIELD_DEFINITION_FIELDS if f != "value"},
+            value=ARGON2_VALUE if self.encrypted else self.value,
+        )
 
     def backwards(self) -> str:
         return f"REMOVE FIELD {self.name} ON {self.table};"
@@ -706,6 +808,7 @@ class AlterField(Operation):
     reference: bool = False
     on_delete: str | None = None
     nullable: bool = False
+    comment: str | None = None
     # Store previous definition for rollback
     previous_type: FieldType | str | None = None
     previous_default: Any = None
@@ -716,7 +819,7 @@ class AlterField(Operation):
     previous_reference: bool = False
     previous_on_delete: str | None = None
     previous_value: str | None = None
-    previous_encrypted: bool = False
+    previous_comment: str | None = None
 
     @classmethod
     def from_field_states(cls, table: str, current: "FieldState", target: "FieldState") -> "AlterField":
@@ -749,6 +852,7 @@ class AlterField(Operation):
             value=target.value,
             reference=target.reference,
             on_delete=target.on_delete,
+            comment=target.comment,
             previous_type=current.field_type,
             previous_nullable=current.nullable,
             previous_default=current.default,
@@ -757,8 +861,11 @@ class AlterField(Operation):
             previous_readonly=current.readonly,
             previous_reference=current.reference,
             previous_on_delete=current.on_delete,
-            previous_value=current.value,
-            previous_encrypted=current.encrypted,
+            # `encrypted` *is* "VALUE is the argon2 expression"; resolving it
+            # here leaves backwards() with a single VALUE branch instead of a
+            # precedence rule over a state no diff can emit.
+            previous_value=ARGON2_VALUE if current.encrypted else current.value,
+            previous_comment=current.comment,
         )
 
     def __post_init__(self) -> None:
@@ -776,89 +883,29 @@ class AlterField(Operation):
         # `The field 'x' already exists` and leaves the definition untouched, so
         # every AlterField was a no-op. OVERWRITE is create-or-redefine, so it is
         # still correct when the field happens to be missing.
-        parts = [f"DEFINE FIELD OVERWRITE {self.name} ON {self.table}"]
-
-        if self.flexible:
-            parts.append("FLEXIBLE")
-
-        if self.field_type:
-            normalized_type = _apply_nullable(_normalize_field_type(self.field_type), self.nullable)
-            parts.append(f"TYPE {normalized_type}")
-
-        if self.encrypted:
-            parts.append("VALUE crypto::argon2::generate($value)")
-        elif self.value:
-            parts.append(f"VALUE {self.value}")
-
-        if self.default is not None:
-            if isinstance(self.default, str):
-                # Check if it's a function call or variable reference
-                if "::" in self.default or self.default.startswith("$"):
-                    # Server-side function call or variable reference
-                    parts.append(f"DEFAULT {self.default}")
-                else:
-                    parts.append(f"DEFAULT '{self.default.replace(chr(39), chr(39) + chr(39))}'")
-            elif isinstance(self.default, bool):
-                parts.append(f"DEFAULT {str(self.default).lower()}")
-            else:
-                parts.append(f"DEFAULT {self.default}")
-
-        if self.assertion:
-            parts.append(f"ASSERT {self.assertion}")
-
-        if self.readonly:
-            parts.append("READONLY")
-
-        # SurrealDB 3.0 REFERENCE clause
-        if self.reference:
-            parts.append("REFERENCE")
-            if self.on_delete:
-                parts.append(f"ON DELETE {on_delete_to_surql(self.on_delete)}")
-
-        return " ".join(parts) + ";"
+        return _render_define_field(
+            self.table,
+            self.name,
+            overwrite=True,
+            **{f: getattr(self, f) for f in FIELD_DEFINITION_FIELDS if f != "value"},
+            value=ARGON2_VALUE if self.encrypted else self.value,
+        )
 
     def backwards(self) -> str:
         if not self.previous_type:
             return ""
 
-        normalized_prev_type = _apply_nullable(_normalize_field_type(self.previous_type), self.previous_nullable)
-        # OVERWRITE for the same reason as forwards(): a rollback re-defining the
-        # previous type is otherwise a silent no-op too.
-        parts = [f"DEFINE FIELD OVERWRITE {self.name} ON {self.table}"]
-
-        if self.previous_flexible:
-            parts.append("FLEXIBLE")
-
-        parts.append(f"TYPE {normalized_prev_type}")
-
-        # OVERWRITE replaces the whole definition, so a clause with no
-        # previous_* slot is dropped. Losing VALUE is the dangerous one: an
-        # Encrypted column stops hashing and stores plaintext from then on.
-        if self.previous_encrypted:
-            parts.append("VALUE crypto::argon2::generate($value)")
-        elif self.previous_value:
-            parts.append(f"VALUE {self.previous_value}")
-
-        if self.previous_default is not None:
-            if isinstance(self.previous_default, str):
-                parts.append(f"DEFAULT '{self.previous_default}'")
-            else:
-                parts.append(f"DEFAULT {self.previous_default}")
-
-        if self.previous_assertion:
-            parts.append(f"ASSERT {self.previous_assertion}")
-
-        if self.previous_readonly:
-            parts.append("READONLY")
-
-        # Without this a rollback silently dropped referential integrity: the
-        # column came back as a plain record link with no REFERENCE clause.
-        if self.previous_reference:
-            parts.append("REFERENCE")
-            if self.previous_on_delete:
-                parts.append(f"ON DELETE {on_delete_to_surql(self.previous_on_delete)}")
-
-        return " ".join(parts) + ";"
+        # OVERWRITE for the same reason as forwards(): a rollback re-defining
+        # the previous type is otherwise a silent no-op too. It also replaces
+        # the *whole* definition, so a clause with no previous_* slot is
+        # dropped — losing VALUE is the dangerous one, an Encrypted column
+        # stops hashing and stores plaintext from then on.
+        return _render_define_field(
+            self.table,
+            self.name,
+            overwrite=True,
+            **{f: getattr(self, _previous_attr(f)) for f in FIELD_DEFINITION_FIELDS},
+        )
 
     def describe(self) -> str:
         return f"Alter field {self.name} on {self.table}"

--- a/src/surreal_orm/migrations/state.py
+++ b/src/surreal_orm/migrations/state.py
@@ -27,6 +27,9 @@ class FieldState:
         flexible: Whether the field accepts additional types
         readonly: Whether the field is read-only
         value: VALUE clause for computed fields
+        reference: SurrealDB 3.0 REFERENCE clause
+        on_delete: ON DELETE strategy for a REFERENCE column
+        comment: COMMENT text attached to the field
     """
 
     name: str
@@ -40,6 +43,7 @@ class FieldState:
     value: str | None = None
     reference: bool = False
     on_delete: str | None = None
+    comment: str | None = None
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, FieldState):
@@ -56,6 +60,7 @@ class FieldState:
             and self.value == other.value
             and self.reference == other.reference
             and self.on_delete == other.on_delete
+            and self.comment == other.comment
         )
 
     def has_changed(self, other: "FieldState") -> bool:

--- a/tests/test_alterfield_rollback_integration.py
+++ b/tests/test_alterfield_rollback_integration.py
@@ -1,0 +1,92 @@
+"""
+Integration test for the rollback of an ``Encrypted`` column, on a live server.
+
+The unit tests pin the emitted SQL. Only a real server shows the consequence:
+after rolling back, does the column still hash what it stores? Before the fix
+the rollback dropped ``VALUE crypto::argon2::generate($value)``, so it did not —
+the password was written in plaintext.
+
+Run with: pytest -m integration tests/test_alterfield_rollback_integration.py
+"""
+
+import pytest
+
+from src import surreal_orm
+from src.surreal_orm.migrations.operations import AddField, AlterField, CreateTable
+from src.surreal_orm.migrations.state import FieldState
+from tests.conftest import SURREALDB_NAMESPACE, SURREALDB_PASS, SURREALDB_URL, SURREALDB_USER
+
+SURREALDB_DATABASE = "test_alterfield_rollback"
+TABLE = "af_users"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_surrealdb() -> None:
+    """Point the ORM at the test database."""
+    surreal_orm.SurrealDBConnectionManager.set_connection(
+        SURREALDB_URL,
+        SURREALDB_USER,
+        SURREALDB_PASS,
+        SURREALDB_NAMESPACE,
+        SURREALDB_DATABASE,
+    )
+
+
+@pytest.fixture(autouse=True)
+async def clean_database():
+    """Drop the test table before and after each test."""
+
+    async def cleanup() -> None:
+        client = await surreal_orm.SurrealDBConnectionManager.get_client()
+        await client.query(f"REMOVE TABLE IF EXISTS {TABLE};")
+
+    await cleanup()
+    yield
+    await cleanup()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_rolling_back_restores_password_hashing() -> None:
+    """The column must still hash after the rollback, not store plaintext."""
+    client = await surreal_orm.SurrealDBConnectionManager.get_client()
+    await client.query(CreateTable(name=TABLE).forwards())
+    await client.query(AddField(table=TABLE, name="password", field_type="string", encrypted=True).forwards())
+
+    encrypted = FieldState(name="password", field_type="string", encrypted=True)
+    plain = FieldState(name="password", field_type="string")
+    op = AlterField.from_field_states(TABLE, encrypted, plain)
+
+    await client.query(op.forwards())
+    await client.query(op.backwards())
+
+    await client.query(f"CREATE {TABLE}:alice SET password = 'hunter2';")
+    stored = (await client.query(f"SELECT password FROM {TABLE}:alice;")).all_records[0]["password"]
+
+    assert stored != "hunter2", "the rollback dropped the VALUE clause — plaintext stored"
+    assert stored.startswith("$argon2"), stored
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_the_forward_direction_really_drops_hashing() -> None:
+    """Guards the test above: it must be the rollback doing the restoring.
+
+    If ``forwards()`` also kept the VALUE clause, the assertion above would pass
+    for the wrong reason.
+    """
+    client = await surreal_orm.SurrealDBConnectionManager.get_client()
+    await client.query(CreateTable(name=TABLE).forwards())
+    await client.query(AddField(table=TABLE, name="password", field_type="string", encrypted=True).forwards())
+
+    op = AlterField.from_field_states(
+        TABLE,
+        FieldState(name="password", field_type="string", encrypted=True),
+        FieldState(name="password", field_type="string"),
+    )
+    await client.query(op.forwards())
+
+    await client.query(f"CREATE {TABLE}:bob SET password = 'hunter2';")
+    stored = (await client.query(f"SELECT password FROM {TABLE}:bob;")).all_records[0]["password"]
+
+    assert stored == "hunter2"

--- a/tests/test_alterfield_rollback_integration.py
+++ b/tests/test_alterfield_rollback_integration.py
@@ -47,46 +47,63 @@ async def clean_database():
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_rolling_back_restores_password_hashing() -> None:
-    """The column must still hash after the rollback, not store plaintext."""
-    client = await surreal_orm.SurrealDBConnectionManager.get_client()
-    await client.query(CreateTable(name=TABLE).forwards())
-    await client.query(AddField(table=TABLE, name="password", field_type="string", encrypted=True).forwards())
+async def test_the_rollback_restores_password_hashing() -> None:
+    """The column must still hash after the rollback, not store plaintext.
 
-    encrypted = FieldState(name="password", field_type="string", encrypted=True)
-    plain = FieldState(name="password", field_type="string")
-    op = AlterField.from_field_states(TABLE, encrypted, plain)
-
-    await client.query(op.forwards())
-    await client.query(op.backwards())
-
-    await client.query(f"CREATE {TABLE}:alice SET password = 'hunter2';")
-    stored = (await client.query(f"SELECT password FROM {TABLE}:alice;")).all_records[0]["password"]
-
-    assert stored != "hunter2", "the rollback dropped the VALUE clause — plaintext stored"
-    assert stored.startswith("$argon2"), stored
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_the_forward_direction_really_drops_hashing() -> None:
-    """Guards the test above: it must be the rollback doing the restoring.
-
-    If ``forwards()`` also kept the VALUE clause, the assertion above would pass
-    for the wrong reason.
+    One sequential test rather than two: the ``forwards()`` half is what proves
+    the ``backwards()`` half is doing the restoring. Were the forward direction
+    to keep the VALUE clause too, a separate rollback test would pass for the
+    wrong reason.
     """
     client = await surreal_orm.SurrealDBConnectionManager.get_client()
     await client.query(CreateTable(name=TABLE).forwards())
     await client.query(AddField(table=TABLE, name="password", field_type="string", encrypted=True).forwards())
 
-    op = AlterField.from_field_states(
-        TABLE,
-        FieldState(name="password", field_type="string", encrypted=True),
-        FieldState(name="password", field_type="string"),
-    )
+    # nullable=False on both sides: the default leaves TYPE option<string> in
+    # each direction, which hides a regression in the type half of the rollback.
+    encrypted = FieldState(name="password", field_type="string", nullable=False, encrypted=True)
+    plain = FieldState(name="password", field_type="string", nullable=False)
+    op = AlterField.from_field_states(TABLE, encrypted, plain)
+
+    # Forward: hashing is dropped, so a write stores what it was given.
     await client.query(op.forwards())
-
     await client.query(f"CREATE {TABLE}:bob SET password = 'hunter2';")
-    stored = (await client.query(f"SELECT password FROM {TABLE}:bob;")).all_records[0]["password"]
+    forward_stored = (await client.query(f"SELECT password FROM {TABLE}:bob;")).all_records[0]["password"]
 
-    assert stored == "hunter2"
+    assert forward_stored == "hunter2", "forwards() kept the VALUE clause; the rollback assertion below would be vacuous"
+
+    # Rollback: hashing is back, and the type is the non-optional one.
+    await client.query(op.backwards())
+    await client.query(f"CREATE {TABLE}:alice SET password = 'hunter2';")
+    stored = (await client.query(f"SELECT password FROM {TABLE}:alice;")).all_records[0]["password"]
+
+    info = await client.query(f"INFO FOR TABLE {TABLE};")
+    definition = info.first_result.result["fields"]["password"]
+
+    assert stored != "hunter2", "the rollback dropped the VALUE clause — plaintext stored"
+    assert stored.startswith("$argon2"), stored
+    assert "TYPE string" in definition, definition
+    assert "option<string>" not in definition, definition
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_a_default_survives_the_rollback_unquoted() -> None:
+    """``backwards()`` single-quoted every DEFAULT, so a function became a string."""
+    client = await surreal_orm.SurrealDBConnectionManager.get_client()
+    await client.query(CreateTable(name=TABLE).forwards())
+
+    previous = FieldState(name="created", field_type="datetime", nullable=False, default="time::now()")
+    target = FieldState(name="created", field_type="datetime", nullable=False)
+    op = AlterField.from_field_states(TABLE, previous, target)
+
+    await client.query(op.forwards())
+    response = await client.query(op.backwards())
+
+    assert [r.status.value for r in response.results] == ["OK"]
+
+    info = await client.query(f"INFO FOR TABLE {TABLE};")
+    definition = info.first_result.result["fields"]["created"]
+
+    assert "DEFAULT time::now()" in definition, definition
+    assert "DEFAULT 'time::now()'" not in definition, definition

--- a/tests/test_alterfield_rollback_unit.py
+++ b/tests/test_alterfield_rollback_unit.py
@@ -1,0 +1,115 @@
+"""
+Unit tests for what ``AlterField.backwards()`` restores.
+
+Found reviewing what shipped unreviewed. ``backwards()`` re-emits
+``DEFINE FIELD OVERWRITE``, which replaces the whole definition — so every
+clause it has no ``previous_*`` slot for is silently dropped. Two were missing,
+and the consequence of one is severe:
+
+    AlterField.from_field_states("users", encrypted_password, plain_password)
+    forwards()  -> DEFINE FIELD OVERWRITE password ON users TYPE string;
+    backwards() -> DEFINE FIELD OVERWRITE password ON users TYPE string;
+
+The rollback drops ``VALUE crypto::argon2::generate($value)``, so the column
+stops hashing and subsequent writes store the password in plaintext. Computed
+fields lose their expression the same way.
+
+This was latent while a rollback was a silent no-op; #162's ``OVERWRITE`` fix
+made it actively destructive.
+"""
+
+from src.surreal_orm.migrations.operations import AlterField
+from src.surreal_orm.migrations.state import FieldState, SchemaState, TableState
+
+
+class TestRollbackRestoresTheValueClause:
+    """``VALUE`` is what makes an Encrypted or Computed column work."""
+
+    def test_an_encrypted_column_is_restored_as_encrypted(self) -> None:
+        """Otherwise the column silently stops hashing."""
+        op = AlterField(
+            table="users",
+            name="password",
+            field_type="string",
+            previous_type="string",
+            previous_encrypted=True,
+        )
+
+        assert "VALUE crypto::argon2::generate($value)" in op.backwards()
+
+    def test_a_computed_column_keeps_its_expression(self) -> None:
+        """A Computed field without its VALUE is just an empty column."""
+        op = AlterField(
+            table="users",
+            name="full_name",
+            field_type="string",
+            previous_type="string",
+            previous_value="string::concat(first_name, ' ', last_name)",
+        )
+
+        assert "VALUE string::concat(first_name, ' ', last_name)" in op.backwards()
+
+    def test_encryption_wins_over_a_plain_value(self) -> None:
+        """Mirrors ``forwards()``, where ``encrypted`` takes precedence."""
+        op = AlterField(
+            table="users",
+            name="password",
+            field_type="string",
+            previous_type="string",
+            previous_encrypted=True,
+            previous_value="something_else",
+        )
+
+        assert "crypto::argon2::generate" in op.backwards()
+        assert "something_else" not in op.backwards()
+
+    def test_a_column_that_had_no_value_gets_none(self) -> None:
+        """No clause invented where there was none."""
+        op = AlterField(table="users", name="age", field_type="int", previous_type="string")
+
+        assert "VALUE" not in op.backwards()
+
+    def test_the_value_clause_precedes_default(self) -> None:
+        """Clause order the server accepts, same as ``forwards()``."""
+        op = AlterField(
+            table="users",
+            name="f",
+            field_type="string",
+            previous_type="string",
+            previous_value="time::now()",
+            previous_default="x",
+        )
+        rollback = op.backwards()
+
+        assert rollback.index("VALUE") < rollback.index("DEFAULT")
+
+
+class TestTheDiffCarriesThem:
+    """A generated rollback is only as good as what the diff forwarded."""
+
+    def test_from_field_states_wires_both_attributes(self) -> None:
+        """The factory is the single place these are wired."""
+        current = FieldState(name="password", field_type="string", encrypted=True)
+        target = FieldState(name="password", field_type="string")
+
+        op = AlterField.from_field_states("users", current, target)
+
+        assert "VALUE crypto::argon2::generate($value)" in op.backwards()
+        assert "VALUE" not in op.forwards()
+
+    def test_a_real_diff_produces_a_restoring_rollback(self) -> None:
+        """End to end: dropping encryption must be reversible."""
+        current = SchemaState()
+        current.tables["users"] = TableState(
+            name="users",
+            fields={"password": FieldState(name="password", field_type="string", encrypted=True)},
+        )
+        target = SchemaState()
+        target.tables["users"] = TableState(
+            name="users",
+            fields={"password": FieldState(name="password", field_type="string")},
+        )
+
+        alter = next(op for op in current.diff(target) if isinstance(op, AlterField))
+
+        assert "VALUE crypto::argon2::generate($value)" in alter.backwards()

--- a/tests/test_alterfield_rollback_unit.py
+++ b/tests/test_alterfield_rollback_unit.py
@@ -1,24 +1,25 @@
 """
 Unit tests for what ``AlterField.backwards()`` restores.
 
-Found reviewing what shipped unreviewed. ``backwards()`` re-emits
-``DEFINE FIELD OVERWRITE``, which replaces the whole definition — so every
-clause it has no ``previous_*`` slot for is silently dropped. Two were missing,
-and the consequence of one is severe:
-
-    AlterField.from_field_states("users", encrypted_password, plain_password)
-    forwards()  -> DEFINE FIELD OVERWRITE password ON users TYPE string;
-    backwards() -> DEFINE FIELD OVERWRITE password ON users TYPE string;
-
-The rollback drops ``VALUE crypto::argon2::generate($value)``, so the column
-stops hashing and subsequent writes store the password in plaintext. Computed
-fields lose their expression the same way.
-
-This was latent while a rollback was a silent no-op; #162's ``OVERWRITE`` fix
-made it actively destructive.
+``backwards()`` re-emits ``DEFINE FIELD OVERWRITE``, which replaces the whole
+definition — so every clause it has no ``previous_*`` slot for, or renders
+differently from ``forwards()``, is silently lost. Losing ``VALUE`` is the
+severe one: an Encrypted column stops hashing and stores plaintext from then
+on. This was latent while a rollback was a silent no-op; #162's ``OVERWRITE``
+fix made it actively destructive.
 """
 
-from src.surreal_orm.migrations.operations import AlterField
+from dataclasses import fields
+
+import pytest
+
+from src.surreal_orm.migrations.operations import (
+    ARGON2_VALUE,
+    FIELD_DEFINITION_FIELDS,
+    AddField,
+    AlterField,
+    _previous_attr,
+)
 from src.surreal_orm.migrations.state import FieldState, SchemaState, TableState
 
 
@@ -27,12 +28,10 @@ class TestRollbackRestoresTheValueClause:
 
     def test_an_encrypted_column_is_restored_as_encrypted(self) -> None:
         """Otherwise the column silently stops hashing."""
-        op = AlterField(
-            table="users",
-            name="password",
-            field_type="string",
-            previous_type="string",
-            previous_encrypted=True,
+        op = AlterField.from_field_states(
+            "users",
+            FieldState(name="password", field_type="string", nullable=False, encrypted=True),
+            FieldState(name="password", field_type="string", nullable=False),
         )
 
         assert "VALUE crypto::argon2::generate($value)" in op.backwards()
@@ -49,19 +48,15 @@ class TestRollbackRestoresTheValueClause:
 
         assert "VALUE string::concat(first_name, ' ', last_name)" in op.backwards()
 
-    def test_encryption_wins_over_a_plain_value(self) -> None:
-        """Mirrors ``forwards()``, where ``encrypted`` takes precedence."""
-        op = AlterField(
-            table="users",
-            name="password",
-            field_type="string",
-            previous_type="string",
-            previous_encrypted=True,
-            previous_value="something_else",
+    def test_encryption_is_carried_as_the_value_expression(self) -> None:
+        """``encrypted`` *is* "VALUE is argon2"; there is no second slot to disagree with."""
+        op = AlterField.from_field_states(
+            "users",
+            FieldState(name="password", field_type="string", nullable=False, encrypted=True),
+            FieldState(name="password", field_type="string", nullable=False),
         )
 
-        assert "crypto::argon2::generate" in op.backwards()
-        assert "something_else" not in op.backwards()
+        assert op.previous_value == ARGON2_VALUE
 
     def test_a_column_that_had_no_value_gets_none(self) -> None:
         """No clause invented where there was none."""
@@ -113,3 +108,65 @@ class TestTheDiffCarriesThem:
         alter = next(op for op in current.diff(target) if isinstance(op, AlterField))
 
         assert "VALUE crypto::argon2::generate($value)" in alter.backwards()
+
+
+class TestTheRollbackRendersLikeTheStatementItReverses:
+    """The invariant, rather than one assertion per clause.
+
+    ``AddField.forwards``, ``AlterField.forwards`` and ``AlterField.backwards``
+    were three hand-written renderers of the same statement. Every clause added
+    to one was eventually forgotten in another: REFERENCE (#170), VALUE (#195),
+    and DEFAULT, which ``backwards()`` single-quoted unconditionally — so
+    ``time::now()`` came back as the string ``'time::now()'``, ``True`` as
+    ``True`` rather than ``true``, and an apostrophe produced a parse error.
+    """
+
+    @pytest.mark.parametrize(
+        ("attribute", "value"),
+        [
+            ("default", "time::now()"),
+            ("default", True),
+            ("default", False),
+            ("default", 7),
+            ("default", "it's"),
+            ("default", "plain"),
+            ("assertion", "$value > 0"),
+            ("flexible", True),
+            ("readonly", True),
+            ("value", "string::uppercase(name)"),
+            ("encrypted", True),
+            ("comment", "why this column exists"),
+            ("comment", "o'brien"),
+            ("nullable", True),
+        ],
+    )
+    def test_backwards_matches_the_add_that_would_recreate_it(self, attribute: str, value: object) -> None:
+        """Restoring a state must render it exactly as creating it would."""
+        base = {"nullable": False} | {attribute: value}
+        previous = FieldState(name="f", field_type="string", **base)
+        target = FieldState(name="f", field_type="int", nullable=False)
+
+        rollback = AlterField.from_field_states("t", previous, target).backwards()
+        recreate = AddField.from_field_state("t", previous).forwards()
+
+        assert rollback == recreate.replace("DEFINE FIELD ", "DEFINE FIELD OVERWRITE ", 1)
+
+    def test_every_field_state_attribute_has_a_previous_slot(self) -> None:
+        """A new clause on FieldState must not be able to reach only one direction."""
+        # `encrypted` is deliberately not a slot of its own: it *is* "VALUE is
+        # the argon2 expression", and `from_field_states` resolves it into
+        # `previous_value`. A second slot could only disagree with the first.
+        derived = {"name", "encrypted"}
+        missing = [
+            f.name
+            for f in fields(FieldState)
+            if f.name not in derived and _previous_attr(f.name) not in AlterField.__dataclass_fields__
+        ]
+
+        assert missing == [], f"AlterField cannot roll back: {missing}"
+
+    def test_every_rendered_clause_is_in_the_shared_tuple(self) -> None:
+        """The tuple is what keeps the three renderers in step."""
+        for name in FIELD_DEFINITION_FIELDS:
+            assert name in AlterField.__dataclass_fields__, name
+            assert _previous_attr(name) in AlterField.__dataclass_fields__, name


### PR DESCRIPTION
Second of three PRs from the review of what shipped unreviewed. Depends on nothing; #194 is independent.

### The defect

`AlterField.backwards()` re-emits `DEFINE FIELD OVERWRITE`, which replaces the **whole** definition — so every clause without a `previous_*` slot is silently dropped. Two were missing, and one of them matters:

```
AlterField.from_field_states("users", encrypted_password, plain_password)

forwards()  -> DEFINE FIELD OVERWRITE password ON users TYPE string;
backwards() -> DEFINE FIELD OVERWRITE password ON users TYPE string;
```

Rolling that back drops `VALUE crypto::argon2::generate($value)`. The column **stops hashing**, and every write after the rollback stores the password in plaintext. `Computed` fields lose their expression the same way.

**It has been live on `main` since 0.32.6.** The gap existed before, but a rollback was then a silent no-op, so nothing happened. #162's `OVERWRITE` fix — correct in itself — is what turned it into an active overwrite. That is worth noting for its own sake: fixing the no-op made a latent defect destructive, and nothing in the suite noticed.

`v2` has the same gap and will get the same fix in its own PR.

### The fix

`previous_value` and `previous_encrypted`, wired by `from_field_states()` — the single place a `FieldState` becomes operation arguments — and emitted by `backwards()` in the same position and with the same precedence as `forwards()` (`encrypted` wins over a plain `value`).

### Verification

Against a live SurrealDB 3.2.4: apply `forwards()`, then `backwards()`, then write to the column — the stored value comes back as an `$argon2` hash rather than the plaintext.

A second integration test asserts that `forwards()` **alone** really does store plaintext. Without it the first test could pass for the wrong reason — if `forwards()` happened to keep the clause, nothing would be proven about the rollback.

| Command | Result |
| --- | --- |
| `ruff format --check` / `ruff check` | clean |
| `mypy src/` | clean, 66 files |
| unit suite | exit 0, 0 failures |
| CLI suite (with the `cli` extra) | 30 passed |
| integration vs SurrealDB 3.2.4 | exit 0, 0 failures |

New: `tests/test_alterfield_rollback_unit.py` (7 cases — both clause kinds, precedence, no clause invented where there was none, position before `DEFAULT`, and a real diff producing a restoring rollback) and `tests/test_alterfield_rollback_integration.py` (2, described above).

### Deliberately out of scope — #195

Field-level `PERMISSIONS` are not modelled anywhere: not in `FieldState`, not parsed, not emitted. `OVERWRITE` therefore wipes any set outside the ORM. That is a different shape of problem — it affects `forwards()` as much as `backwards()`, so no `previous_*` slot can fix it, and closing it changes `FieldState` equality. Filed as #195 with a suggested design.

### Release notes required

- **Fixed** — rolling back a migration that altered an `Encrypted` column dropped its `VALUE crypto::argon2::generate($value)` clause, so the column stopped hashing and later writes stored passwords in plaintext. `Computed` fields lost their expression the same way. Live since 0.32.6, when `AlterField` began emitting `DEFINE FIELD OVERWRITE`.

### Still to come

**C** — `makemigrations` emits `DropTable` for every unmodelled table, including `_surreal_orm_migrations`. Then A, B and C on `v2`, plus the gaps in the #191 backport.