### PR TITLE
fix(migrations): make a table definition survive the round trip

### DIFF
--- a/src/surreal_orm/migrations/__init__.py
+++ b/src/surreal_orm/migrations/__init__.py
@@ -31,6 +31,7 @@ from .model_generator import ModelCodeGenerator
 from .operations import (
     AddField,
     AlterField,
+    AlterTable,
     CreateIndex,
     CreateTable,
     DataMigration,
@@ -57,6 +58,7 @@ __all__ = [
     # Migrations
     "Migration",
     "Operation",
+    "AlterTable",
     "CreateTable",
     "DropTable",
     "AddField",

--- a/src/surreal_orm/migrations/db_introspector.py
+++ b/src/surreal_orm/migrations/db_introspector.py
@@ -166,6 +166,7 @@ class DatabaseIntrospector:
             view_query=table_props.get("view_query"),
             relation_in=table_props.get("relation_in"),
             relation_out=table_props.get("relation_out"),
+            comment=table_props.get("comment"),
             enforced=table_props.get("enforced", False),
         )
 

--- a/src/surreal_orm/migrations/define_parser.py
+++ b/src/surreal_orm/migrations/define_parser.py
@@ -26,6 +26,10 @@ _FIELD_KEYWORDS = [
     "TYPE",
 ]
 
+# The four actions a table PERMISSIONS clause can govern, in the order
+# SurrealDB reports them.
+_PERMISSION_ACTIONS = ("select", "create", "update", "delete")
+
 # Keywords that delimit clauses in a DEFINE TABLE statement.
 _TABLE_KEYWORDS = [
     "SCHEMAFULL",
@@ -126,8 +130,12 @@ def _consume_until_keyword(text: str, keywords: list[str]) -> tuple[str, str]:
         elif ch == ">":
             depth_angle -= 1
 
-        # Only check for keyword boundaries at depth 0
-        if depth_paren == 0 and depth_angle == 0:
+        # Only check for keyword boundaries at depth 0, and only where a clause
+        # could actually start: after whitespace. Without the left-hand check a
+        # keyword appearing inside an expression ended the clause — `PERMISSIONS
+        # FOR select WHERE meta.type != NONE` was cut at `type`, leaving the
+        # condition as `meta.` and the table type as `!= none`.
+        if depth_paren == 0 and depth_angle == 0 and (i == 0 or text[i - 1] in (" ", "\t", "\n")):
             upper_rest = text[i:].upper()
             for kw in keywords:
                 if upper_rest.startswith(kw):
@@ -317,6 +325,15 @@ def parse_define_table(statement: str) -> dict[str, Any]:
     # Permissions
     permissions = _parse_permissions(clauses.get("PERMISSIONS"))
 
+    # Comment — the server echoes it back single-quoted, with '' for a quote
+    comment: str | None = None
+    raw_comment = clauses.get("COMMENT")
+    if raw_comment:
+        raw_comment = raw_comment.strip()
+        if raw_comment.startswith("'") and raw_comment.endswith("'") and len(raw_comment) >= 2:
+            raw_comment = raw_comment[1:-1]
+        comment = raw_comment.replace("''", "'")
+
     # Materialized view (AS SELECT ... or AS (SELECT ...))
     # We re-extract from the raw body because _extract_clauses may split on
     # ``AS`` tokens inside the view query itself (e.g. ``count() AS total``).
@@ -343,50 +360,112 @@ def parse_define_table(statement: str) -> dict[str, Any]:
         "relation_in": relation_in,
         "relation_out": relation_out,
         "enforced": enforced,
+        "comment": comment,
     }
 
 
+def _split_permission_groups(raw: str) -> list[str]:
+    """Split a PERMISSIONS clause into its ``FOR ...`` groups.
+
+    Scanning rather than matching a regex, so that a ``FOR`` inside a quoted
+    string or a parenthesised sub-expression does not start a new group. The
+    regex this replaces also backtracked quadratically on a long run of ``FOR``
+    tokens.
+
+    Args:
+        raw: The clause body, without the ``PERMISSIONS`` keyword
+
+    Returns:
+        One string per group, each still starting with ``FOR``
+    """
+    groups: list[str] = []
+    start: int | None = None
+    depth = 0
+    in_quote = False
+    i = 0
+
+    while i < len(raw):
+        ch = raw[i]
+
+        if ch == "'" and not (in_quote and i > 0 and raw[i - 1] == "\\"):
+            in_quote = not in_quote
+            i += 1
+            continue
+        if in_quote:
+            i += 1
+            continue
+
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+
+        # A group starts at a `FOR` token: at depth 0, preceded by nothing, a
+        # separator or whitespace, and followed by whitespace.
+        if (
+            depth == 0
+            and raw[i : i + 3].upper() == "FOR"
+            and (i == 0 or raw[i - 1] in " \t\n,")
+            and i + 3 < len(raw)
+            and raw[i + 3] in " \t\n"
+        ):
+            if start is not None:
+                groups.append(raw[start:i])
+            start = i
+
+        i += 1
+
+    if start is not None:
+        groups.append(raw[start:])
+
+    return groups
+
+
 def _parse_permissions(raw: str | None) -> dict[str, str]:
-    """Parse a PERMISSIONS clause into a dict of action → condition.
+    """Parse a PERMISSIONS clause into a dict of action → rule.
+
+    A rule is either a condition expression or one of the keywords ``FULL`` /
+    ``NONE``, kept uppercase so the renderer can tell them apart from an
+    expression — ``FOR select WHERE FULL`` is not the same statement as
+    ``FOR select FULL``: the first evaluates ``FULL`` as a field reference,
+    gets ``NONE``, and denies.
 
     Handles formats like:
-    - ``FULL`` → {}
+    - ``FULL`` → {"select": "FULL", "create": "FULL", ...}
     - ``NONE`` → {"select": "NONE", "create": "NONE", ...}
-    - ``FOR select WHERE $auth.id = id FOR update WHERE $auth.id = id``
+    - ``FOR select WHERE $auth.id = id, FOR create, update, delete NONE``
     """
     if raw is None or raw == "":
         return {}
 
     raw = raw.strip()
     if raw.upper() == "FULL":
-        return {}
+        return dict.fromkeys(_PERMISSION_ACTIONS, "FULL")
     if raw.upper() == "NONE":
-        return {
-            "select": "NONE",
-            "create": "NONE",
-            "update": "NONE",
-            "delete": "NONE",
-        }
+        return dict.fromkeys(_PERMISSION_ACTIONS, "NONE")
 
     permissions: dict[str, str] = {}
-    # Two group shapes, and the server mixes them in one clause:
-    #   FOR select WHERE $auth.id = id, FOR create, update, delete NONE
-    # The condition form needs the trailing comma stripped — it separates the
-    # groups, not part of the expression — and the keyword form has no WHERE at
-    # all, so a WHERE-only pattern dropped those actions entirely.
-    for m in re.finditer(
-        r"FOR\s+([\w\s,]+?)\s+(?:WHERE\s+(.+?)|(FULL|NONE))(?=\s*,?\s*FOR\s+|\s*$)",
-        raw,
-        re.IGNORECASE,
-    ):
-        actions_str = m.group(1).strip()
-        condition = (m.group(2) or m.group(3) or "").strip().rstrip(",").strip()
-        if m.group(3):
-            condition = condition.upper()
-        for action in re.split(r"[,\s]+", actions_str):
+    for group in _split_permission_groups(raw):
+        # Drop the leading FOR and the comma that separated this group from the
+        # next one — it belongs to the clause, not to the expression.
+        body = group[3:].strip().rstrip(",").strip()
+        if not body:
+            continue
+
+        # Either `<actions> WHERE <condition>` or `<actions> FULL|NONE`.
+        split = re.split(r"\s+WHERE\s+", body, maxsplit=1, flags=re.IGNORECASE)
+        if len(split) == 2:
+            actions_str, rule = split[0], split[1].strip()
+        else:
+            head, _, last = body.rpartition(" ")
+            if last.upper() not in ("FULL", "NONE"):
+                continue
+            actions_str, rule = head, last.upper()
+
+        for action in re.split(r"[,\s]+", actions_str.strip()):
             action = action.strip().lower()
             if action:
-                permissions[action] = condition
+                permissions[action] = rule
 
     return permissions
 

--- a/src/surreal_orm/migrations/define_parser.py
+++ b/src/surreal_orm/migrations/define_parser.py
@@ -369,14 +369,20 @@ def _parse_permissions(raw: str | None) -> dict[str, str]:
         }
 
     permissions: dict[str, str] = {}
-    # Match: FOR <action[, action]> WHERE <condition>
+    # Two group shapes, and the server mixes them in one clause:
+    #   FOR select WHERE $auth.id = id, FOR create, update, delete NONE
+    # The condition form needs the trailing comma stripped — it separates the
+    # groups, not part of the expression — and the keyword form has no WHERE at
+    # all, so a WHERE-only pattern dropped those actions entirely.
     for m in re.finditer(
-        r"FOR\s+([\w\s,]+?)\s+WHERE\s+(.+?)(?=\s+FOR\s+|\s*$)",
+        r"FOR\s+([\w\s,]+?)\s+(?:WHERE\s+(.+?)|(FULL|NONE))(?=\s*,?\s*FOR\s+|\s*$)",
         raw,
         re.IGNORECASE,
     ):
         actions_str = m.group(1).strip()
-        condition = m.group(2).strip()
+        condition = (m.group(2) or m.group(3) or "").strip().rstrip(",").strip()
+        if m.group(3):
+            condition = condition.upper()
         for action in re.split(r"[,\s]+", actions_str):
             action = action.strip().lower()
             if action:

--- a/src/surreal_orm/migrations/introspector.py
+++ b/src/surreal_orm/migrations/introspector.py
@@ -78,13 +78,23 @@ class ModelIntrospector:
         changefeed = model.get_changefeed()
         permissions = model.get_permissions()
 
-        # Build table state
+        # Build table state. The view and relation clauses live on the model
+        # config; leaving them off the state made a materialized view diff on
+        # every run and, worse, emit an overwrite with no AS clause — which
+        # turns the view into a plain table.
+        config = getattr(model, "model_config", {})
+
         table_state = TableState(
             name=table_name,
             schema_mode=str(schema_mode),
             table_type=str(table_type),
             changefeed=changefeed,
             permissions=permissions,
+            view_query=config.get("view_query"),
+            relation_in=config.get("relation_in"),
+            relation_out=config.get("relation_out"),
+            enforced=bool(config.get("enforced", False)),
+            comment=config.get("comment"),
         )
 
         # Introspect fields

--- a/src/surreal_orm/migrations/operations.py
+++ b/src/surreal_orm/migrations/operations.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any
 from ..types import FieldType
 
 if TYPE_CHECKING:
-    from .state import FieldState
+    from .state import FieldState, TableState
 
 
 def _normalize_field_type(field_type: FieldType | str) -> str:
@@ -141,51 +141,148 @@ class CreateTable(Operation):
     relation_in: str | None = None
     relation_out: str | None = None
     enforced: bool = False
+    #: Redefine a table that already exists, instead of creating a new one.
+    #: Set by the diff when a table's definition changed; it also decides what
+    #: ``backwards()`` means — see there.
+    overwrite: bool = False
+    # Previous definition, for a non-destructive rollback of an overwrite
+    previous_schema_mode: str | None = None
+    previous_table_type: str | None = None
+    previous_changefeed: str | None = None
+    previous_permissions: dict[str, str] | None = None
+    previous_view_query: str | None = None
+    previous_relation_in: str | None = None
+    previous_relation_out: str | None = None
+    previous_enforced: bool = False
 
-    def forwards(self) -> str:
+    @classmethod
+    def from_table_states(cls, current: "TableState", target: "TableState") -> "CreateTable":
+        """
+        Build the operation that redefines *current* as *target*.
+
+        Used by the diff when a table's definition changed. Carrying the current
+        state is what lets ``backwards()`` restore it rather than drop the table.
+
+        Args:
+            current: The table definition the database holds
+            target: The definition the models describe
+
+        Returns:
+            A ``CreateTable`` in overwrite mode, carrying both definitions
+        """
+        return cls(
+            name=target.name,
+            schema_mode=target.schema_mode,
+            table_type=target.table_type,
+            changefeed=target.changefeed,
+            permissions=target.permissions or None,
+            view_query=target.view_query,
+            relation_in=target.relation_in,
+            relation_out=target.relation_out,
+            enforced=target.enforced,
+            overwrite=True,
+            previous_schema_mode=current.schema_mode,
+            previous_table_type=current.table_type,
+            previous_changefeed=current.changefeed,
+            previous_permissions=current.permissions or None,
+            previous_view_query=current.view_query,
+            previous_relation_in=current.relation_in,
+            previous_relation_out=current.relation_out,
+            previous_enforced=current.enforced,
+        )
+
+    def _render(
+        self,
+        schema_mode: str | None,
+        table_type: str | None,
+        changefeed: str | None,
+        permissions: dict[str, str] | None,
+        view_query: str | None,
+        relation_in: str | None,
+        relation_out: str | None,
+        enforced: bool,
+        overwrite: bool,
+    ) -> str:
+        """
+        Render one ``DEFINE TABLE`` statement.
+
+        Shared by ``forwards()`` and ``backwards()`` so a rollback cannot drift
+        from the definition it is restoring.
+        """
+        keyword = "DEFINE TABLE OVERWRITE" if overwrite else "DEFINE TABLE"
+
         # Materialized view — different syntax
-        if self.view_query:
-            return f"DEFINE TABLE {self.name} AS ({self.view_query});"
+        if view_query:
+            return f"{keyword} {self.name} AS ({view_query});"
 
-        parts = [f"DEFINE TABLE {self.name}"]
+        parts = [f"{keyword} {self.name}"]
 
         # TYPE clause
-        if self.table_type and self.table_type.upper() == "RELATION":
+        if table_type and table_type.upper() == "RELATION":
             type_clause = "TYPE RELATION"
-            if self.relation_in:
-                type_clause += f" IN {self.relation_in}"
-            if self.relation_out:
-                type_clause += f" OUT {self.relation_out}"
-            if self.enforced:
+            if relation_in:
+                type_clause += f" IN {relation_in}"
+            if relation_out:
+                type_clause += f" OUT {relation_out}"
+            if enforced:
                 type_clause += " ENFORCED"
             parts.append(type_clause)
-        elif self.table_type and self.table_type.lower() not in ("normal", ""):
-            parts.append(f"TYPE {self.table_type.upper()}")
+        elif table_type and table_type.lower() not in ("normal", ""):
+            parts.append(f"TYPE {table_type.upper()}")
 
-        if self.schema_mode:
-            parts.append(self.schema_mode)
+        if schema_mode:
+            parts.append(schema_mode)
 
-        if self.changefeed:
-            parts.append(f"CHANGEFEED {self.changefeed}")
+        if changefeed:
+            parts.append(f"CHANGEFEED {changefeed}")
 
         if self.comment:
             escaped_comment = self.comment.replace("'", "''")
             parts.append(f"COMMENT '{escaped_comment}'")
 
-        sql = " ".join(parts) + ";"
+        # PERMISSIONS is a clause of DEFINE TABLE. It used to be emitted as a
+        # second `DEFINE TABLE ... PERMISSIONS ...`, which SurrealDB rejects once
+        # the table exists ("The table 'x' already exists"), so declared table
+        # permissions never reached the database at all.
+        if permissions:
+            rules = " ".join(f"FOR {action} WHERE {condition}" for action, condition in permissions.items())
+            if rules:
+                parts.append(f"PERMISSIONS {rules}")
 
-        # Add permissions if specified
-        if self.permissions:
-            perm_parts = []
-            for action, condition in self.permissions.items():
-                perm_parts.append(f"FOR {action} WHERE {condition}")
-            if perm_parts:
-                sql += f"\nDEFINE TABLE {self.name} PERMISSIONS {' '.join(perm_parts)};"
+        return " ".join(parts) + ";"
 
-        return sql
+    def forwards(self) -> str:
+        return self._render(
+            self.schema_mode,
+            self.table_type,
+            self.changefeed,
+            self.permissions,
+            self.view_query,
+            self.relation_in,
+            self.relation_out,
+            self.enforced,
+            self.overwrite,
+        )
 
     def backwards(self) -> str:
-        return f"REMOVE TABLE {self.name};"
+        # A table this migration created is removed again. But the diff also
+        # reuses CreateTable to *redefine* an existing table, and dropping it
+        # there destroys every row — so an overwrite rolls back by restoring the
+        # definition it replaced.
+        if not self.overwrite:
+            return f"REMOVE TABLE {self.name};"
+
+        return self._render(
+            self.previous_schema_mode,
+            self.previous_table_type,
+            self.previous_changefeed,
+            self.previous_permissions,
+            self.previous_view_query,
+            self.previous_relation_in,
+            self.previous_relation_out,
+            self.previous_enforced,
+            overwrite=True,
+        )
 
     def describe(self) -> str:
         return f"Create table {self.name}"

--- a/src/surreal_orm/migrations/operations.py
+++ b/src/surreal_orm/migrations/operations.py
@@ -90,6 +90,192 @@ def _apply_nullable(field_type: str, nullable: bool) -> str:
     return f"option<{field_type}>"
 
 
+#: The attributes a ``DEFINE TABLE`` statement carries. ``CreateTable``,
+#: ``AlterTable`` and the renderer are all driven off this one tuple: a clause
+#: added here reaches the forward statement, the rollback and the diff at once,
+#: instead of being spelled out in four places and forgotten in one of them.
+TABLE_DEFINITION_FIELDS = (
+    "schema_mode",
+    "table_type",
+    "changefeed",
+    "permissions",
+    "comment",
+    "view_query",
+    "relation_in",
+    "relation_out",
+    "enforced",
+)
+
+#: The only table types SurrealDB itself accepts. NORMAL, USER, STREAM and HASH
+#: are ORM-level concepts.
+_SURQL_TABLE_TYPES = ("relation", "any")
+
+
+def _surql_table_type(table_type: str | None) -> str | None:
+    """
+    Reduce an ORM table type to one SurrealDB will parse.
+
+    ``TableType`` carries ORM-only classifications — USER marks an auth table,
+    STREAM and HASH are hints — but ``DEFINE TABLE ... TYPE`` accepts only
+    ``NORMAL``, ``RELATION`` and ``ANY``. Passing USER through produced
+    ``Parse error: Unexpected token `USER``` and made any change to such a table
+    unmigratable.
+
+    Args:
+        table_type: The table type as the model or the database reports it
+
+    Returns:
+        The type when SurrealDB understands it, otherwise None
+    """
+    if table_type and table_type.lower() in _SURQL_TABLE_TYPES:
+        return table_type
+    return None
+
+
+def _render_permission_rule(action: str, rule: str) -> str:
+    """
+    Render one ``FOR <action>`` group of a PERMISSIONS clause.
+
+    ``FULL`` and ``NONE`` are keywords, not expressions: SurrealDB accepts
+    ``FOR select WHERE FULL`` but evaluates ``FULL`` as a field reference, gets
+    ``NONE`` and denies — turning a world-readable table into an unreadable one
+    with no error.
+
+    Args:
+        action: The action the rule governs (select, create, update, delete)
+        rule: A condition expression, or the keyword FULL / NONE
+
+    Returns:
+        The rendered group
+    """
+    keyword = str(rule).strip().upper()
+    if keyword in ("FULL", "NONE"):
+        return f"FOR {action} {keyword}"
+    return f"FOR {action} WHERE {rule}"
+
+
+def _effective_permissions(permissions: dict[str, str] | None) -> dict[str, str]:
+    """
+    Drop permission entries that only restate SurrealDB's default.
+
+    A table defined without a ``PERMISSIONS`` clause is reported back by
+    ``INFO FOR DB`` as ``{"select": "NONE", "create": "NONE", ...}`` — those are
+    the server's defaults, not a configured value. Comparing the raw dicts made a
+    database-read state differ from a model state that configures nothing, so the
+    diff re-emitted ``CreateTable`` for every table on every run (#171).
+
+    Normalising both sides also makes an explicit ``NONE`` equal to omitting the
+    clause, which is what it means, and keeps a generated rollback from carrying
+    the server's three default ``NONE`` entries as if they had been configured.
+
+    Args:
+        permissions: The permissions mapping, or None
+
+    Returns:
+        The mapping without its default-valued entries
+    """
+    if not permissions:
+        return {}
+    return {action: rule for action, rule in permissions.items() if str(rule).strip().upper() != "NONE"}
+
+
+def _relation_tables(value: "str | list[str] | None") -> str | None:
+    """
+    Render an IN/OUT target list as SurrealDB spells it.
+
+    ``SurrealConfigDict`` accepts a list — ``relation_out=["blog_post", "book"]``
+    is the documented form — but the clause takes pipe-separated names, so a
+    list reached the DDL as ``OUT ['blog_post', 'book']``.
+
+    Args:
+        value: One table name, several, or None
+
+    Returns:
+        The pipe-separated form, or None
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return " | ".join(str(v) for v in value)
+
+
+def _render_define_table(
+    name: str,
+    *,
+    overwrite: bool,
+    schema_mode: str | None = None,
+    table_type: str | None = None,
+    changefeed: str | None = None,
+    permissions: dict[str, str] | None = None,
+    comment: str | None = None,
+    view_query: str | None = None,
+    relation_in: str | None = None,
+    relation_out: str | None = None,
+    enforced: bool = False,
+) -> str:
+    """
+    Render one ``DEFINE TABLE`` statement.
+
+    Shared by ``CreateTable`` and both directions of ``AlterTable`` so a
+    rollback cannot drift from the definition it restores.
+
+    Args:
+        name: Table name
+        overwrite: Emit ``DEFINE TABLE OVERWRITE``, redefining an existing table
+        schema_mode: SCHEMAFULL or SCHEMALESS
+        table_type: ORM table type; sanitised to what SurrealDB accepts
+        changefeed: CHANGEFEED duration
+        permissions: Action → rule mapping
+        comment: COMMENT text
+        view_query: AS SELECT ... body for a materialized view
+        relation_in: IN table(s) for TYPE RELATION
+        relation_out: OUT table(s) for TYPE RELATION
+        enforced: Whether the relation constraint is enforced
+
+    Returns:
+        The complete statement, semicolon included
+    """
+    keyword = "DEFINE TABLE OVERWRITE" if overwrite else "DEFINE TABLE"
+
+    # Materialized view — different syntax
+    if view_query:
+        return f"{keyword} {name} AS ({view_query});"
+
+    parts = [f"{keyword} {name}"]
+
+    surql_type = _surql_table_type(table_type)
+    if surql_type and surql_type.upper() == "RELATION":
+        type_clause = "TYPE RELATION"
+        if relation_in:
+            type_clause += f" IN {_relation_tables(relation_in)}"
+        if relation_out:
+            type_clause += f" OUT {_relation_tables(relation_out)}"
+        if enforced:
+            type_clause += " ENFORCED"
+        parts.append(type_clause)
+    elif surql_type:
+        parts.append(f"TYPE {surql_type.upper()}")
+
+    if schema_mode:
+        parts.append(schema_mode)
+
+    if changefeed:
+        parts.append(f"CHANGEFEED {changefeed}")
+
+    if comment:
+        parts.append(f"COMMENT '{comment.replace(chr(39), chr(39) * 2)}'")
+
+    # PERMISSIONS is a clause of DEFINE TABLE. It used to be emitted as a
+    # second `DEFINE TABLE ... PERMISSIONS ...`, which SurrealDB rejects once
+    # the table exists ("The table 'x' already exists"), so declared table
+    # permissions never reached the database at all.
+    if permissions:
+        parts.append("PERMISSIONS " + " ".join(_render_permission_rule(a, r) for a, r in permissions.items()))
+
+    return " ".join(parts) + ";"
+
+
 @dataclass
 class Operation(ABC):
     """
@@ -124,6 +310,10 @@ class CreateTable(Operation):
     Supports materialized views (``view_query``) and TYPE RELATION
     constraints (``relation_in``, ``relation_out``, ``enforced``).
 
+    Redefining a table that already exists is :class:`AlterTable`, not this
+    operation: a plain ``DEFINE TABLE`` is rejected once the table exists, and
+    rolling back a creation means dropping the table.
+
     Example:
         CreateTable(name="users", schema_mode="SCHEMAFULL", changefeed="7d")
 
@@ -141,151 +331,160 @@ class CreateTable(Operation):
     relation_in: str | None = None
     relation_out: str | None = None
     enforced: bool = False
-    #: Redefine a table that already exists, instead of creating a new one.
-    #: Set by the diff when a table's definition changed; it also decides what
-    #: ``backwards()`` means — see there.
-    overwrite: bool = False
-    # Previous definition, for a non-destructive rollback of an overwrite
+
+    @classmethod
+    def from_table_state(cls, state: "TableState") -> "CreateTable":
+        """
+        Build the operation that creates *state*.
+
+        The single place that maps a ``TableState`` onto the definition fields,
+        so a new clause cannot reach the diff and miss table creation.
+
+        Args:
+            state: The table definition the models describe
+
+        Returns:
+            A ``CreateTable`` carrying every definition field of *state*
+        """
+        return cls(
+            name=state.name,
+            permissions=_effective_permissions(state.permissions) or None,
+            **{f: getattr(state, f) for f in TABLE_DEFINITION_FIELDS if f != "permissions"},
+        )
+
+    def forwards(self) -> str:
+        return _render_define_table(
+            self.name,
+            overwrite=False,
+            **{f: getattr(self, f) for f in TABLE_DEFINITION_FIELDS},
+        )
+
+    def backwards(self) -> str:
+        return f"REMOVE TABLE {self.name};"
+
+    def describe(self) -> str:
+        return f"Create table {self.name}"
+
+
+@dataclass
+class AlterTable(Operation):
+    """
+    Redefine a table that already exists.
+
+    Emitted by the diff when a table's definition changed. A plain
+    ``DEFINE TABLE`` is not idempotent — the server rejects it once the table
+    exists ("The table 'x' already exists") — so the statement is
+    ``DEFINE TABLE OVERWRITE``, which preserves the table's fields, indexes,
+    events and rows.
+
+    Rolling back restores the definition that was replaced rather than dropping
+    the table, which is why the previous values travel with the operation. An
+    ``AlterTable`` built without them is **not** reversible: a bare
+    ``DEFINE TABLE OVERWRITE t;`` resets the table to
+    ``TYPE ANY SCHEMALESS PERMISSIONS NONE``, silently discarding the very
+    definition a rollback is supposed to restore.
+
+    Example:
+        AlterTable(name="users", schema_mode="SCHEMAFULL",
+                   previous_schema_mode="SCHEMALESS")
+
+    Generates:
+        DEFINE TABLE OVERWRITE users SCHEMAFULL;
+    """
+
+    name: str
+    schema_mode: str | None = None
+    table_type: str | None = None
+    changefeed: str | None = None
+    permissions: dict[str, str] | None = None
+    comment: str | None = None
+    view_query: str | None = None
+    relation_in: str | None = None
+    relation_out: str | None = None
+    enforced: bool = False
+    # Previous definition, for a non-destructive rollback
     previous_schema_mode: str | None = None
     previous_table_type: str | None = None
     previous_changefeed: str | None = None
     previous_permissions: dict[str, str] | None = None
+    previous_comment: str | None = None
     previous_view_query: str | None = None
     previous_relation_in: str | None = None
     previous_relation_out: str | None = None
     previous_enforced: bool = False
 
+    def __post_init__(self) -> None:
+        # Mirrors AlterField: without the previous definition there is nothing
+        # to restore, and emitting a bare OVERWRITE would reset the table.
+        self.reversible = self.previous_schema_mode is not None
+
     @classmethod
-    def from_table_states(cls, current: "TableState", target: "TableState") -> "CreateTable":
+    def from_table_state(cls, state: "TableState") -> "AlterTable":
+        """
+        Build the operation that redefines a table to match *state*.
+
+        For callers that apply a model's schema directly — ``define_table()`` —
+        rather than migrating between two known states. The result carries no
+        previous definition and is therefore not reversible.
+
+        Args:
+            state: The table definition the model describes
+
+        Returns:
+            An ``AlterTable`` carrying only the target definition
+        """
+        return cls(
+            name=state.name,
+            permissions=_effective_permissions(state.permissions) or None,
+            **{f: getattr(state, f) for f in TABLE_DEFINITION_FIELDS if f != "permissions"},
+        )
+
+    @classmethod
+    def from_table_states(cls, current: "TableState", target: "TableState") -> "AlterTable":
         """
         Build the operation that redefines *current* as *target*.
 
-        Used by the diff when a table's definition changed. Carrying the current
-        state is what lets ``backwards()`` restore it rather than drop the table.
+        Both permission mappings go through :func:`_effective_permissions`, so
+        the server's default ``NONE`` entries do not travel into generated
+        migration files as though they had been configured.
 
         Args:
             current: The table definition the database holds
             target: The definition the models describe
 
         Returns:
-            A ``CreateTable`` in overwrite mode, carrying both definitions
+            An ``AlterTable`` carrying both definitions
         """
         return cls(
             name=target.name,
-            schema_mode=target.schema_mode,
-            table_type=target.table_type,
-            changefeed=target.changefeed,
-            permissions=target.permissions or None,
-            view_query=target.view_query,
-            relation_in=target.relation_in,
-            relation_out=target.relation_out,
-            enforced=target.enforced,
-            overwrite=True,
-            previous_schema_mode=current.schema_mode,
-            previous_table_type=current.table_type,
-            previous_changefeed=current.changefeed,
-            previous_permissions=current.permissions or None,
-            previous_view_query=current.view_query,
-            previous_relation_in=current.relation_in,
-            previous_relation_out=current.relation_out,
-            previous_enforced=current.enforced,
+            permissions=_effective_permissions(target.permissions) or None,
+            previous_permissions=_effective_permissions(current.permissions) or None,
+            **{f: getattr(target, f) for f in TABLE_DEFINITION_FIELDS if f != "permissions"},
+            **{f"previous_{f}": getattr(current, f) for f in TABLE_DEFINITION_FIELDS if f != "permissions"},
         )
 
-    def _render(
-        self,
-        schema_mode: str | None,
-        table_type: str | None,
-        changefeed: str | None,
-        permissions: dict[str, str] | None,
-        view_query: str | None,
-        relation_in: str | None,
-        relation_out: str | None,
-        enforced: bool,
-        overwrite: bool,
-    ) -> str:
-        """
-        Render one ``DEFINE TABLE`` statement.
-
-        Shared by ``forwards()`` and ``backwards()`` so a rollback cannot drift
-        from the definition it is restoring.
-        """
-        keyword = "DEFINE TABLE OVERWRITE" if overwrite else "DEFINE TABLE"
-
-        # Materialized view — different syntax
-        if view_query:
-            return f"{keyword} {self.name} AS ({view_query});"
-
-        parts = [f"{keyword} {self.name}"]
-
-        # TYPE clause
-        if table_type and table_type.upper() == "RELATION":
-            type_clause = "TYPE RELATION"
-            if relation_in:
-                type_clause += f" IN {relation_in}"
-            if relation_out:
-                type_clause += f" OUT {relation_out}"
-            if enforced:
-                type_clause += " ENFORCED"
-            parts.append(type_clause)
-        elif table_type and table_type.lower() not in ("normal", ""):
-            parts.append(f"TYPE {table_type.upper()}")
-
-        if schema_mode:
-            parts.append(schema_mode)
-
-        if changefeed:
-            parts.append(f"CHANGEFEED {changefeed}")
-
-        if self.comment:
-            escaped_comment = self.comment.replace("'", "''")
-            parts.append(f"COMMENT '{escaped_comment}'")
-
-        # PERMISSIONS is a clause of DEFINE TABLE. It used to be emitted as a
-        # second `DEFINE TABLE ... PERMISSIONS ...`, which SurrealDB rejects once
-        # the table exists ("The table 'x' already exists"), so declared table
-        # permissions never reached the database at all.
-        if permissions:
-            rules = " ".join(f"FOR {action} WHERE {condition}" for action, condition in permissions.items())
-            if rules:
-                parts.append(f"PERMISSIONS {rules}")
-
-        return " ".join(parts) + ";"
-
     def forwards(self) -> str:
-        return self._render(
-            self.schema_mode,
-            self.table_type,
-            self.changefeed,
-            self.permissions,
-            self.view_query,
-            self.relation_in,
-            self.relation_out,
-            self.enforced,
-            self.overwrite,
+        return _render_define_table(
+            self.name,
+            overwrite=True,
+            **{f: getattr(self, f) for f in TABLE_DEFINITION_FIELDS},
         )
 
     def backwards(self) -> str:
-        # A table this migration created is removed again. But the diff also
-        # reuses CreateTable to *redefine* an existing table, and dropping it
-        # there destroys every row — so an overwrite rolls back by restoring the
-        # definition it replaced.
-        if not self.overwrite:
-            return f"REMOVE TABLE {self.name};"
-
-        return self._render(
-            self.previous_schema_mode,
-            self.previous_table_type,
-            self.previous_changefeed,
-            self.previous_permissions,
-            self.previous_view_query,
-            self.previous_relation_in,
-            self.previous_relation_out,
-            self.previous_enforced,
+        if not self.reversible:
+            raise ValueError(
+                f"AlterTable({self.name!r}) carries no previous definition, so it cannot be "
+                f"rolled back: a bare DEFINE TABLE OVERWRITE would reset the table to "
+                f"TYPE ANY SCHEMALESS PERMISSIONS NONE. Build it with from_table_states()."
+            )
+        return _render_define_table(
+            self.name,
             overwrite=True,
+            **{f: getattr(self, f"previous_{f}") for f in TABLE_DEFINITION_FIELDS},
         )
 
     def describe(self) -> str:
-        return f"Create table {self.name}"
+        return f"Alter table {self.name}"
 
 
 @dataclass
@@ -351,6 +550,11 @@ class AddField(Operation):
     value: str | None = None
     comment: str | None = None
     nullable: bool = False
+    #: Emit ``DEFINE FIELD OVERWRITE``. A migration adds a field that is not
+    #: there yet, so the plain form is right there and a second run *should*
+    #: fail. ``define_table()`` applies a model's whole schema and has to be
+    #: callable twice, so it opts in.
+    overwrite: bool = False
 
     def __post_init__(self) -> None:
         """Validate field_type on initialization."""
@@ -387,7 +591,8 @@ class AddField(Operation):
         )
 
     def forwards(self) -> str:
-        parts = [f"DEFINE FIELD {self.name} ON {self.table}"]
+        keyword = "DEFINE FIELD OVERWRITE" if self.overwrite else "DEFINE FIELD"
+        parts = [f"{keyword} {self.name} ON {self.table}"]
 
         if self.flexible:
             parts.append("FLEXIBLE")

--- a/src/surreal_orm/migrations/state.py
+++ b/src/surreal_orm/migrations/state.py
@@ -401,20 +401,10 @@ class SchemaState:
                     or current_table.relation_out != target_table.relation_out
                     or current_table.enforced != target_table.enforced
                 ):
-                    # Recreate table definition (DEFINE TABLE is idempotent)
-                    operations.append(
-                        CreateTable(
-                            name=table_name,
-                            schema_mode=target_table.schema_mode,
-                            table_type=target_table.table_type,
-                            changefeed=target_table.changefeed,
-                            permissions=target_table.permissions or None,
-                            view_query=target_table.view_query,
-                            relation_in=target_table.relation_in,
-                            relation_out=target_table.relation_out,
-                            enforced=target_table.enforced,
-                        )
-                    )
+                    # Redefine the table. A plain DEFINE TABLE is NOT idempotent
+                    # — the server rejects it once the table exists — and its
+                    # rollback would be REMOVE TABLE, destroying every row.
+                    operations.append(CreateTable.from_table_states(current_table, target_table))
 
                 # Fields to add
                 for field_name, field_state in target_table.fields.items():

--- a/src/surreal_orm/migrations/state.py
+++ b/src/surreal_orm/migrations/state.py
@@ -12,31 +12,6 @@ if TYPE_CHECKING:
     from .operations import CreateIndex, Operation
 
 
-def _effective_permissions(permissions: dict[str, str] | None) -> dict[str, str]:
-    """
-    Drop permission entries that only restate SurrealDB's default.
-
-    A table defined without a ``PERMISSIONS`` clause is reported back as
-    ``PERMISSIONS NONE``, which the parser expands to
-    ``{"select": "NONE", "create": "NONE", ...}`` — the server's defaults, not a
-    configured value. Comparing the raw dicts made a database-read state differ
-    from a model state that configures nothing, so the diff re-emitted
-    ``CreateTable`` for every table on every run (#171).
-
-    Normalising both sides also makes an explicit ``NONE`` equal to omitting the
-    clause, which is what it means.
-
-    Args:
-        permissions: The permissions mapping, or None
-
-    Returns:
-        The mapping without its default-valued entries
-    """
-    if not permissions:
-        return {}
-    return {action: rule for action, rule in permissions.items() if str(rule).strip().upper() != "NONE"}
-
-
 @dataclass
 class FieldState:
     """
@@ -236,6 +211,7 @@ class TableState:
         relation_in: IN table(s) for TYPE RELATION (pipe-separated if multiple)
         relation_out: OUT table(s) for TYPE RELATION (pipe-separated if multiple)
         enforced: Whether the relation constraint is enforced
+        comment: COMMENT text attached to the table
     """
 
     name: str
@@ -251,6 +227,7 @@ class TableState:
     relation_in: str | None = None
     relation_out: str | None = None
     enforced: bool = False
+    comment: str | None = None
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, TableState):
@@ -269,6 +246,7 @@ class TableState:
             and self.relation_in == other.relation_in
             and self.relation_out == other.relation_out
             and self.enforced == other.enforced
+            and self.comment == other.comment
         )
 
 
@@ -302,6 +280,7 @@ class SchemaState:
         from .operations import (
             AddField,
             AlterField,
+            AlterTable,
             CreateTable,
             DefineAccess,
             DefineAnalyzer,
@@ -312,6 +291,7 @@ class SchemaState:
             RemoveAccess,
             RemoveAnalyzer,
             RemoveEvent,
+            _effective_permissions,
         )
 
         operations: list[Operation] = []
@@ -339,19 +319,7 @@ class SchemaState:
         for table_name, target_table in target.tables.items():
             if table_name not in self.tables:
                 # Create the table
-                operations.append(
-                    CreateTable(
-                        name=table_name,
-                        schema_mode=target_table.schema_mode,
-                        table_type=target_table.table_type,
-                        changefeed=target_table.changefeed,
-                        permissions=target_table.permissions or None,
-                        view_query=target_table.view_query,
-                        relation_in=target_table.relation_in,
-                        relation_out=target_table.relation_out,
-                        enforced=target_table.enforced,
-                    )
-                )
+                operations.append(CreateTable.from_table_state(target_table))
                 # Add all fields
                 for _field_name, field_state in target_table.fields.items():
                     operations.append(AddField.from_field_state(table_name, field_state))
@@ -396,6 +364,7 @@ class SchemaState:
                     current_table.schema_mode != target_table.schema_mode
                     or current_table.changefeed != target_table.changefeed
                     or _effective_permissions(current_table.permissions) != _effective_permissions(target_table.permissions)
+                    or current_table.comment != target_table.comment
                     or current_table.view_query != target_table.view_query
                     or current_table.relation_in != target_table.relation_in
                     or current_table.relation_out != target_table.relation_out
@@ -404,7 +373,7 @@ class SchemaState:
                     # Redefine the table. A plain DEFINE TABLE is NOT idempotent
                     # — the server rejects it once the table exists — and its
                     # rollback would be REMOVE TABLE, destroying every row.
-                    operations.append(CreateTable.from_table_states(current_table, target_table))
+                    operations.append(AlterTable.from_table_states(current_table, target_table))
 
                 # Fields to add
                 for field_name, field_state in target_table.fields.items():

--- a/src/surreal_orm/model_base.py
+++ b/src/surreal_orm/model_base.py
@@ -327,6 +327,7 @@ class SurrealConfigDict(ConfigDict):
         relation_in: IN table(s) for TYPE RELATION constraint.
         relation_out: OUT table(s) for TYPE RELATION constraint.
         enforced: Whether the TYPE RELATION constraint is enforced.
+        comment: COMMENT text attached to the table definition.
         flexible_fields: List of field names that should use ``FLEXIBLE TYPE``
             in migrations.  FLEXIBLE allows nested structures (arrays inside
             objects, etc.) that would otherwise be stripped by SCHEMAFULL tables.
@@ -349,6 +350,7 @@ class SurrealConfigDict(ConfigDict):
     relation_in: str | list[str] | None
     relation_out: str | list[str] | None
     enforced: bool | None
+    comment: str | None
     flexible_fields: list[str] | None
 
 

--- a/tests/test_createtable_roundtrip_integration.py
+++ b/tests/test_createtable_roundtrip_integration.py
@@ -1,0 +1,141 @@
+"""
+Integration tests for the table-definition round trip, against a live server.
+
+The unit tests pin the emitted SQL; only a real server shows that the permissions
+actually land and that the state read back compares equal to the model — which is
+what makes `makemigrations` converge. Before this fix SurrealDB 2.6.5 stored
+``PERMISSIONS NONE`` for a model declaring a rule, because the clause was emitted
+as a second ``DEFINE TABLE`` and rejected with "already exists".
+
+This branch has no ``define_table()`` (a main-only API), so the DDL is built from
+the operations directly — which is what the migration executor does anyway.
+
+Run with: pytest -m integration tests/test_createtable_roundtrip_integration.py
+"""
+
+import pytest
+
+from src import surreal_orm
+from src.surreal_orm.migrations.db_introspector import DatabaseIntrospector
+from src.surreal_orm.migrations.introspector import introspect_models
+from src.surreal_orm.migrations.operations import AddField, CreateTable
+from src.surreal_orm.migrations.state import SchemaState, TableState
+from src.surreal_orm.model_base import BaseSurrealModel, SurrealConfigDict
+from tests.conftest import SURREALDB_NAMESPACE, SURREALDB_PASS, SURREALDB_URL, SURREALDB_USER
+
+SURREALDB_DATABASE = "test_createtable_roundtrip"
+TABLE = "ct_guarded"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_surrealdb() -> None:
+    """Point the ORM at the test database."""
+    surreal_orm.SurrealDBConnectionManager.set_connection(
+        SURREALDB_URL,
+        SURREALDB_USER,
+        SURREALDB_PASS,
+        SURREALDB_NAMESPACE,
+        SURREALDB_DATABASE,
+    )
+
+
+@pytest.fixture(autouse=True)
+async def clean_database():
+    """Drop the test table before and after each test."""
+
+    async def cleanup() -> None:
+        client = await surreal_orm.SurrealDBConnectionManager.get_client()
+        await client.query(f"REMOVE TABLE IF EXISTS {TABLE};")
+
+    await cleanup()
+    yield
+    await cleanup()
+
+
+class Guarded(BaseSurrealModel):
+    """A model that declares table permissions."""
+
+    model_config = SurrealConfigDict(table_name=TABLE, permissions={"select": "$auth.id = id"})
+
+    id: str | None = None
+    n: int = 0
+
+
+async def _apply_model_schema() -> None:
+    """Create the table and its fields the way the executor would."""
+    client = await surreal_orm.SurrealDBConnectionManager.get_client()
+    state = introspect_models([Guarded]).tables[TABLE]
+    await client.query(
+        CreateTable(name=state.name, schema_mode=state.schema_mode, permissions=state.permissions or None).forwards()
+    )
+    for field_state in state.fields.values():
+        await client.query(AddField.from_field_state(TABLE, field_state).forwards())
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_declared_permissions_reach_the_database() -> None:
+    """They used to be silently dropped: the server stored PERMISSIONS NONE."""
+    await _apply_model_schema()
+
+    client = await surreal_orm.SurrealDBConnectionManager.get_client()
+    info = await client.query("INFO FOR DB;")
+    definition = info.first_result.result["tables"][TABLE]
+
+    assert "FOR select WHERE $auth.id = id" in definition, definition
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_a_permissioned_table_diffs_to_nothing_once_applied() -> None:
+    """The round trip has to converge, or makemigrations repeats itself forever."""
+    await _apply_model_schema()
+
+    current = await DatabaseIntrospector().introspect()
+    operations = [
+        op for op in current.diff(introspect_models([Guarded])) if getattr(op, "table", getattr(op, "name", None)) == TABLE
+    ]
+
+    assert operations == []
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_redefining_a_table_is_accepted_by_the_server() -> None:
+    """A plain second DEFINE TABLE was rejected as 'already exists'."""
+    await _apply_model_schema()
+
+    current = SchemaState()
+    current.tables[TABLE] = TableState(name=TABLE, permissions={"select": "$auth.id = id"})
+    target = SchemaState()
+    target.tables[TABLE] = TableState(name=TABLE, permissions={"select": "true"})
+    op = next(o for o in current.diff(target) if isinstance(o, CreateTable))
+
+    client = await surreal_orm.SurrealDBConnectionManager.get_client()
+    response = await client.query(op.forwards())
+
+    assert [r.status.value for r in response.results] == ["OK"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_rolling_back_a_redefinition_keeps_the_rows() -> None:
+    """The rollback used to be REMOVE TABLE, dropping every row."""
+    await _apply_model_schema()
+    client = await surreal_orm.SurrealDBConnectionManager.get_client()
+    await client.query(f"CREATE {TABLE}:keepme SET n = 7;")
+
+    current = SchemaState()
+    current.tables[TABLE] = TableState(name=TABLE, permissions={"select": "$auth.id = id"})
+    target = SchemaState()
+    target.tables[TABLE] = TableState(name=TABLE, permissions={"select": "true"})
+    op = next(o for o in current.diff(target) if isinstance(o, CreateTable))
+
+    await client.query(op.forwards())
+    await client.query(op.backwards())
+
+    rows = await client.query(f"SELECT * FROM {TABLE};")
+    info = await client.query("INFO FOR DB;")
+
+    assert len(rows.all_records) == 1, "the rollback destroyed the data"
+    assert "FOR select WHERE $auth.id = id" in info.first_result.result["tables"][TABLE]

--- a/tests/test_createtable_roundtrip_integration.py
+++ b/tests/test_createtable_roundtrip_integration.py
@@ -18,7 +18,7 @@ import pytest
 from src import surreal_orm
 from src.surreal_orm.migrations.db_introspector import DatabaseIntrospector
 from src.surreal_orm.migrations.introspector import introspect_models
-from src.surreal_orm.migrations.operations import AddField, CreateTable
+from src.surreal_orm.migrations.operations import AddField, AlterTable, CreateTable
 from src.surreal_orm.migrations.state import SchemaState, TableState
 from src.surreal_orm.model_base import BaseSurrealModel, SurrealConfigDict
 from tests.conftest import SURREALDB_NAMESPACE, SURREALDB_PASS, SURREALDB_URL, SURREALDB_USER
@@ -109,7 +109,7 @@ async def test_redefining_a_table_is_accepted_by_the_server() -> None:
     current.tables[TABLE] = TableState(name=TABLE, permissions={"select": "$auth.id = id"})
     target = SchemaState()
     target.tables[TABLE] = TableState(name=TABLE, permissions={"select": "true"})
-    op = next(o for o in current.diff(target) if isinstance(o, CreateTable))
+    op = next(o for o in current.diff(target) if isinstance(o, AlterTable))
 
     client = await surreal_orm.SurrealDBConnectionManager.get_client()
     response = await client.query(op.forwards())
@@ -129,7 +129,7 @@ async def test_rolling_back_a_redefinition_keeps_the_rows() -> None:
     current.tables[TABLE] = TableState(name=TABLE, permissions={"select": "$auth.id = id"})
     target = SchemaState()
     target.tables[TABLE] = TableState(name=TABLE, permissions={"select": "true"})
-    op = next(o for o in current.diff(target) if isinstance(o, CreateTable))
+    op = next(o for o in current.diff(target) if isinstance(o, AlterTable))
 
     await client.query(op.forwards())
     await client.query(op.backwards())
@@ -138,4 +138,76 @@ async def test_rolling_back_a_redefinition_keeps_the_rows() -> None:
     info = await client.query("INFO FOR DB;")
 
     assert len(rows.all_records) == 1, "the rollback destroyed the data"
+    assert "FOR select WHERE $auth.id = id" in info.first_result.result["tables"][TABLE]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_a_full_permission_is_stored_as_an_allow() -> None:
+    """``FOR select WHERE FULL`` is accepted, then denies every read."""
+    client = await surreal_orm.SurrealDBConnectionManager.get_client()
+    op = AlterTable(name=TABLE, schema_mode="SCHEMAFULL", permissions={"select": "FULL"})
+
+    response = await client.query(op.forwards())
+    assert [r.status.value for r in response.results] == ["OK"]
+
+    info = await client.query("INFO FOR DB;")
+    stored = info.first_result.result["tables"][TABLE]
+
+    assert "FOR select FULL" in stored, stored
+    assert "WHERE FULL" not in stored, stored
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_an_orm_table_type_does_not_reach_the_server() -> None:
+    """``TYPE USER`` is a parse error, so the whole migration aborts."""
+    client = await surreal_orm.SurrealDBConnectionManager.get_client()
+    current = TableState(name=TABLE, schema_mode="SCHEMALESS", table_type="user")
+    target = TableState(name=TABLE, schema_mode="SCHEMAFULL", table_type="user")
+
+    response = await client.query(AlterTable.from_table_states(current, target).forwards())
+
+    assert [r.status.value for r in response.results] == ["OK"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_redefining_a_view_keeps_the_view() -> None:
+    """An overwrite with no AS clause turns the view into a plain table."""
+    # SurrealDB rejects a view whose source table does not exist.
+    await _apply_model_schema()
+    client = await surreal_orm.SurrealDBConnectionManager.get_client()
+    view = f"{TABLE}_v"
+    await client.query(f"REMOVE TABLE IF EXISTS {view}; DEFINE TABLE {view} AS (SELECT n FROM {TABLE});")
+
+    current = TableState(name=view, schema_mode="SCHEMALESS", view_query=f"SELECT n FROM {TABLE}")
+    target = TableState(name=view, schema_mode="SCHEMAFULL", view_query=f"SELECT n FROM {TABLE}")
+    await client.query(AlterTable.from_table_states(current, target).forwards())
+
+    info = await client.query("INFO FOR DB;")
+    stored = info.first_result.result["tables"][view]
+    await client.query(f"REMOVE TABLE IF EXISTS {view};")
+
+    assert "AS SELECT" in stored, stored
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_reapplying_the_schema_is_not_an_error() -> None:
+    """A plain second DEFINE TABLE is rejected once the table exists.
+
+    ``define_table()`` is a main-only API; here the same invariant is that the
+    operations the executor emits can be applied twice, which is what a
+    re-``migrate`` does.
+    """
+    await _apply_model_schema()
+
+    client = await surreal_orm.SurrealDBConnectionManager.get_client()
+    state = introspect_models([Guarded]).tables[TABLE]
+    response = await client.query(AlterTable.from_table_state(state).forwards())
+
+    assert [r.status.value for r in response.results] == ["OK"]
+
+    info = await client.query("INFO FOR DB;")
     assert "FOR select WHERE $auth.id = id" in info.first_result.result["tables"][TABLE]

--- a/tests/test_createtable_roundtrip_unit.py
+++ b/tests/test_createtable_roundtrip_unit.py
@@ -1,0 +1,135 @@
+"""
+Unit tests for the table-definition round trip.
+
+Reviewing what shipped in 0.33.1 turned up three defects that share one cause —
+a ``DEFINE TABLE`` does not survive the trip to the server and back:
+
+1. ``CreateTable.forwards()`` emitted the ``PERMISSIONS`` clause as a *second*
+   ``DEFINE TABLE``, which SurrealDB rejects for an existing table
+   (``The table 'x' already exists``). Declared table permissions therefore never
+   reached the database at all — verified against 3.2.4 and 2.6.5, both of which
+   stored ``PERMISSIONS NONE`` — and since the executor started surfacing
+   statement errors, the first migration of any model using ``permissions={...}``
+   aborts.
+2. The "table definition changed" diff branch reuses ``CreateTable``, whose
+   ``backwards()`` is ``REMOVE TABLE``. A migration that merely changed a
+   permission had a rollback that dropped the table and every row in it — and
+   reported ``reversible = True``.
+3. ``_parse_permissions`` could not read back what the server reports
+   (``FOR select WHERE $auth.id = id, FOR create, update, delete NONE``): the
+   condition kept its trailing comma and the ``NONE`` group was dropped, so the
+   diff never converged once permissions did reach the database.
+"""
+
+from src.surreal_orm.migrations.define_parser import parse_define_table
+from src.surreal_orm.migrations.operations import CreateTable
+from src.surreal_orm.migrations.state import SchemaState, TableState
+
+#: What SurrealDB reports for a table defined with one explicit rule.
+SERVER_REPORTED = (
+    "DEFINE TABLE s1 TYPE NORMAL SCHEMAFULL PERMISSIONS FOR select WHERE $auth.id = id, FOR create, update, delete NONE"
+)
+
+
+class TestPermissionsReachTheDatabase:
+    """The clause belongs to the DEFINE TABLE, not to a second statement."""
+
+    def test_permissions_are_a_clause_of_the_single_statement(self) -> None:
+        """A second ``DEFINE TABLE`` is rejected once the table exists."""
+        sql = CreateTable(name="users", permissions={"select": "$auth.id = id"}).forwards()
+
+        assert sql.count("DEFINE TABLE") == 1, sql
+        assert "PERMISSIONS FOR select WHERE $auth.id = id" in sql
+
+    def test_a_table_without_permissions_is_unchanged(self) -> None:
+        """No clause when nothing is configured."""
+        sql = CreateTable(name="users").forwards()
+
+        assert sql == "DEFINE TABLE users SCHEMAFULL;"
+
+    def test_permissions_come_after_the_schema_mode(self) -> None:
+        """Clause order the server accepts."""
+        sql = CreateTable(name="users", changefeed="7d", permissions={"select": "true"}).forwards()
+
+        assert sql.index("SCHEMAFULL") < sql.index("PERMISSIONS")
+        assert "CHANGEFEED 7d" in sql
+
+
+class TestModifyingATableIsNotDestructive:
+    """The modify path must not roll back into a DROP."""
+
+    def test_overwrite_redefines_rather_than_recreates(self) -> None:
+        """``DEFINE TABLE OVERWRITE`` updates an existing definition."""
+        sql = CreateTable(name="users", overwrite=True, permissions={"select": "true"}).forwards()
+
+        assert sql.startswith("DEFINE TABLE OVERWRITE users")
+
+    def test_rollback_restores_the_previous_definition(self) -> None:
+        """Not ``REMOVE TABLE`` — that dropped the table and all its rows."""
+        op = CreateTable(
+            name="users",
+            overwrite=True,
+            permissions={"select": "true"},
+            previous_schema_mode="SCHEMAFULL",
+            previous_permissions={"select": "$auth.id = id"},
+        )
+
+        rollback = op.backwards()
+
+        assert "REMOVE TABLE" not in rollback, rollback
+        assert rollback.startswith("DEFINE TABLE OVERWRITE users")
+        assert "PERMISSIONS FOR select WHERE $auth.id = id" in rollback
+
+    def test_creating_a_new_table_still_rolls_back_to_a_drop(self) -> None:
+        """A table this migration created should still be removed on rollback."""
+        assert CreateTable(name="users").backwards() == "REMOVE TABLE users;"
+
+    def test_the_diff_uses_the_non_destructive_form(self) -> None:
+        """A permissions-only change must not produce a destructive rollback."""
+        current = SchemaState()
+        current.tables["Article"] = TableState(name="Article", permissions={"select": "$auth.id = id"})
+        target = SchemaState()
+        target.tables["Article"] = TableState(name="Article", permissions={"select": "true"})
+
+        op = next(o for o in current.diff(target) if isinstance(o, CreateTable))
+
+        assert op.forwards().startswith("DEFINE TABLE OVERWRITE Article")
+        assert "REMOVE TABLE" not in op.backwards()
+        assert "PERMISSIONS FOR select WHERE $auth.id = id" in op.backwards()
+
+
+class TestPermissionsParseBackFromTheServer:
+    """``_parse_permissions`` must read the shape ``INFO FOR DB`` returns."""
+
+    def test_a_rule_keeps_no_trailing_comma(self) -> None:
+        """The comma separating the groups leaked into the condition."""
+        parsed = parse_define_table(SERVER_REPORTED)["permissions"]
+
+        assert parsed["select"] == "$auth.id = id"
+
+    def test_the_grouped_none_actions_are_parsed(self) -> None:
+        """``FOR create, update, delete NONE`` has no WHERE and was dropped."""
+        parsed = parse_define_table(SERVER_REPORTED)["permissions"]
+
+        assert parsed["create"] == "NONE"
+        assert parsed["update"] == "NONE"
+        assert parsed["delete"] == "NONE"
+
+    def test_a_grouped_full_is_parsed(self) -> None:
+        """``FULL`` is the other keyword form the server can report."""
+        parsed = parse_define_table("DEFINE TABLE t SCHEMAFULL PERMISSIONS FOR select, create FULL")["permissions"]
+
+        assert parsed == {"select": "FULL", "create": "FULL"}
+
+    def test_the_round_trip_converges(self) -> None:
+        """Emit, parse back, and the states must compare equal."""
+        model_permissions = {"select": "$auth.id = id"}
+        emitted = CreateTable(name="s1", permissions=model_permissions).forwards()
+        reparsed = parse_define_table(emitted.rstrip(";"))["permissions"]
+
+        current = SchemaState()
+        current.tables["s1"] = TableState(name="s1", permissions=reparsed)
+        target = SchemaState()
+        target.tables["s1"] = TableState(name="s1", permissions=model_permissions)
+
+        assert [o for o in current.diff(target) if isinstance(o, CreateTable)] == []

--- a/tests/test_createtable_roundtrip_unit.py
+++ b/tests/test_createtable_roundtrip_unit.py
@@ -1,28 +1,24 @@
 """
 Unit tests for the table-definition round trip.
 
-Reviewing what shipped in 0.33.1 turned up three defects that share one cause —
-a ``DEFINE TABLE`` does not survive the trip to the server and back:
+A ``DEFINE TABLE`` has to survive the trip to the server and back: what the ORM
+emits, what SurrealDB stores, what ``INFO FOR DB`` reports and what the parser
+reads must all agree, or the diff either never converges or converges on the
+wrong definition.
 
-1. ``CreateTable.forwards()`` emitted the ``PERMISSIONS`` clause as a *second*
-   ``DEFINE TABLE``, which SurrealDB rejects for an existing table
-   (``The table 'x' already exists``). Declared table permissions therefore never
-   reached the database at all — verified against 3.2.4 and 2.6.5, both of which
-   stored ``PERMISSIONS NONE`` — and since the executor started surfacing
-   statement errors, the first migration of any model using ``permissions={...}``
-   aborts.
-2. The "table definition changed" diff branch reuses ``CreateTable``, whose
-   ``backwards()`` is ``REMOVE TABLE``. A migration that merely changed a
-   permission had a rollback that dropped the table and every row in it — and
-   reported ``reversible = True``.
-3. ``_parse_permissions`` could not read back what the server reports
-   (``FOR select WHERE $auth.id = id, FOR create, update, delete NONE``): the
-   condition kept its trailing comma and the ``NONE`` group was dropped, so the
-   diff never converged once permissions did reach the database.
+Two families of defect are pinned here. The first is the clause reaching the
+database at all: ``PERMISSIONS`` used to be emitted as a *second*
+``DEFINE TABLE``, which the server rejects once the table exists. The second is
+subtler and worse — a clause that reaches the database meaning something other
+than what the model said. ``FOR select WHERE FULL`` is accepted, stored, and
+denies every read, because ``FULL`` in an expression is a field reference that
+evaluates to ``NONE``.
 """
 
+import pytest
+
 from src.surreal_orm.migrations.define_parser import parse_define_table
-from src.surreal_orm.migrations.operations import CreateTable
+from src.surreal_orm.migrations.operations import AlterTable, CreateTable
 from src.surreal_orm.migrations.state import SchemaState, TableState
 
 #: What SurrealDB reports for a table defined with one explicit rule.
@@ -55,20 +51,67 @@ class TestPermissionsReachTheDatabase:
         assert "CHANGEFEED 7d" in sql
 
 
+class TestKeywordPermissionsAreNotConditions:
+    """``FULL`` and ``NONE`` are keywords; rendering them as a WHERE inverts them."""
+
+    @pytest.mark.parametrize("keyword", ["FULL", "NONE"])
+    def test_a_keyword_rule_has_no_where(self, keyword: str) -> None:
+        """``FOR select WHERE FULL`` parses, stores, and then denies every read."""
+        sql = CreateTable(name="pw", permissions={"select": keyword}).forwards()
+
+        assert f"FOR select {keyword}" in sql
+        assert "WHERE" not in sql, sql
+
+    def test_a_condition_still_gets_its_where(self) -> None:
+        """Only the two keywords are special."""
+        sql = CreateTable(name="pw", permissions={"select": "$auth.id = id"}).forwards()
+
+        assert "FOR select WHERE $auth.id = id" in sql
+
+    def test_a_keyword_survives_the_round_trip(self) -> None:
+        """Emit, parse back, and the rule must still be the keyword."""
+        emitted = CreateTable(name="pw", permissions={"select": "FULL"}).forwards()
+
+        assert parse_define_table(emitted.rstrip(";"))["permissions"]["select"] == "FULL"
+
+
+class TestOrmOnlyTableTypesAreNotEmitted:
+    """USER, STREAM and HASH classify a model; SurrealDB does not know them."""
+
+    @pytest.mark.parametrize("table_type", ["user", "stream", "hash", "normal"])
+    def test_the_type_clause_is_dropped(self, table_type: str) -> None:
+        """``TYPE USER`` is a parse error, not a definition."""
+        assert "TYPE" not in CreateTable(name="acct", table_type=table_type).forwards()
+
+    @pytest.mark.parametrize("table_type", ["relation", "any"])
+    def test_a_real_surreal_type_is_kept(self, table_type: str) -> None:
+        assert f"TYPE {table_type.upper()}" in CreateTable(name="t", table_type=table_type).forwards()
+
+    def test_the_diff_does_not_forward_an_orm_type(self) -> None:
+        """Any change on a USER table was unmigratable."""
+        current = TableState(name="acct", schema_mode="SCHEMALESS", table_type="user")
+        target = TableState(name="acct", schema_mode="SCHEMAFULL", table_type="user")
+
+        sql = AlterTable.from_table_states(current, target).forwards()
+
+        assert "TYPE USER" not in sql
+        assert sql == "DEFINE TABLE OVERWRITE acct SCHEMAFULL;"
+
+
 class TestModifyingATableIsNotDestructive:
     """The modify path must not roll back into a DROP."""
 
     def test_overwrite_redefines_rather_than_recreates(self) -> None:
         """``DEFINE TABLE OVERWRITE`` updates an existing definition."""
-        sql = CreateTable(name="users", overwrite=True, permissions={"select": "true"}).forwards()
+        sql = AlterTable(name="users", schema_mode="SCHEMAFULL", permissions={"select": "true"}).forwards()
 
         assert sql.startswith("DEFINE TABLE OVERWRITE users")
 
     def test_rollback_restores_the_previous_definition(self) -> None:
         """Not ``REMOVE TABLE`` — that dropped the table and all its rows."""
-        op = CreateTable(
+        op = AlterTable(
             name="users",
-            overwrite=True,
+            schema_mode="SCHEMAFULL",
             permissions={"select": "true"},
             previous_schema_mode="SCHEMAFULL",
             previous_permissions={"select": "$auth.id = id"},
@@ -84,6 +127,14 @@ class TestModifyingATableIsNotDestructive:
         """A table this migration created should still be removed on rollback."""
         assert CreateTable(name="users").backwards() == "REMOVE TABLE users;"
 
+    def test_an_alter_without_a_previous_definition_is_irreversible(self) -> None:
+        """A bare ``DEFINE TABLE OVERWRITE t;`` resets the table, it does not restore it."""
+        op = AlterTable(name="c", permissions={"select": "FULL"})
+
+        assert op.reversible is False
+        with pytest.raises(ValueError, match="no previous definition"):
+            op.backwards()
+
     def test_the_diff_uses_the_non_destructive_form(self) -> None:
         """A permissions-only change must not produce a destructive rollback."""
         current = SchemaState()
@@ -91,11 +142,68 @@ class TestModifyingATableIsNotDestructive:
         target = SchemaState()
         target.tables["Article"] = TableState(name="Article", permissions={"select": "true"})
 
-        op = next(o for o in current.diff(target) if isinstance(o, CreateTable))
+        op = next(o for o in current.diff(target) if isinstance(o, AlterTable))
 
+        assert op.reversible is True
         assert op.forwards().startswith("DEFINE TABLE OVERWRITE Article")
         assert "REMOVE TABLE" not in op.backwards()
         assert "PERMISSIONS FOR select WHERE $auth.id = id" in op.backwards()
+
+    def test_a_redefinition_is_described_as_one(self) -> None:
+        """``makemigrations`` and the executor label the operation for the reader."""
+        current = TableState(name="Article", schema_mode="SCHEMALESS")
+        target = TableState(name="Article", schema_mode="SCHEMAFULL")
+
+        assert AlterTable.from_table_states(current, target).describe() == "Alter table Article"
+        assert CreateTable(name="Article").describe() == "Create table Article"
+
+
+class TestTheDefinitionTravelsWhole:
+    """Every clause must reach both directions of the operation."""
+
+    def test_a_view_is_not_flattened_into_a_plain_table(self) -> None:
+        """An overwrite with no AS clause turns the view into a normal table."""
+        current = TableState(name="v", schema_mode="SCHEMALESS", view_query="SELECT n FROM src")
+        target = TableState(name="v", schema_mode="SCHEMAFULL", view_query="SELECT n FROM src")
+
+        op = AlterTable.from_table_states(current, target)
+
+        assert "AS (SELECT n FROM src)" in op.forwards()
+        assert "AS (SELECT n FROM src)" in op.backwards()
+
+    def test_a_comment_survives_both_directions(self) -> None:
+        """COMMENT had no previous slot, so an overwrite dropped it either way."""
+        current = TableState(name="t", comment="before")
+        target = TableState(name="t", comment="after")
+
+        op = AlterTable.from_table_states(current, target)
+
+        assert "COMMENT 'after'" in op.forwards()
+        assert "COMMENT 'before'" in op.backwards()
+
+    def test_a_relation_list_is_pipe_separated(self) -> None:
+        """``relation_out=["a", "b"]`` is the documented config form."""
+        sql = CreateTable(
+            name="likes",
+            table_type="relation",
+            relation_in="person",
+            relation_out=["blog_post", "book"],
+        ).forwards()
+
+        assert "OUT blog_post | book" in sql
+
+    def test_the_previous_permissions_drop_the_server_defaults(self) -> None:
+        """The server reports three default NONE entries; they are not configuration."""
+        current = TableState(
+            name="t",
+            permissions={"select": "$auth.id = id", "create": "NONE", "update": "NONE", "delete": "NONE"},
+        )
+        target = TableState(name="t", permissions={"select": "true"})
+
+        rollback = AlterTable.from_table_states(current, target).backwards()
+
+        assert "FOR create NONE" not in rollback, rollback
+        assert "PERMISSIONS FOR select WHERE $auth.id = id" in rollback
 
 
 class TestPermissionsParseBackFromTheServer:
@@ -121,6 +229,22 @@ class TestPermissionsParseBackFromTheServer:
 
         assert parsed == {"select": "FULL", "create": "FULL"}
 
+    def test_a_quoted_for_does_not_start_a_group(self) -> None:
+        """Splitting on the bare token truncated the condition at the quote."""
+        parsed = parse_define_table(
+            "DEFINE TABLE t SCHEMAFULL PERMISSIONS FOR select WHERE label = 'FOR sale', FOR create NONE"
+        )["permissions"]
+
+        assert parsed["select"] == "label = 'FOR sale'"
+        assert parsed["create"] == "NONE"
+
+    def test_a_keyword_inside_a_condition_does_not_end_the_clause(self) -> None:
+        """``meta.type`` cut the clause, leaving ``meta.`` and a bogus table type."""
+        parsed = parse_define_table("DEFINE TABLE t SCHEMAFULL PERMISSIONS FOR select WHERE meta.type != NONE")
+
+        assert parsed["permissions"]["select"] == "meta.type != NONE"
+        assert parsed["table_type"] == "normal"
+
     def test_the_round_trip_converges(self) -> None:
         """Emit, parse back, and the states must compare equal."""
         model_permissions = {"select": "$auth.id = id"}
@@ -132,4 +256,4 @@ class TestPermissionsParseBackFromTheServer:
         target = SchemaState()
         target.tables["s1"] = TableState(name="s1", permissions=model_permissions)
 
-        assert [o for o in current.diff(target) if isinstance(o, CreateTable)] == []
+        assert [o for o in current.diff(target) if isinstance(o, AlterTable)] == []

--- a/tests/test_define_parser.py
+++ b/tests/test_define_parser.py
@@ -216,7 +216,14 @@ class TestParseDefineTable:
 
     def test_table_with_permissions_full(self) -> None:
         result = parse_define_table("DEFINE TABLE users SCHEMAFULL PERMISSIONS FULL")
-        assert result["permissions"] == {}
+        # Bare FULL expands like bare NONE does: both spell out all four
+        # actions, so the two forms are comparable in a diff.
+        assert result["permissions"] == {
+            "select": "FULL",
+            "create": "FULL",
+            "update": "FULL",
+            "delete": "FULL",
+        }
 
     def test_table_with_permissions_none(self) -> None:
         result = parse_define_table("DEFINE TABLE users SCHEMAFULL PERMISSIONS NONE")

--- a/tests/test_issue_185_v2_unit.py
+++ b/tests/test_issue_185_v2_unit.py
@@ -12,14 +12,14 @@ a state that compares unequal to a model configuring nothing::
 
     db.permissions    = {'select': 'NONE', 'create': 'NONE', 'update': 'NONE', 'delete': 'NONE'}
     model.permissions = {}
-    -> ['CreateTable']
+    -> ['AlterTable']
 
 This lands after the #179 backport on purpose: diffing against the database while
 the model side still lost optionality would have proposed a phantom ``AlterField``
 on every run.
 """
 
-from src.surreal_orm.migrations.operations import CreateTable
+from src.surreal_orm.migrations.operations import AlterTable
 from src.surreal_orm.migrations.state import SchemaState, TableState
 
 #: What SurrealDB 2.6.x reports for a table defined with no PERMISSIONS clause.
@@ -41,22 +41,22 @@ class TestDefaultPermissionsAreNotAChange:
         """The database's default block equals a model that configures nothing."""
         current, target = _states(SURREAL_DEFAULT_PERMISSIONS, {})
 
-        assert [op for op in current.diff(target) if isinstance(op, CreateTable)] == []
+        assert [op for op in current.diff(target) if isinstance(op, AlterTable)] == []
 
     def test_explicitly_setting_none_is_also_the_default(self) -> None:
         """Spelling out NONE is the same schema, so it is not a change either."""
         current, target = _states(SURREAL_DEFAULT_PERMISSIONS, {"select": "NONE"})
 
-        assert [op for op in current.diff(target) if isinstance(op, CreateTable)] == []
+        assert [op for op in current.diff(target) if isinstance(op, AlterTable)] == []
 
     def test_a_real_permission_still_diffs(self) -> None:
         """A configured rule must still be detected against the default block."""
         current, target = _states(SURREAL_DEFAULT_PERMISSIONS, {"select": "$auth.id = id"})
 
-        assert [op for op in current.diff(target) if isinstance(op, CreateTable)]
+        assert [op for op in current.diff(target) if isinstance(op, AlterTable)]
 
     def test_removing_a_permission_still_diffs(self) -> None:
         """Dropping a configured rule is a change in the other direction."""
         current, target = _states({"select": "$auth.id = id"}, {})
 
-        assert [op for op in current.diff(target) if isinstance(op, CreateTable)]
+        assert [op for op in current.diff(target) if isinstance(op, AlterTable)]

--- a/tests/test_materialized_views.py
+++ b/tests/test_materialized_views.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import pytest
 
 from surreal_orm.migrations.define_parser import parse_define_table
-from surreal_orm.migrations.operations import CreateTable
+from surreal_orm.migrations.operations import AlterTable, CreateTable
 from surreal_orm.migrations.state import SchemaState, TableState
 
 # ---------------------------------------------------------------------------
@@ -184,7 +184,7 @@ class TestViewStateDiff:
         )
         ops = current.diff(target)
 
-        create_ops = [op for op in ops if isinstance(op, CreateTable)]
+        create_ops = [op for op in ops if isinstance(op, AlterTable)]
         assert len(create_ops) == 1
         assert "WHERE status = 'paid'" in create_ops[0].view_query
 
@@ -195,7 +195,7 @@ class TestViewStateDiff:
         target = self._make_state({"stats": TableState(name="stats", view_query=vq)})
         ops = current.diff(target)
 
-        create_ops = [op for op in ops if isinstance(op, CreateTable)]
+        create_ops = [op for op in ops if isinstance(op, AlterTable)]
         assert len(create_ops) == 0
 
 

--- a/tests/test_relation_type.py
+++ b/tests/test_relation_type.py
@@ -5,7 +5,7 @@ Tests for TYPE RELATION — CreateTable relation support, parser, diff, enum.
 from __future__ import annotations
 
 from surreal_orm.migrations.define_parser import parse_define_table
-from surreal_orm.migrations.operations import CreateTable
+from surreal_orm.migrations.operations import AlterTable, CreateTable
 from surreal_orm.migrations.state import SchemaState, TableState
 from surreal_orm.types import TableType
 
@@ -90,10 +90,13 @@ class TestCreateTableRelation:
         sql = op.forwards()
         assert "TYPE" not in sql
 
-    def test_user_type_emitted(self) -> None:
+    def test_user_type_not_emitted(self) -> None:
+        # USER is an ORM classification, not a SurrealDB table type: the server
+        # answers `Parse error: Unexpected token \`USER\`, expected \`NORMAL\`,
+        # \`RELATION\`, or \`ANY\``, which made every USER table unmigratable.
         op = CreateTable(name="users", table_type="user", schema_mode="SCHEMAFULL")
         sql = op.forwards()
-        assert "TYPE USER" in sql
+        assert "TYPE" not in sql
 
     def test_any_type_emitted(self) -> None:
         op = CreateTable(name="data", table_type="any", schema_mode="SCHEMAFULL")
@@ -211,7 +214,7 @@ class TestRelationStateDiff:
         )
         ops = current.diff(target)
 
-        create_ops = [op for op in ops if isinstance(op, CreateTable)]
+        create_ops = [op for op in ops if isinstance(op, AlterTable)]
         assert len(create_ops) == 1
         assert "book" in create_ops[0].relation_out
 
@@ -237,7 +240,7 @@ class TestRelationStateDiff:
         )
         ops = current.diff(target)
 
