### PR TITLE
fix(cli): stop makemigrations writing REMOVE TABLE for unmodelled tables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,15 @@ warn_unused_configs = true
 module = ["aiohttp.*", "httpx.*", "click.*"]
 ignore_missing_imports = true
 
+# The CLI imports click conditionally: it is an optional extra for users and a
+# dev dependency here. Its decorators therefore type-check differently depending
+# on whether click is installed, so the `type: ignore` comments the module needs
+# when it is absent are reported as unused when it is present. Neither state is
+# wrong, and pinning either one breaks the other environment.
+[[tool.mypy.overrides]]
+module = ["surreal_orm.cli.*"]
+warn_unused_ignores = false
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
@@ -109,6 +118,10 @@ include = ["src"]
 
 [dependency-groups]
 dev = [
+    # CI runs `uv sync --frozen`, which does not install the `cli` extra, so
+    # every CLI test skipped there and the commands were only ever exercised
+    # locally. It is a dev dependency here and an optional extra for users.
+    "click>=8.1.8",
     "ipykernel>=7.2.0",
     "mypy>=1.14.0",
     "pytest>=8.3.4",

--- a/src/surreal_orm/cli/commands.py
+++ b/src/surreal_orm/cli/commands.py
@@ -11,8 +11,10 @@ from typing import Any
 
 try:
     import click
-except ImportError:
-    click = None
+except ImportError:  # pragma: no cover - depends on whether the `cli` extra is installed
+    # Annotated as Any so the fallback assignment type-checks in both
+    # environments: with click installed mypy infers Module and rejects None.
+    click = None  # type: ignore[assignment]
 
 
 def require_click() -> None:
@@ -125,7 +127,7 @@ if click is not None:
     @click.option(  # type: ignore[untyped-decorator]
         "--drop-missing",
         is_flag=True,
-        help="Also emit REMOVE TABLE for database tables that have no model (irreversible)",
+        help="Also emit the irreversible removals (REMOVE TABLE/FIELD/ANALYZER/...) for database objects that have no model",
     )
     @click.pass_context  # type: ignore[untyped-decorator]
     def makemigrations(
@@ -139,7 +141,7 @@ if click is not None:
         """Generate migration files from model changes."""
         from ..migrations.generator import MigrationGenerator, generate_empty_migration
         from ..migrations.introspector import introspect_models
-        from ..migrations.operations import DropTable
+        from ..migrations.operations import split_destructive
         from ..migrations.state import SchemaState
 
         migrations_dir = ctx.obj["migrations_dir"]
@@ -186,19 +188,21 @@ if click is not None:
         # Compute differences
         operations = current_state.diff(desired_state)
 
-        # A table with no model is not necessarily obsolete: it may be a RELATE
-        # edge table (ModelIntrospector skips Relation fields, so those can only
-        # ever look unmodelled), or belong to a module that simply was not
-        # imported. REMOVE TABLE is irreversible, so it is opt-in — but say what
-        # was skipped, otherwise a genuinely obsolete table is invisible.
+        # Irreversible removals are opt-in: see split_destructive for why a
+        # database object with no model is not necessarily obsolete. Say what
+        # was skipped, otherwise a genuinely obsolete one is invisible.
         if not drop_missing:
-            skipped = [op.name for op in operations if isinstance(op, DropTable)]
-            operations = [op for op in operations if not isinstance(op, DropTable)]
+            operations, skipped = split_destructive(operations)
             if skipped:
-                click.echo(f"Skipped {len(skipped)} table(s) present in the database with no model:")
-                for table_name in skipped:
-                    click.echo(f"  - {table_name}")
-                click.echo("Pass --drop-missing to remove them (irreversible).")
+                click.echo(f"Skipped {len(skipped)} irreversible operation(s) with no model to justify them:")
+                for op in skipped:
+                    click.echo(f"  - {op.describe()}")
+                click.echo("Pass --drop-missing to apply them (irreversible).")
+
+        if drop_missing and not from_db:
+            # Nothing was read from the database, so nothing can be missing from
+            # the models: the flag can only be a misunderstanding.
+            click.echo("--drop-missing has no effect with --no-from-db: the diff has no database state to compare.")
 
         if not operations:
             click.echo("No changes detected.")
@@ -410,6 +414,7 @@ if click is not None:
         """Compare Python models against the live database schema."""
         from ..connection_manager import SurrealDBConnectionManager
         from ..introspection import schema_diff
+        from ..migrations.operations import split_destructive
 
         async def run() -> list[Any]:
             SurrealDBConnectionManager.set_connection(
@@ -433,12 +438,24 @@ if click is not None:
 
         try:
             operations = run_async(run())
-            if operations:
-                click.echo(f"Found {len(operations)} difference(s):")
-                for op in operations:
+            # Same partition as makemigrations, so the two commands cannot
+            # disagree about one database. Reporting them separately is what
+            # lets a CI gate on `schemadiff` ignore the RELATE edge tables and
+            # analyzers that no model can ever declare.
+            reversible, destructive = split_destructive(operations)
+
+            if reversible:
+                click.echo(f"Found {len(reversible)} difference(s):")
+                for op in reversible:
                     click.echo(f"  - {op.describe()}")
-            else:
+            elif not destructive:
                 click.echo("Models and database are in sync.")
+
+            if destructive:
+                click.echo(f"{len(destructive)} irreversible operation(s) with no model to justify them:")
+                for op in destructive:
+                    click.echo(f"  - {op.describe()}")
+                click.echo("makemigrations writes these only with --drop-missing.")
         except Exception as e:
             click.echo(f"Schema diff failed: {e}", err=True)
             sys.exit(1)

--- a/src/surreal_orm/cli/commands.py
+++ b/src/surreal_orm/cli/commands.py
@@ -122,6 +122,11 @@ if click is not None:
         default=True,
         help="Diff against the live database schema (default) instead of an empty schema",
     )
+    @click.option(  # type: ignore[untyped-decorator]
+        "--drop-missing",
+        is_flag=True,
+        help="Also emit REMOVE TABLE for database tables that have no model (irreversible)",
+    )
     @click.pass_context  # type: ignore[untyped-decorator]
     def makemigrations(
         ctx: click.Context,
@@ -129,10 +134,12 @@ if click is not None:
         empty: bool,
         models: tuple[str, ...],
         from_db: bool,
+        drop_missing: bool,
     ) -> None:
         """Generate migration files from model changes."""
         from ..migrations.generator import MigrationGenerator, generate_empty_migration
         from ..migrations.introspector import introspect_models
+        from ..migrations.operations import DropTable
         from ..migrations.state import SchemaState
 
         migrations_dir = ctx.obj["migrations_dir"]
@@ -178,6 +185,20 @@ if click is not None:
 
         # Compute differences
         operations = current_state.diff(desired_state)
+
+        # A table with no model is not necessarily obsolete: it may be a RELATE
+        # edge table (ModelIntrospector skips Relation fields, so those can only
+        # ever look unmodelled), or belong to a module that simply was not
+        # imported. REMOVE TABLE is irreversible, so it is opt-in — but say what
+        # was skipped, otherwise a genuinely obsolete table is invisible.
+        if not drop_missing:
+            skipped = [op.name for op in operations if isinstance(op, DropTable)]
+            operations = [op for op in operations if not isinstance(op, DropTable)]
+            if skipped:
+                click.echo(f"Skipped {len(skipped)} table(s) present in the database with no model:")
+                for table_name in skipped:
+                    click.echo(f"  - {table_name}")
+                click.echo("Pass --drop-missing to remove them (irreversible).")
 
         if not operations:
             click.echo("No changes detected.")

--- a/src/surreal_orm/migrations/__init__.py
+++ b/src/surreal_orm/migrations/__init__.py
@@ -46,9 +46,11 @@ from .operations import (
     RebuildIndex,
     RemoveAccess,
     RemoveGraphQLConfig,
+    split_destructive,
 )
 
 __all__ = [
+    "split_destructive",
     # Introspection
     "DatabaseIntrospector",
     "ModelCodeGenerator",

--- a/src/surreal_orm/migrations/constants.py
+++ b/src/surreal_orm/migrations/constants.py
@@ -1,0 +1,10 @@
+"""
+Constants shared across the migrations package.
+
+``state.py`` is pure data: it computes a diff and knows nothing about applying
+one. Reaching into ``executor.py`` for a single string dragged the connection
+manager into that dependency, so the names both modules need live here.
+"""
+
+#: Table where the executor records which migrations have been applied.
+MIGRATIONS_TABLE = "_surreal_orm_migrations"

--- a/src/surreal_orm/migrations/executor.py
+++ b/src/surreal_orm/migrations/executor.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ..connection_manager import SurrealDBConnectionManager
+from .constants import MIGRATIONS_TABLE
 from .migration import Migration, parse_migration_name
 from .operations import DataMigration
 
@@ -23,7 +24,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Table name for tracking migrations
-MIGRATIONS_TABLE = "_surreal_orm_migrations"
 
 
 class MigrationStatementError(RuntimeError):

--- a/src/surreal_orm/migrations/operations.py
+++ b/src/surreal_orm/migrations/operations.py
@@ -415,6 +415,34 @@ def _render_define_table(
     return " ".join(parts) + ";"
 
 
+def split_destructive(operations: "list[Operation]") -> "tuple[list[Operation], list[Operation]]":
+    """
+    Separate the operations that cannot be rolled back from the rest.
+
+    A table the database holds and no model declares is not necessarily
+    obsolete: it may be a RELATE edge table — ``ModelIntrospector`` skips
+    ``Relation`` fields, so those can only ever look unmodelled — or belong to a
+    module that simply was not imported. The same is true of an analyzer, an
+    API, a GraphQL config, and of the ``in``/``out`` fields SurrealDB defines on
+    a ``TYPE RELATION`` table itself: nothing a model can ever declare, so the
+    diff proposes removing them on every run.
+
+    Partitioning on ``reversible`` rather than on a list of operation classes is
+    what keeps the next irreversible operation from having to be remembered
+    here.
+
+    Args:
+        operations: The operations a diff produced
+
+    Returns:
+        ``(keep, destructive)`` — the reversible operations, and the ones a
+        caller must opt into
+    """
+    keep = [op for op in operations if op.reversible]
+    destructive = [op for op in operations if not op.reversible]
+    return keep, destructive
+
+
 @dataclass
 class Operation(ABC):
     """

--- a/src/surreal_orm/migrations/state.py
+++ b/src/surreal_orm/migrations/state.py
@@ -429,9 +429,14 @@ class SchemaState:
                         )
                     )
 
-        # Tables to drop (in self but not in target)
+        # Tables to drop (in self but not in target). The ORM's own migration
+        # history is never a candidate: dropping it erases the record of what
+        # has been applied, and DropTable is irreversible. This is an invariant,
+        # not a policy — callers decide whether to *act* on the other drops.
+        from .executor import MIGRATIONS_TABLE
+
         for table_name in self.tables:
-            if table_name not in target.tables:
+            if table_name not in target.tables and table_name != MIGRATIONS_TABLE:
                 operations.append(DropTable(name=table_name))
 
         # Tables to modify (in both)

--- a/src/surreal_orm/migrations/state.py
+++ b/src/surreal_orm/migrations/state.py
@@ -8,6 +8,8 @@ and compute the differences between two states to generate migrations.
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from .constants import MIGRATIONS_TABLE
+
 if TYPE_CHECKING:
     from .operations import CreateIndex, Operation
 
@@ -433,8 +435,6 @@ class SchemaState:
         # history is never a candidate: dropping it erases the record of what
         # has been applied, and DropTable is irreversible. This is an invariant,
         # not a policy — callers decide whether to *act* on the other drops.
-        from .executor import MIGRATIONS_TABLE
-
         for table_name in self.tables:
             if table_name not in target.tables and table_name != MIGRATIONS_TABLE:
                 operations.append(DropTable(name=table_name))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -294,22 +294,17 @@ class TestMakeMigrationsAgainstDatabase:
 
 
 class TestMakeMigrationsDropMissing:
-    """Which tables `makemigrations` is willing to write a REMOVE TABLE for.
+    """Which irreversible operations `makemigrations` is willing to write.
 
-    Diffing against the live database made `diff()`'s drop branch reachable, and
-    it fires for every table with no registered model — the migration history,
-    `RELATE` edge tables, anything whose module was not imported. `DropTable` is
-    irreversible, so it is opt-in now.
+    See ``split_destructive`` for why a database object with no model is not
+    necessarily obsolete.
     """
 
     @staticmethod
     def _db_state(*names: str):
-        from src.surreal_orm.migrations.state import SchemaState, TableState
+        from tests.test_makemigrations_drop_unit import _db_with
 
-        state = SchemaState()
-        for name in names:
-            state.tables[name] = TableState(name=name)
-        return state
+        return _db_with(*names)
 
     @patch("src.surreal_orm.cli.commands.run_async")
     def test_an_unmodelled_table_is_not_dropped_by_default(
@@ -333,7 +328,8 @@ class TestMakeMigrationsDropMissing:
 
         clear_model_registry()
         assert result.exit_code == 0, result.output
-        assert "Drop table" not in result.output
+        written = "".join(p.read_text() for p in temp_migrations_dir.glob("0001_*.py"))
+        assert "DropTable" not in written, written
 
     @patch("src.surreal_orm.cli.commands.run_async")
     def test_skipped_tables_are_reported_not_hidden(
@@ -356,6 +352,7 @@ class TestMakeMigrationsDropMissing:
         )
 
         clear_model_registry()
+        assert result.exit_code == 0, result.output
         assert "legacy_audit" in result.output
         assert "--drop-missing" in result.output
 
@@ -417,7 +414,10 @@ class TestMakeMigrationsDropMissing:
         )
 
         clear_model_registry()
+        assert result.exit_code == 0, result.output
         assert MIGRATIONS_TABLE not in result.output
+        written = "".join(p.read_text() for p in temp_migrations_dir.glob("0001_*.py"))
+        assert MIGRATIONS_TABLE not in written, written
 
 
 class TestMigrateCommand:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -293,6 +293,133 @@ class TestMakeMigrationsAgainstDatabase:
         assert "Created migration" not in result.output
 
 
+class TestMakeMigrationsDropMissing:
+    """Which tables `makemigrations` is willing to write a REMOVE TABLE for.
+
+    Diffing against the live database made `diff()`'s drop branch reachable, and
+    it fires for every table with no registered model — the migration history,
+    `RELATE` edge tables, anything whose module was not imported. `DropTable` is
+    irreversible, so it is opt-in now.
+    """
+
+    @staticmethod
+    def _db_state(*names: str):
+        from src.surreal_orm.migrations.state import SchemaState, TableState
+
+        state = SchemaState()
+        for name in names:
+            state.tables[name] = TableState(name=name)
+        return state
+
+    @patch("src.surreal_orm.cli.commands.run_async")
+    def test_an_unmodelled_table_is_not_dropped_by_default(
+        self, mock_run_async, runner: "CliRunner", cli_command, temp_migrations_dir: Path
+    ) -> None:
+        """Silently writing an irreversible REMOVE TABLE is the wrong default."""
+        from src.surreal_orm.model_base import BaseSurrealModel, clear_model_registry
+
+        clear_model_registry()
+
+        class KeptModel(BaseSurrealModel):
+            id: str | None = None
+            name: str
+
+        mock_run_async.side_effect = mock_run_async_factory(self._db_state("legacy_audit"))
+
+        result = runner.invoke(
+            cli_command,
+            ["--migrations-dir", str(temp_migrations_dir), "makemigrations", "--name", "x"],
+        )
+
+        clear_model_registry()
+        assert result.exit_code == 0, result.output
+        assert "Drop table" not in result.output
+
+    @patch("src.surreal_orm.cli.commands.run_async")
+    def test_skipped_tables_are_reported_not_hidden(
+        self, mock_run_async, runner: "CliRunner", cli_command, temp_migrations_dir: Path
+    ) -> None:
+        """A genuinely obsolete table must not vanish from view."""
+        from src.surreal_orm.model_base import BaseSurrealModel, clear_model_registry
+
+        clear_model_registry()
+
+        class KeptModel2(BaseSurrealModel):
+            id: str | None = None
+            name: str
+
+        mock_run_async.side_effect = mock_run_async_factory(self._db_state("legacy_audit"))
+
+        result = runner.invoke(
+            cli_command,
+            ["--migrations-dir", str(temp_migrations_dir), "makemigrations", "--name", "x"],
+        )
+
+        clear_model_registry()
+        assert "legacy_audit" in result.output
+        assert "--drop-missing" in result.output
+
+    @patch("src.surreal_orm.cli.commands.run_async")
+    def test_drop_missing_opts_in(self, mock_run_async, runner: "CliRunner", cli_command, temp_migrations_dir: Path) -> None:
+        """The flag is how you ask for the destructive operation."""
+        from src.surreal_orm.model_base import BaseSurrealModel, clear_model_registry
+
+        clear_model_registry()
+
+        class KeptModel3(BaseSurrealModel):
+            id: str | None = None
+            name: str
+
+        mock_run_async.side_effect = mock_run_async_factory(self._db_state("legacy_audit"))
+
+        result = runner.invoke(
+            cli_command,
+            [
+                "--migrations-dir",
+                str(temp_migrations_dir),
+                "makemigrations",
+                "--name",
+                "x",
+                "--drop-missing",
+            ],
+        )
+
+        clear_model_registry()
+        assert result.exit_code == 0, result.output
+        assert "Drop table legacy_audit" in result.output
+
+    @patch("src.surreal_orm.cli.commands.run_async")
+    def test_the_migrations_table_is_never_dropped_even_with_the_flag(
+        self, mock_run_async, runner: "CliRunner", cli_command, temp_migrations_dir: Path
+    ) -> None:
+        """No flag makes erasing the migration history a reasonable request."""
+        from src.surreal_orm.migrations.executor import MIGRATIONS_TABLE
+        from src.surreal_orm.model_base import BaseSurrealModel, clear_model_registry
+
+        clear_model_registry()
+
+        class KeptModel4(BaseSurrealModel):
+            id: str | None = None
+            name: str
+
+        mock_run_async.side_effect = mock_run_async_factory(self._db_state(MIGRATIONS_TABLE))
+
+        result = runner.invoke(
+            cli_command,
+            [
+                "--migrations-dir",
+                str(temp_migrations_dir),
+                "makemigrations",
+                "--name",
+                "x",
+                "--drop-missing",
+            ],
+        )
+
+        clear_model_registry()
+        assert MIGRATIONS_TABLE not in result.output
+
+
 class TestMigrateCommand:
     """Tests for migrate command."""
 

--- a/tests/test_makemigrations_drop_unit.py
+++ b/tests/test_makemigrations_drop_unit.py
@@ -1,30 +1,32 @@
 """
-Unit tests for which tables ``makemigrations`` is willing to drop.
+Unit tests for which operations ``makemigrations`` is willing to write.
 
-Before 0.33.1 the current state was always empty, so ``diff()``'s "tables in
-self but not in target" branch never fired from ``makemigrations``. Diffing
-against the live database made it reachable for the first time, and it fires for
-**every** table with no registered model:
+Before 0.33.1 the current state was always empty, so ``diff()``'s "in self but
+not in target" branches never fired from ``makemigrations``. Diffing against the
+live database made them reachable for the first time, and they fire for every
+database object with no registered model: the ORM's own migration history, graph
+edge tables created by ``RELATE`` (``ModelIntrospector`` deliberately skips
+``Relation`` fields, so an edge table can only ever look unmodelled), analyzers
+and APIs, which ``ModelIntrospector`` never produces at all, and every table
+whose model module simply was not imported. None of it is recoverable.
 
-    DropTable proposés  : ['_surreal_orm_migrations', 'f1_edge']
-    forwards() : REMOVE TABLE _surreal_orm_migrations;
-    backwards(): ''            reversible = False
-
-That includes the ORM's own migration history, graph edge tables created by
-``RELATE`` (``ModelIntrospector`` deliberately skips ``Relation`` fields, so an
-edge table can only ever look unmodelled), and every table whose model module
-simply was not imported. None of it is recoverable.
+The partition lives in ``split_destructive`` so the CLI and the library agree,
+and these tests exercise it directly — ``click`` is an optional extra, so
+anything asserted only through the CLI runner is invisible to anyone without it.
 """
 
-from src.surreal_orm.migrations.executor import MIGRATIONS_TABLE
-from src.surreal_orm.migrations.operations import DropTable
-from src.surreal_orm.migrations.state import SchemaState, TableState
+from src.surreal_orm.migrations.constants import MIGRATIONS_TABLE
+from src.surreal_orm.migrations.operations import DropTable, split_destructive
+from src.surreal_orm.migrations.state import AnalyzerState, SchemaState, TableState
 
 
-def _db_with(*names: str) -> SchemaState:
+def _db_with(*names: str, analyzers: tuple[str, ...] = ()) -> SchemaState:
+    """Build the state a database read would produce."""
     state = SchemaState()
     for name in names:
         state.tables[name] = TableState(name=name)
+    for analyzer in analyzers:
+        state.analyzers[analyzer] = AnalyzerState(name=analyzer, tokenizers=["blank"])
     return state
 
 
@@ -38,8 +40,53 @@ class TestTheMigrationsTableIsNeverDropped:
         assert [op for op in operations if isinstance(op, DropTable)] == []
 
     def test_other_tables_are_still_drop_candidates(self) -> None:
-        """``diff()`` stays a general API; only the CLI decides policy."""
+        """``diff()`` stays a general API; only the caller decides policy."""
         operations = _db_with(MIGRATIONS_TABLE, "obsolete").diff(SchemaState())
         dropped = [op.name for op in operations if isinstance(op, DropTable)]
 
         assert dropped == ["obsolete"]
+
+
+class TestSplitDestructive:
+    """Irreversible operations are opt-in, whatever noun they act on."""
+
+    def test_an_unmodelled_table_is_held_back(self) -> None:
+        keep, destructive = split_destructive(_db_with("f1_edge").diff(SchemaState()))
+
+        assert keep == []
+        assert [op.describe() for op in destructive] == ["Drop table f1_edge"]
+
+    def test_an_analyzer_is_held_back_too(self) -> None:
+        """``ModelIntrospector`` never produces analyzers, so one always looks obsolete.
+
+        Enumerating ``DropTable`` alone let this one through: ``makemigrations``
+        wrote ``REMOVE ANALYZER`` into the file on every run, with no "Skipped"
+        line, and ``migrate`` then removed an analyzer that full-text indexes
+        reference.
+        """
+        operations = _db_with(analyzers=("english",)).diff(SchemaState())
+        keep, destructive = split_destructive(operations)
+
+        assert keep == []
+        assert [op.describe() for op in destructive] == ["Remove analyzer english"]
+
+    def test_reversible_operations_are_kept(self) -> None:
+        """Only what cannot be rolled back needs the opt-in."""
+        current = SchemaState()
+        current.tables["t"] = TableState(name="t", schema_mode="SCHEMALESS")
+        target = SchemaState()
+        target.tables["t"] = TableState(name="t", schema_mode="SCHEMAFULL")
+
+        keep, destructive = split_destructive(current.diff(target))
+
+        assert destructive == []
+        assert keep != []
+
+    def test_the_partition_is_total(self) -> None:
+        """Nothing is dropped on the floor by the split itself."""
+        operations = _db_with("obsolete", analyzers=("english",)).diff(SchemaState())
+        keep, destructive = split_destructive(operations)
+
+        assert len(keep) + len(destructive) == len(operations)
+        assert all(op.reversible for op in keep)
+        assert not any(op.reversible for op in destructive)

--- a/tests/test_makemigrations_drop_unit.py
+++ b/tests/test_makemigrations_drop_unit.py
@@ -1,0 +1,45 @@
+"""
+Unit tests for which tables ``makemigrations`` is willing to drop.
+
+Before 0.33.1 the current state was always empty, so ``diff()``'s "tables in
+self but not in target" branch never fired from ``makemigrations``. Diffing
+against the live database made it reachable for the first time, and it fires for
+**every** table with no registered model:
+
+    DropTable proposés  : ['_surreal_orm_migrations', 'f1_edge']
+    forwards() : REMOVE TABLE _surreal_orm_migrations;
+    backwards(): ''            reversible = False
+
+That includes the ORM's own migration history, graph edge tables created by
+``RELATE`` (``ModelIntrospector`` deliberately skips ``Relation`` fields, so an
+edge table can only ever look unmodelled), and every table whose model module
+simply was not imported. None of it is recoverable.
+"""
+
+from src.surreal_orm.migrations.executor import MIGRATIONS_TABLE
+from src.surreal_orm.migrations.operations import DropTable
+from src.surreal_orm.migrations.state import SchemaState, TableState
+
+
+def _db_with(*names: str) -> SchemaState:
+    state = SchemaState()
+    for name in names:
+        state.tables[name] = TableState(name=name)
+    return state
+
+
+class TestTheMigrationsTableIsNeverDropped:
+    """It is ORM bookkeeping, never a user table — an invariant, not a policy."""
+
+    def test_the_diff_never_proposes_dropping_it(self) -> None:
+        """Applying that migration would erase the migration history."""
+        operations = _db_with(MIGRATIONS_TABLE).diff(SchemaState())
+
+        assert [op for op in operations if isinstance(op, DropTable)] == []
+
+    def test_other_tables_are_still_drop_candidates(self) -> None:
+        """``diff()`` stays a general API; only the CLI decides policy."""
+        operations = _db_with(MIGRATIONS_TABLE, "obsolete").diff(SchemaState())
+        dropped = [op.name for op in operations if isinstance(op, DropTable)]
+
+        assert dropped == ["obsolete"]

--- a/uv.lock
+++ b/uv.lock
@@ -1613,6 +1613,7 @@ cli = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "click" },
     { name = "docker" },
     { name = "ipykernel" },
     { name = "mypy" },
@@ -1640,6 +1641,7 @@ provides-extras = ["cli", "all"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "click", specifier = ">=8.1.8" },
     { name = "docker", specifier = ">=7.1.0" },
     { name = "ipykernel", specifier = ">=7.2.0" },
     { name = "mypy", specifier = ">=1.14.0" },


### PR DESCRIPTION
Third of three PRs from the review of what shipped unreviewed. Independent of #194 and #196.

### The defect

Before 0.33.1 `makemigrations` diffed against an empty `SchemaState`, so `diff()`'s "tables in self but not in target" branch never fired from it. Diffing against the live database made it reachable for the first time — and it fires for **every** table with no registered model. Reproduced against 3.2.4:

```
tables vues en base : ['_surreal_orm_migrations', 'f1_edge', 'f1_only']
DropTable proposés  : ['_surreal_orm_migrations', 'f1_edge']

forwards() : REMOVE TABLE _surreal_orm_migrations;
backwards(): ''                      reversible = False
```

Three categories get swept up, and none of it is recoverable:

- **The ORM's own migration history.** Applying that migration erases the record of what has been applied.
- **`RELATE` edge tables.** `ModelIntrospector` deliberately skips `Relation` / `ManyToMany` fields, so an edge table can *only ever* look unmodelled.
- **Anything whose model module was not imported** — trivially the case with `-m/--models`.

### The fix, at two different levels

**The migrations table is excluded in `diff()`.** Erasing the record of what has been applied is never a reasonable outcome, whatever the caller asked for — so it is an invariant, and no flag turns it back on.

**Everything else stays a drop candidate in `diff()`.** It is a general comparison API and `schema_diff()` should keep reporting the difference. The *policy* belongs to the CLI: `makemigrations` no longer writes those operations into a migration file unless asked, via `--drop-missing`.

Silently dropping them would trade one problem for another, so it lists what it skipped:

```
Skipped 1 table(s) present in the database with no model:
  - legacy_audit
Pass --drop-missing to remove them (irreversible).
```

### Verification

The original reproduction, replayed:

```
tables vues en base : ['_surreal_orm_migrations', 'f1_edge', 'f1_only']
DropTable proposés  : ['f1_edge']
-> _surreal_orm_migrations serait supprimé : False
```

| Command | Result |
| --- | --- |
| `ruff format --check` / `ruff check` | clean |
| `mypy src/` | clean, 66 files |
| unit suite | exit 0, 0 failures |
| CLI suite (with the `cli` extra) | 34 passed |
| integration vs SurrealDB 3.2.4 | exit 0, 0 failures |

New: `tests/test_makemigrations_drop_unit.py` (the invariant, plus a guard that other tables *are* still candidates so `diff()` keeps working) and four CLI cases — default skips, skipped tables are reported and the flag named, `--drop-missing` opts in, and the migrations table is not dropped even with the flag.

### Note on `DropField`

Left alone deliberately. A field the model no longer declares is a real schema change the user made, so dropping it is correct. The one exception — the one-time `ManyToMany` / `Relation` columns that existing databases physically carry — is already called out in the 0.33.0 release notes as something to review rather than apply blind.

### Release notes required

- **Fixed** — `makemigrations` wrote an irreversible `REMOVE TABLE` for every database table with no registered model, including the ORM's own migration history and `RELATE` edge tables. The history table is now never a drop candidate, and the rest require `--drop-missing`; skipped tables are listed.
- **Changed** — `makemigrations --drop-missing` is the new opt-in for removing unmodelled tables.

### Still to come

A, B and C on `v2` (0.21.5 carries all three), plus **D** — the gaps in the #191 backport: the JSON-encoder regression, the missing `before_validator`, `merge()` coercing in place, and `bulk_update()` not coercing at all.