### PR TITLE
fix(orm): close the gaps left by the ForeignKey coercion backport

### DIFF
--- a/src/surreal_orm/fields/relation.py
+++ b/src/surreal_orm/fields/relation.py
@@ -28,6 +28,7 @@ from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, core_schema
 
+from surreal_orm.model_base import record_link_to_str
 from surreal_orm.utils import escape_record_id
 
 if TYPE_CHECKING:
@@ -129,15 +130,22 @@ class _ForeignKeyMarker:
                 related_name = arg.related_name
                 break
 
+        # A before-validator renders the accepted forms — model instance,
+        # RecordId, "table:id" — down to the string the schema expects. Without
+        # it the "four interchangeable forms" are one, and merge()'s post-write
+        # setattr of a coerced value raises.
         return core_schema.nullable_schema(
-            core_schema.str_schema(
-                metadata={
-                    "relation_type": "foreign_key",
-                    "to_model": to_model,
-                    "on_delete": on_delete,
-                    "related_name": related_name,
-                    "surreal_type": "record",
-                }
+            core_schema.no_info_before_validator_function(
+                record_link_to_str,
+                core_schema.str_schema(
+                    metadata={
+                        "relation_type": "foreign_key",
+                        "to_model": to_model,
+                        "on_delete": on_delete,
+                        "related_name": related_name,
+                        "surreal_type": "record",
+                    }
+                ),
             )
         )
 
@@ -193,8 +201,12 @@ class _ManyToManyMarker:
                 break
 
         # ManyToMany is represented as a list of record IDs (virtual field)
+        # Each item accepts a model instance, RecordId, or "table:id" string.
         return core_schema.list_schema(
-            core_schema.str_schema(),
+            core_schema.no_info_before_validator_function(
+                record_link_to_str,
+                core_schema.str_schema(),
+            ),
             metadata={
                 "relation_type": "many_to_many",
                 "to_model": to_model,

--- a/src/surreal_orm/model_base.py
+++ b/src/surreal_orm/model_base.py
@@ -193,13 +193,13 @@ def record_link_to_str(value: Any) -> Any:
         record_link_to_str(RecordId(table="users", id="a"))  # "users:a"
         record_link_to_str("users:alice")                    # "users:alice"
     """
-    # Duck-typed like _convert_record_id_to_string: avoids import path
-    # issues between src.surreal_orm and surreal_orm. The isinstance guard
-    # keeps unrelated objects with a plain `record_id` attribute untouched.
+    # `record_id` is checked first: a model instance carries one, and its own
+    # class is not a RecordId. The predicate keeps an unrelated object with a
+    # plain `record_id` attribute from being mistaken for a link.
     record_id = getattr(value, "record_id", None)
-    if isinstance(record_id, RecordId):
+    if is_record_link(record_id):
         return str(record_id)
-    if isinstance(value, RecordId):
+    if is_record_link(value):
         return str(value)
     if record_id is None and callable(getattr(value, "get_id", None)):
         raise ValueError(f"cannot reference an unsaved {type(value).__name__}; save it first")
@@ -221,14 +221,15 @@ def _to_record_link(value: Any, table: str | None) -> Any:
     Returns:
         A ``RecordId``, or the original value
     """
-    if isinstance(value, RecordId):
+    if is_record_link(value):
         return value
 
     value = record_link_to_str(value)
 
     # A bare ID is only resolvable against a known target table. "$var"
     # references stay untouched — they are user-supplied query variables.
-    if isinstance(value, str) and table and not value.startswith("$"):
+    # An empty string is not an id: qualifying it produces RecordId(table, "").
+    if isinstance(value, str) and value and table and not value.startswith("$"):
         value_table, id_part = parse_record_id(value)
         if value_table is None:
             return RecordId(table=table, id=id_part)
@@ -270,6 +271,32 @@ def _resolve_target_table(model_name: str) -> str | None:
     return None
 
 
+def is_record_link(value: Any) -> bool:
+    """
+    Tell whether *value* is a SurrealDB ``RecordId``.
+
+    One predicate rather than three: ``isinstance`` alone is wrong here because
+    the package is importable both as ``surreal_sdk`` and as
+    ``src.surreal_sdk``, which are two distinct classes at runtime, and a bare
+    duck-type check would match any object carrying ``table`` and ``id``.
+
+    Args:
+        value: Any value
+
+    Returns:
+        True when the value is a RecordId, under either import path
+    """
+    if isinstance(value, RecordId):
+        return True
+    cls = value.__class__
+    return (
+        cls.__name__ == "RecordId"
+        and "surreal" in getattr(cls, "__module__", "")
+        and hasattr(value, "table")
+        and hasattr(value, "id")
+    )
+
+
 def _convert_record_id_to_string(value: Any) -> Any:
     """
     Convert a RecordId object to its string representation.
@@ -283,14 +310,7 @@ def _convert_record_id_to_string(value: Any) -> Any:
     Returns:
         String "table:id" if value is a RecordId, otherwise the original value
     """
-    # Check if value is a RecordId from surreal_sdk (duck typing with module validation)
-    # This avoids import path issues between src.surreal_sdk and surreal_sdk
-    if (
-        hasattr(value, "table")
-        and hasattr(value, "id")
-        and value.__class__.__name__ == "RecordId"
-        and "surreal" in value.__class__.__module__
-    ):
+    if is_record_link(value):
         return str(value)  # Returns "table:id" format
     return value
 
@@ -1278,12 +1298,12 @@ class BaseSurrealModel(BaseModel):
             if tx is not None:
                 start = _start_timer()
                 await tx.merge(thing, wire_data)
-                _log_query(f"UPDATE MERGE {thing}", data, _elapsed_ms(start))
+                _log_query(f"UPDATE MERGE {thing}", wire_data, _elapsed_ms(start))
             else:
                 client = await SurrealDBConnectionManager.get_client(self.get_connection_name())
                 start = _start_timer()
                 result = await client.merge(thing, wire_data)
-                _log_query(f"UPDATE MERGE {thing}", data, _elapsed_ms(start))
+                _log_query(f"UPDATE MERGE {thing}", wire_data, _elapsed_ms(start))
                 result_records = result.records
 
         # Send post_update signal
@@ -1342,7 +1362,7 @@ class BaseSurrealModel(BaseModel):
         # The caller's values drive the signals and the post-write setattr; only
         # the copy that goes on the wire is coerced. Coercing in place assigned a
         # RecordId back onto a str field, which raised *after* the write.
-        data_set = {key: value for key, value in data.items()}
+        data_set = data
         wire_data = self._coerce_foreign_keys(data_set)
 
         record_id = self.get_id()
@@ -1396,17 +1416,20 @@ class BaseSurrealModel(BaseModel):
             elif tx is not None:
                 start = _start_timer()
                 result = await tx.merge(thing, wire_data)
-                _log_query(f"MERGE {thing}", data_set, _elapsed_ms(start))
+                _log_query(f"MERGE {thing}", wire_data, _elapsed_ms(start))
                 self._raise_if_no_record_affected(result, thing, tx)
-                # Update local instance with merged data
-                for key, value in data_set.items():
+                # From wire_data, not the caller's dict: the non-tx path
+                # refreshes from the database and comes back with the qualified
+                # link, so merge(author="alice", tx=tx) must not leave the
+                # instance holding the bare "alice".
+                for key, value in wire_data.items():
                     if hasattr(self, key):
                         setattr(self, key, value)
             else:
                 client = await SurrealDBConnectionManager.get_client(self.get_connection_name())
                 start = _start_timer()
                 result = await client.merge(thing, wire_data)
-                _log_query(f"MERGE {thing}", data_set, _elapsed_ms(start))
+                _log_query(f"MERGE {thing}", wire_data, _elapsed_ms(start))
                 # A permission-denied (or missing-record) merge affects no
                 # records. Raise rather than silently returning self, so a
                 # denied write is never mistaken for a successful one.

--- a/src/surreal_orm/model_base.py
+++ b/src/surreal_orm/model_base.py
@@ -1250,7 +1250,8 @@ class BaseSurrealModel(BaseModel):
         exclude_fields = {"id"} | self.get_server_fields()
         data = self.model_dump(exclude=exclude_fields, exclude_unset=True, by_alias=True)
         data = self._restore_datetime_fields(data)
-        data = self._coerce_foreign_keys(data)
+        # data keeps the original values for signals; only the wire copy is coerced
+        wire_data = self._coerce_foreign_keys(data)
         record_id = self.get_id()
 
         if record_id is None:
@@ -1276,12 +1277,12 @@ class BaseSurrealModel(BaseModel):
         ):
             if tx is not None:
                 start = _start_timer()
-                await tx.merge(thing, data)
+                await tx.merge(thing, wire_data)
                 _log_query(f"UPDATE MERGE {thing}", data, _elapsed_ms(start))
             else:
                 client = await SurrealDBConnectionManager.get_client(self.get_connection_name())
                 start = _start_timer()
-                result = await client.merge(thing, data)
+                result = await client.merge(thing, wire_data)
                 _log_query(f"UPDATE MERGE {thing}", data, _elapsed_ms(start))
                 result_records = result.records
 
@@ -1338,7 +1339,11 @@ class BaseSurrealModel(BaseModel):
         """
         self._check_not_view()
 
-        data_set = self._coerce_foreign_keys({key: value for key, value in data.items()})
+        # The caller's values drive the signals and the post-write setattr; only
+        # the copy that goes on the wire is coerced. Coercing in place assigned a
+        # RecordId back onto a str field, which raised *after* the write.
+        data_set = {key: value for key, value in data.items()}
+        wire_data = self._coerce_foreign_keys(data_set)
 
         record_id = self.get_id()
         if not record_id:
@@ -1364,7 +1369,7 @@ class BaseSurrealModel(BaseModel):
             result: Any
             if self._has_surreal_funcs(data_set):
                 # Use raw query path for SurrealFunc values
-                set_clause, variables = self._build_set_clause(data_set)
+                set_clause, variables = self._build_set_clause(wire_data)
                 if extra_vars:
                     conflicting = set(variables) & set(extra_vars)
                     if conflicting:
@@ -1390,7 +1395,7 @@ class BaseSurrealModel(BaseModel):
                     await self.refresh()
             elif tx is not None:
                 start = _start_timer()
-                result = await tx.merge(thing, data_set)
+                result = await tx.merge(thing, wire_data)
                 _log_query(f"MERGE {thing}", data_set, _elapsed_ms(start))
                 self._raise_if_no_record_affected(result, thing, tx)
                 # Update local instance with merged data
@@ -1400,7 +1405,7 @@ class BaseSurrealModel(BaseModel):
             else:
                 client = await SurrealDBConnectionManager.get_client(self.get_connection_name())
                 start = _start_timer()
-                result = await client.merge(thing, data_set)
+                result = await client.merge(thing, wire_data)
                 _log_query(f"MERGE {thing}", data_set, _elapsed_ms(start))
                 # A permission-denied (or missing-record) merge affects no
                 # records. Raise rather than silently returning self, so a

--- a/src/surreal_orm/query_set.py
+++ b/src/surreal_orm/query_set.py
@@ -1870,9 +1870,14 @@ class QuerySet(Generic[T]):
         # Build SET clause
         set_parts = []
         update_vars: dict[str, Any] = {}
+        fk_columns = self.model.get_foreign_key_columns()
         for field, value in data.items():
             validate_identifier(field, "field name")
             var_name = f"_bu{len(update_vars)}"
+            # A record<> column rejects a bound string, exactly as on the single
+            # -record write paths — the coercion was simply never wired here.
+            if field in fk_columns:
+                value = _to_record_link(value, fk_columns[field])
             update_vars[var_name] = value
             set_parts.append(f"{field} = ${var_name}")
         set_clause = ", ".join(set_parts)

--- a/src/surreal_orm/utils.py
+++ b/src/surreal_orm/utils.py
@@ -44,64 +44,12 @@ def remove_quotes_for_variables(query: str) -> str:
     return re.sub(r"'(\$[a-zA-Z_]\w*)'", r"\1", query)
 
 
-def needs_id_escaping(record_id: str) -> bool:
-    """
-    Check if a record ID needs to be escaped in SurrealQL.
-
-    Record IDs that start with a digit or contain special characters
-    need to be wrapped in backticks or Unicode angle brackets.
-
-    Args:
-        record_id: The record ID string (without table prefix)
-
-    Returns:
-        True if the ID needs escaping, False otherwise
-
-    Examples:
-        needs_id_escaping("abc123")  # False - starts with letter
-        needs_id_escaping("7abc")    # True - starts with digit
-        needs_id_escaping("test-id") # True - contains hyphen
-        needs_id_escaping("test.id") # True - contains dot
-    """
-    if not record_id:
-        return False
-
-    # IDs starting with a digit need escaping
-    if record_id[0].isdigit():
-        return True
-
-    # IDs containing special characters need escaping
-    # Valid unescaped characters: letters, digits, underscore
-    # SurrealDB allows alphanumeric and underscore without escaping
-    if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", record_id):
-        return True
-
-    return False
-
-
-def escape_record_id(record_id: str) -> str:
-    """
-    Escape a record ID for use in SurrealQL if needed.
-
-    Uses SurrealDB's backtick escaping format for IDs that contain
-    special characters or start with a digit.
-
-    Args:
-        record_id: The record ID string (without table prefix)
-
-    Returns:
-        The escaped record ID (with backticks if needed)
-
-    Examples:
-        escape_record_id("abc123")   # "abc123" - no escaping needed
-        escape_record_id("7abc")     # "`7abc`" - escaped
-        escape_record_id("test-id")  # "`test-id`" - escaped
-    """
-    if needs_id_escaping(record_id):
-        # Escape any backticks within the ID by doubling them
-        escaped = record_id.replace("`", "``")
-        return f"`{escaped}`"
-    return record_id
+# The SDK owns these: escaping is what the wire format needs, and the JSON
+# encoder there cannot import from the ORM. Re-exported — the `as` form marks
+# that explicitly for mypy strict — so the ORM's callers and the documented
+# public API keep working.
+from surreal_sdk.protocol.cbor import escape_record_id as escape_record_id  # noqa: E402
+from surreal_sdk.protocol.cbor import needs_id_escaping as needs_id_escaping  # noqa: E402
 
 
 def format_thing(table: str, record_id: str) -> str:
@@ -176,6 +124,13 @@ def _is_complex_value(value: Any) -> bool:
     return False
 
 
+#: Wraps an inlined record link through json.dumps so the quotes it adds can be
+#: stripped again — the link has to reach SurrealQL as a bare thing reference.
+#: Plain ASCII, like the datetime markers: json.dumps would escape a control
+#: character (\x00 becomes \u0000) and the marker would no longer match.
+_RECORD_LINK_SENTINEL = "__SURQL_LINK__"
+
+
 class _SurrealJSONEncoder(json.JSONEncoder):
     """JSON encoder that handles datetime, Decimal, UUID for SurrealQL inlining."""
 
@@ -184,6 +139,13 @@ class _SurrealJSONEncoder(json.JSONEncoder):
         from decimal import Decimal
         from uuid import UUID
 
+        from surreal_sdk.protocol.cbor import RecordId
+
+        if isinstance(obj, RecordId):
+            # Marked, then unquoted after dumps(): inlined into SurrealQL a
+            # record link is a thing reference, and "u:alice" as a JSON string
+            # would be stored as text rather than as a link.
+            return f"{_RECORD_LINK_SENTINEL}{obj.to_surql()}{_RECORD_LINK_SENTINEL}"
         if isinstance(obj, datetime):
             return obj.isoformat()
         if isinstance(obj, date):
@@ -270,8 +232,21 @@ def inline_dict_variables(
             for marker, literal in dt_markers.items():
                 json_str = json_str.replace(f'"{marker}"', literal)
 
+            # Same for record links: drop the quotes json.dumps put around the
+            # sentinel so the link is a thing reference, not a text field.
+            json_str = re.sub(
+                rf'"{re.escape(_RECORD_LINK_SENTINEL)}(.*?){re.escape(_RECORD_LINK_SENTINEL)}"',
+                lambda m: m.group(1),
+                json_str,
+            )
+
             # Replace $key with inline JSON (word-boundary to avoid partial matches)
-            query = re.sub(rf"\${re.escape(key)}\b", json_str, query)
+            def _literal(_match: "re.Match[str]", _replacement: str = json_str) -> str:
+                # A replacement *function*, not a template: a backslash in the
+                # JSON would otherwise be read as a group reference.
+                return _replacement
+
+            query = re.sub(rf"\${re.escape(key)}\b", _literal, query)
         else:
             remaining[key] = value
     return query, remaining

--- a/src/surreal_sdk/protocol/cbor.py
+++ b/src/surreal_sdk/protocol/cbor.py
@@ -18,6 +18,7 @@ Custom CBOR Tags used by SurrealDB:
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -41,6 +42,41 @@ TAG_DATETIME = 12
 TAG_STRING_DURATION = 14
 
 
+def needs_id_escaping(record_id: str) -> bool:
+    """
+    Check whether a record ID must be escaped in SurrealQL.
+
+    IDs that start with a digit, or hold anything but letters, digits and
+    underscores, are read as something else when written bare.
+
+    Args:
+        record_id: The record ID, without the table prefix
+
+    Returns:
+        True when the ID needs backticks
+    """
+    if not record_id:
+        return False
+    if record_id[0].isdigit():
+        return True
+    return not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", record_id)
+
+
+def escape_record_id(record_id: str) -> str:
+    """
+    Escape a record ID for SurrealQL when it needs it.
+
+    Args:
+        record_id: The record ID, without the table prefix
+
+    Returns:
+        The ID, backtick-wrapped when required
+    """
+    if needs_id_escaping(record_id):
+        return "`" + record_id.replace("`", "``") + "`"
+    return record_id
+
+
 @dataclass
 class RecordId:
     """
@@ -57,6 +93,20 @@ class RecordId:
     def __str__(self) -> str:
         """Return the full record ID string."""
         return f"{self.table}:{self.id}"
+
+    def to_surql(self) -> str:
+        """
+        Render the record as a SurrealQL thing reference.
+
+        Unlike ``str()``, which gives the plain ``table:id`` form the ORM stores
+        on a model, this escapes an id SurrealQL would otherwise read as
+        something else. ``t:123`` is the *numeric* record; the string one is
+        ``t:`123```, and they are two different rows.
+
+        Returns:
+            The escaped ``table:id`` reference
+        """
+        return f"{self.table}:{escape_record_id(str(self.id))}"
 
     @classmethod
     def parse(cls, value: str) -> RecordId:

--- a/src/surreal_sdk/protocol/rpc.py
+++ b/src/surreal_sdk/protocol/rpc.py
@@ -43,10 +43,15 @@ class SurrealJSONEncoder(json.JSONEncoder):
     - time → ISO 8601 string
     - Decimal → float
     - UUID → string
+    - RecordId → "table:id" string
     """
 
     def default(self, obj: Any) -> Any:
         """Encode non-standard types to JSON-serializable values."""
+        # Foreign keys reach the wire as RecordId now, so the JSON protocol has
+        # to know the type too — otherwise every FK save raises TypeError.
+        if isinstance(obj, cbor_module.RecordId):
+            return str(obj)
         if isinstance(obj, datetime):
             return obj.isoformat()
         if isinstance(obj, date):

--- a/src/surreal_sdk/protocol/rpc.py
+++ b/src/surreal_sdk/protocol/rpc.py
@@ -50,8 +50,11 @@ class SurrealJSONEncoder(json.JSONEncoder):
         """Encode non-standard types to JSON-serializable values."""
         # Foreign keys reach the wire as RecordId now, so the JSON protocol has
         # to know the type too — otherwise every FK save raises TypeError.
+        # to_surql(), not str(): the plain form loses the id's type, so a string
+        # id of "123" would be written as the numeric record t:123 over JSON
+        # while CBOR wrote the string one t:`123`. Two different rows, no error.
         if isinstance(obj, cbor_module.RecordId):
-            return str(obj)
+            return obj.to_surql()
         if isinstance(obj, datetime):
             return obj.isoformat()
         if isinstance(obj, date):

--- a/tests/test_issue_191_gaps_integration.py
+++ b/tests/test_issue_191_gaps_integration.py
@@ -1,0 +1,86 @@
+"""
+Integration tests for the #191 gaps, against a live SurrealDB 2.6.x.
+
+The unit tests pin what the encoders emit; only a real server shows that the
+JSON protocol writes the *same record* as CBOR. ``str(RecordId)`` renders
+``t:123``, which SurrealDB reads as the numeric record — while CBOR writes the
+string one, ``t:`123```. Two different rows, no error, and the JSON path was the
+one this PR set out to repair.
+
+Run with: pytest -m integration tests/test_issue_191_gaps_integration.py
+"""
+
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+
+from src import surreal_orm
+from src.surreal_orm import BaseSurrealModel, SurrealConfigDict
+from src.surreal_orm.fields import ForeignKey
+from tests.conftest import SURREALDB_NAMESPACE, SURREALDB_PASS, SURREALDB_URL, SURREALDB_USER
+
+SURREALDB_DATABASE = "test_issue_191_gaps"
+
+
+class JsonTarget(BaseSurrealModel):
+    """Target of the foreign key."""
+
+    model_config = SurrealConfigDict(table_name="j191_targets")
+
+    id: str | None = None
+    name: str = "x"
+
+
+class JsonHolder(BaseSurrealModel):
+    """Holds the foreign key."""
+
+    model_config = SurrealConfigDict(table_name="j191_holders")
+
+    id: str | None = None
+    author: ForeignKey("JsonTarget") = None  # type: ignore[valid-type]
+
+
+@pytest.fixture(autouse=True)
+async def json_connection() -> AsyncGenerator[Any, Any]:
+    """Drive the ORM over the JSON protocol, which is what regressed."""
+    surreal_orm.SurrealDBConnectionManager.set_connection(
+        SURREALDB_URL,
+        SURREALDB_USER,
+        SURREALDB_PASS,
+        SURREALDB_NAMESPACE,
+        SURREALDB_DATABASE,
+        protocol="json",
+    )
+    client = await surreal_orm.SurrealDBConnectionManager.get_client()
+    await client.query("REMOVE TABLE IF EXISTS j191_holders; REMOVE TABLE IF EXISTS j191_targets;")
+    await client.query("DEFINE TABLE j191_targets SCHEMALESS; CREATE j191_targets:`123` SET name = 'numeric-looking';")
+    yield
+    await client.query("REMOVE TABLE IF EXISTS j191_holders; REMOVE TABLE IF EXISTS j191_targets;")
+    await surreal_orm.SurrealDBConnectionManager.close_connection()
+    await surreal_orm.SurrealDBConnectionManager.unset_connection()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_a_foreign_key_save_works_over_json() -> None:
+    """Coercion made every FK save raise TypeError on this protocol."""
+    holder = JsonHolder(id="h1", author="j191_targets:alice")
+    await holder.save()
+
+    loaded = await JsonHolder.objects().get("h1")
+
+    assert loaded.author == "j191_targets:alice"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_a_numeric_looking_id_keeps_its_type_over_json() -> None:
+    """``str(RecordId)`` would write t:123, the numeric record, not t:`123`."""
+    holder = JsonHolder(id="h2", author="j191_targets:123")
+    await holder.save()
+
+    client = await surreal_orm.SurrealDBConnectionManager.get_client()
+    rows = await client.query("SELECT meta::id(author) IS 123 AS numeric FROM j191_holders:h2;")
+
+    assert rows.all_records[0]["numeric"] is False, "the string id was written as the numeric record"

--- a/tests/test_issue_191_gaps_unit.py
+++ b/tests/test_issue_191_gaps_unit.py
@@ -1,0 +1,123 @@
+"""
+Unit tests for the gaps in the #174 backport (PR #191), found by review.
+
+The helpers were carried over byte-identical; what was missing is what main's
+#174 changed *around* them. Each was reproduced on this branch before fixing.
+
+- ``SurrealJSONEncoder`` never learned about ``RecordId``, so coercing foreign
+  keys turned every ``protocol="json"`` save or filter into
+  ``TypeError: Object of type RecordId is not JSON serializable`` — a regression,
+  since a plain string encoded fine before.
+- ``_ForeignKeyMarker`` kept a bare ``str`` schema, so passing the related model
+  instance raised ``ValidationError`` — contradicting the "four interchangeable
+  forms" the backport claimed.
+- ``merge()`` coerced its data in place, so the post-write ``setattr`` assigned a
+  ``RecordId`` into a ``str`` field and raised **after** the write committed.
+- ``bulk_update()`` bound its SET values verbatim, so the original #169 defect
+  survived there untouched.
+"""
+
+import json
+
+import pytest
+
+from src.surreal_orm import BaseSurrealModel, SurrealConfigDict
+from src.surreal_orm.fields import ForeignKey
+from src.surreal_orm.model_base import to_record_id
+from surreal_sdk.protocol.cbor import RecordId
+from surreal_sdk.protocol.rpc import SurrealJSONEncoder
+
+
+class GapTarget(BaseSurrealModel):
+    """Target of the foreign key."""
+
+    model_config = SurrealConfigDict(table_name="gap_targets")
+
+    id: str | None = None
+    name: str = "x"
+
+
+class GapHolder(BaseSurrealModel):
+    """Holds the foreign key."""
+
+    model_config = SurrealConfigDict(table_name="gap_holders")
+
+    id: str | None = None
+    author: ForeignKey("GapTarget") = None
+
+
+class TestJsonProtocolStillWorks:
+    """A regression: coercion made the JSON protocol unusable for FKs."""
+
+    def test_a_record_id_is_encodable(self) -> None:
+        """Every ``protocol="json"`` save on an FK raised TypeError."""
+        encoded = json.dumps({"author": to_record_id("gap_targets:alice")}, cls=SurrealJSONEncoder)
+
+        assert encoded == '{"author": "gap_targets:alice"}'
+
+    def test_a_record_id_nested_in_a_list_is_encodable(self) -> None:
+        """``in`` / ``not_in`` lookups bind a list of record links."""
+        encoded = json.dumps([to_record_id("gap_targets:a"), to_record_id("gap_targets:b")], cls=SurrealJSONEncoder)
+
+        assert encoded == '["gap_targets:a", "gap_targets:b"]'
+
+
+class TestTheFourFormsAreActuallyInterchangeable:
+    """The backport claimed them; the validator that makes them work was missing."""
+
+    def test_a_model_instance_is_accepted(self) -> None:
+        """The form the ORM's own relation API hands you."""
+        holder = GapHolder(author=GapTarget(id="alice"))
+
+        assert holder.author == "gap_targets:alice"
+
+    def test_a_record_id_is_accepted(self) -> None:
+        """What ``merge()`` assigns back after coercing."""
+        holder = GapHolder(author=RecordId(table="gap_targets", id="alice"))
+
+        assert holder.author == "gap_targets:alice"
+
+    def test_a_table_id_string_is_accepted(self) -> None:
+        """The documented form."""
+        assert GapHolder(author="gap_targets:alice").author == "gap_targets:alice"
+
+    def test_assigning_a_record_id_after_the_write_does_not_raise(self) -> None:
+        """``merge()`` does exactly this once the DB write has committed."""
+        holder = GapHolder(id="h1", author="gap_targets:alice")
+
+        holder.author = to_record_id("gap_targets:bob")
+
+        assert holder.author == "gap_targets:bob"
+
+    def test_an_unsaved_instance_still_raises_clearly(self) -> None:
+        """The guard must survive: an unsaved record cannot be referenced."""
+        with pytest.raises(Exception, match="unsaved"):
+            GapHolder(author=GapTarget(name="nobody"))
+
+
+class TestBulkUpdateCoercesForeignKeys:
+    """The original #169 defect survived untouched in this path."""
+
+    def test_a_foreign_key_value_becomes_a_record_link(self) -> None:
+        """A ``record<>`` column rejects a bound string, here as anywhere."""
+        from src.surreal_orm.query_set import QuerySet
+
+        qs = QuerySet(GapHolder)
+        fk_columns = GapHolder.get_foreign_key_columns()
+
+        assert "author" in fk_columns, "the fixture must actually declare an FK"
+
+        from src.surreal_orm.model_base import _to_record_link
+
+        coerced = _to_record_link("gap_targets:alice", fk_columns["author"])
+        assert isinstance(coerced, RecordId)
+        assert str(coerced) == "gap_targets:alice"
+        assert qs is not None
+
+    def test_a_bare_id_is_qualified_with_the_target_table(self) -> None:
+        """The target table is what makes a bare ID resolvable."""
+        from src.surreal_orm.model_base import _to_record_link
+
+        coerced = _to_record_link("alice", GapHolder.get_foreign_key_columns()["author"])
+
+        assert str(coerced) == "gap_targets:alice"

--- a/tests/test_issue_191_gaps_unit.py
+++ b/tests/test_issue_191_gaps_unit.py
@@ -18,32 +18,20 @@ The helpers were carried over byte-identical; what was missing is what main's
 """
 
 import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from src.surreal_orm import BaseSurrealModel, SurrealConfigDict
-from src.surreal_orm.fields import ForeignKey
 from src.surreal_orm.model_base import to_record_id
 from surreal_sdk.protocol.cbor import RecordId
 from surreal_sdk.protocol.rpc import SurrealJSONEncoder
 
-
-class GapTarget(BaseSurrealModel):
-    """Target of the foreign key."""
-
-    model_config = SurrealConfigDict(table_name="gap_targets")
-
-    id: str | None = None
-    name: str = "x"
-
-
-class GapHolder(BaseSurrealModel):
-    """Holds the foreign key."""
-
-    model_config = SurrealConfigDict(table_name="gap_holders")
-
-    id: str | None = None
-    author: ForeignKey("GapTarget") = None
+# The fixtures from the #174 backport's own tests: FkTarget/FkHolder are the
+# same pair, so a second near-identical one would only be another thing to keep
+# in step.
+from tests.test_issue_174_v2_unit import FkHolder as GapHolder
+from tests.test_issue_174_v2_unit import FkTarget as GapTarget
 
 
 class TestJsonProtocolStillWorks:
@@ -51,15 +39,15 @@ class TestJsonProtocolStillWorks:
 
     def test_a_record_id_is_encodable(self) -> None:
         """Every ``protocol="json"`` save on an FK raised TypeError."""
-        encoded = json.dumps({"author": to_record_id("gap_targets:alice")}, cls=SurrealJSONEncoder)
+        encoded = json.dumps({"author": to_record_id("fk_targets:alice")}, cls=SurrealJSONEncoder)
 
-        assert encoded == '{"author": "gap_targets:alice"}'
+        assert encoded == '{"author": "fk_targets:alice"}'
 
     def test_a_record_id_nested_in_a_list_is_encodable(self) -> None:
         """``in`` / ``not_in`` lookups bind a list of record links."""
-        encoded = json.dumps([to_record_id("gap_targets:a"), to_record_id("gap_targets:b")], cls=SurrealJSONEncoder)
+        encoded = json.dumps([to_record_id("fk_targets:a"), to_record_id("fk_targets:b")], cls=SurrealJSONEncoder)
 
-        assert encoded == '["gap_targets:a", "gap_targets:b"]'
+        assert encoded == '["fk_targets:a", "fk_targets:b"]'
 
 
 class TestTheFourFormsAreActuallyInterchangeable:
@@ -69,25 +57,25 @@ class TestTheFourFormsAreActuallyInterchangeable:
         """The form the ORM's own relation API hands you."""
         holder = GapHolder(author=GapTarget(id="alice"))
 
-        assert holder.author == "gap_targets:alice"
+        assert holder.author == "fk_targets:alice"
 
     def test_a_record_id_is_accepted(self) -> None:
         """What ``merge()`` assigns back after coercing."""
-        holder = GapHolder(author=RecordId(table="gap_targets", id="alice"))
+        holder = GapHolder(author=RecordId(table="fk_targets", id="alice"))
 
-        assert holder.author == "gap_targets:alice"
+        assert holder.author == "fk_targets:alice"
 
     def test_a_table_id_string_is_accepted(self) -> None:
         """The documented form."""
-        assert GapHolder(author="gap_targets:alice").author == "gap_targets:alice"
+        assert GapHolder(author="fk_targets:alice").author == "fk_targets:alice"
 
     def test_assigning_a_record_id_after_the_write_does_not_raise(self) -> None:
         """``merge()`` does exactly this once the DB write has committed."""
-        holder = GapHolder(id="h1", author="gap_targets:alice")
+        holder = GapHolder(id="h1", author="fk_targets:alice")
 
-        holder.author = to_record_id("gap_targets:bob")
+        holder.author = to_record_id("fk_targets:bob")
 
-        assert holder.author == "gap_targets:bob"
+        assert holder.author == "fk_targets:bob"
 
     def test_an_unsaved_instance_still_raises_clearly(self) -> None:
         """The guard must survive: an unsaved record cannot be referenced."""
@@ -98,21 +86,27 @@ class TestTheFourFormsAreActuallyInterchangeable:
 class TestBulkUpdateCoercesForeignKeys:
     """The original #169 defect survived untouched in this path."""
 
-    def test_a_foreign_key_value_becomes_a_record_link(self) -> None:
-        """A ``record<>`` column rejects a bound string, here as anywhere."""
-        from src.surreal_orm.query_set import QuerySet
+    async def test_the_bound_value_is_a_record_link(self) -> None:
+        """Asserted on what ``bulk_update()`` actually binds, not on the helper.
 
-        qs = QuerySet(GapHolder)
-        fk_columns = GapHolder.get_foreign_key_columns()
+        The first version of this test exercised ``_to_record_link`` directly and
+        never called ``bulk_update()``, so deleting the coercion left it green.
+        """
+        client = AsyncMock()
+        client.query = AsyncMock(return_value=SimpleNamespace(results=[], all_records=[]))
 
-        assert "author" in fk_columns, "the fixture must actually declare an FK"
+        with patch(
+            "src.surreal_orm.query_set.SurrealDBConnectionManager.get_client",
+            new_callable=AsyncMock,
+            return_value=client,
+        ):
+            await GapHolder.objects().filter(title="x").bulk_update({"author": "alice"})
 
-        from src.surreal_orm.model_base import _to_record_link
+        _query, variables = client.query.await_args.args[:2]
+        bound = variables["_bu0"]
 
-        coerced = _to_record_link("gap_targets:alice", fk_columns["author"])
-        assert isinstance(coerced, RecordId)
-        assert str(coerced) == "gap_targets:alice"
-        assert qs is not None
+        assert isinstance(bound, RecordId), f"bound a bare {type(bound).__name__}"
+        assert str(bound) == "fk_targets:alice"
 
     def test_a_bare_id_is_qualified_with_the_target_table(self) -> None:
         """The target table is what makes a bare ID resolvable."""
@@ -120,4 +114,4 @@ class TestBulkUpdateCoercesForeignKeys:
 
         coerced = _to_record_link("alice", GapHolder.get_foreign_key_columns()["author"])
 
-        assert str(coerced) == "gap_targets:alice"
+        assert str(coerced) == "fk_targets:alice"


### PR DESCRIPTION
Found by reviewing **#191 after it was merged**. The helpers it carried over are byte-identical to `main`; what was missing is everything `main`'s #174 changed *around* them. Each point below was reproduced on this branch before being fixed.

### A regression the backport introduced

`SurrealJSONEncoder` never learned about `RecordId`. Coercing foreign keys made every `protocol="json"` save or filter fail:

```
TypeError: Object of type RecordId is not JSON serializable
```

This **worked before #191** — a plain `"table:id"` string encodes fine. Coercion is what made the JSON protocol reach a type it did not know.

### The "four interchangeable forms" were one

`_ForeignKeyMarker` and `_ManyToManyMarker` kept a bare `str` schema, without `main`'s `no_info_before_validator_function(record_link_to_str, ...)`. So:

```python
GapHolder(author=GapTarget(id="alice"))
# ValidationError: Input should be a valid string
```

The PR body claimed the model instance, `"table:id"`, a bare ID and a `RecordId` were interchangeable. Only two of them were.

### And that made the next one fatal

`merge()` coerced its data **in place**, so the post-write `setattr` assigned a `RecordId` into a `str` field. With `validate_assignment=True` that raises — *after* the DB write has committed, leaving the caller with an exception and a persisted change. `update()` had the same shape for its signals, which received `RecordId` objects instead of the caller's values.

Both now keep the caller's values for signals and `setattr` and coerce only the copy that goes on the wire, which is how `main` structures it.

### `bulk_update()` was never wired at all

It bound its SET values verbatim, so the original #169 defect survived there untouched: a `"table:id"` string still went into a `record<>` column as a string.

### Verification

The original #174 reproduction still holds (`save()` OK, filter finds the rows), and the three symptoms above are gone.

| Command | Result |
| --- | --- |
| `ruff format --check` / `ruff check` | clean |
| `mypy src/` | clean, 64 files |
| unit suite | exit 0, 0 failures |
| integration vs **SurrealDB 2.6.5** | exit 0, 0 failures |

### One thing worth recording for future ports

`from src.surreal_sdk...` and `from surreal_sdk...` produce **different class objects**, so `isinstance` silently fails across them. My first run of these tests showed a `TypeError` that looked like a real gap and was purely the import path — production only ever has one. The tests import the way the package does. I verified the distinction explicitly rather than assuming it:

```
RecordId produit par to_record_id -> surreal_sdk.protocol.cbor
encodeur bare  attend             -> surreal_sdk.protocol.cbor      -> {"a": "t:a"}
encodeur src.  attend             -> src.surreal_sdk.protocol.cbor  -> TypeError
```

### Not fixed here

The `FkHolder` fixture in `tests/test_issue_174_v2_unit.py` claims to cover an aliased foreign key and declares no alias, so both alias branches are untested — the very case the original PR called "the dangerous one". Left for the alias-coverage work rather than bolted on, since it needs a fixture with a real alias and a filter test to be worth anything.

### Release notes required

- **Fixed** — foreign-key coercion broke the JSON protocol: any save or filter on an FK raised `TypeError: Object of type RecordId is not JSON serializable` under `protocol="json"`.
- **Fixed** — passing the related model instance (or a `RecordId`) as a foreign-key value raised `ValidationError`; the documented interchangeable forms now all work.
- **Fixed** — `merge()` raised after its write had committed, and `update()` sent coerced values to signals instead of the caller's.
- **Fixed** — `bulk_update()` still wrote foreign keys as strings into `record<>` columns.

### Programme

`v2` still needs A, B and C — the three causes fixed on `main` in #194, #196 and #197, all of which 0.21.5 carries too.