-        create_ops = [op for op in ops if isinstance(op, CreateTable)]
+        create_ops = [op for op in ops if isinstance(op, AlterTable)]
         assert len(create_ops) == 1
         assert create_ops[0].enforced is True
 
@@ -267,7 +270,7 @@ class TestRelationStateDiff:
         )
         ops = current.diff(target)
 
-        create_ops = [op for op in ops if isinstance(op, CreateTable)]
+        create_ops = [op for op in ops if isinstance(op, AlterTable)]
         assert len(create_ops) == 0
 
 


### PR DESCRIPTION
Backport of **#194** onto the v2 LTS line, re-implemented against this branch. All three defects are present here verbatim, and each was reproduced on a live SurrealDB **2.6.5** before porting.

### 1. Declared table permissions never reached the database

```
DEFINE TABLE p SCHEMAFULL;                                 -> OK
DEFINE TABLE p PERMISSIONS FOR select WHERE $auth.id = id; -> ERR "The table 'p' already exists"
in the database: DEFINE TABLE p TYPE NORMAL SCHEMAFULL PERMISSIONS NONE
```

A model declaring `permissions={"select": "$auth.id = id"}` got a table with **no** rule. It fails closed (`PERMISSIONS NONE` denies record users), so this is broken access control rather than leaked data — but the rule the user asked for was never applied. And since #187 made the executor surface per-statement errors, the *first* migration of any such model now aborts.

`PERMISSIONS` is a clause of `DEFINE TABLE`; it is emitted as one.

### 2. Rolling back a table change dropped the table

The diff reuses `CreateTable` to redefine an existing table, and its `backwards()` was `REMOVE TABLE`. A permissions-only change rolled back by dropping the table and every row in it, while reporting `reversible = True`.

`CreateTable` gains an **overwrite mode** — `DEFINE TABLE OVERWRITE`, which the plain form's rejection made necessary anyway — and carries the previous definition so `backwards()` restores it. `_render()` is shared by both directions, so a rollback cannot drift from the definition it restores. A table the migration actually *created* still rolls back to `REMOVE TABLE`.

### 3. The permissions the server reports could not be parsed back

```
PERMISSIONS FOR select WHERE $auth.id = id, FOR create, update, delete NONE
```

The condition kept the comma separating the groups, and the keyword form has no `WHERE`, so those three actions were dropped entirely. **This one is load-bearing**: without it the first fix would only make the mismatch *visible* — permissions would finally land, and every `makemigrations` would then propose a redundant redefinition forever.

### Verification

| Command | Result |
| --- | --- |
| `ruff format --check` / `ruff check` | clean |
| `mypy src/` | clean, 64 files |
| unit suite | exit 0, 0 failures |
| integration vs **SurrealDB 2.6.5** | exit 0, 0 failures |

11 unit cases and 4 integration, including one that writes a row, applies the redefinition, rolls it back, and asserts the row is still there.

**One adaptation from the main version:** the integration tests build the DDL from `CreateTable` / `AddField` directly rather than through `define_table()`, which does not exist on this branch. That is what the migration executor does anyway, so it exercises the same path.

### Release notes required

- **Fixed** — table permissions declared in `model_config` never reached the database: the clause was emitted as a second `DEFINE TABLE`, which SurrealDB rejects for an existing table.
- **Fixed** — a migration that changed a table definition rolled back with `REMOVE TABLE`, dropping the table and all its rows while reporting itself reversible.
- **Fixed** — the `PERMISSIONS` shape `INFO FOR DB` reports could not be parsed back, so a permissioned table diffed as changed on every run.

### Programme

`v2` backports from the review: **A (this) → B → C**. #198 (the FK-coercion gaps) is independent and already open.