### PR TITLE
chore(release): bump version to 0.21.6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,103 @@ and adheres to [SemVer](https://semver.org/) versioning.
 
 ---
 
+## [0.21.6] - 2026-09-07
+
+**Bug-fix maintenance release (V2 LTS).** Three migration fixes ported from the
+3.x `main` line, plus the gaps left by 0.21.5's own ForeignKey backport. Every
+point was reproduced against a live SurrealDB 2.6.5 on this branch — none was
+carried over on the assumption that a fix which mattered on 3.x also matters
+here.
+
+### Fixed — Migrations
+
+- **Table permissions never reached the database (#199).** The `PERMISSIONS`
+  clause was emitted as a *second* `DEFINE TABLE`, which 2.6.x rejects once the
+  table exists (`The table 'x' already exists`). Since 0.21.5 started surfacing
+  statement errors, the first migration of any model declaring
+  `permissions={...}` aborted.
+
+- **`FULL` was written as a silent deny (#199).** Re-emitting a table defined
+  with `FOR select FULL` produced `FOR select WHERE FULL`. SurrealDB accepts
+  that, evaluates `FULL` as a field reference, gets `NONE`, and denies — a
+  world-readable table became unreadable with no error. `FULL` and `NONE` render
+  as keywords now.
+
+- **Redefining a table is `AlterTable`, not `CreateTable(overwrite=True)`
+  (#199).** The diff reused `CreateTable`, whose `backwards()` is
+  `REMOVE TABLE`: a migration that changed one permission had a rollback that
+  dropped the table and every row in it, and reported `reversible = True`. Built
+  without a previous definition an `AlterTable` is deliberately irreversible — a
+  bare `DEFINE TABLE OVERWRITE t;` resets the table to
+  `TYPE ANY SCHEMALESS PERMISSIONS NONE`.
+
+- **`TYPE USER` reached the DDL, and views were flattened (#199).** 2.6.5
+  answers ``Parse error: Unexpected token `USER` `` exactly as 3.2.4 does, so
+  any change to a USER table was unmigratable; and a materialized view diffed on
+  every run because `view_query` never reached the model state, with the
+  redefinition carrying no `AS` clause.
+
+- **A rollback rendered `DEFAULT` differently from the statement it reverses
+  (#200).** `AlterField.backwards()` single-quoted every string with no function
+  detection, no quote escaping and Python `str()` for booleans, so
+  `time::now()` came back as `'time::now()'`, `True` as `True`, and an
+  apostrophe as a parse error. The three renderers share one function now.
+
+- **`AlterField.backwards()` dropped the `VALUE` clause (#200).**
+  `DEFINE FIELD OVERWRITE` replaces the whole definition, so rolling back an
+  alter on an `Encrypted` column stopped it hashing and stored plaintext from
+  then on.
+
+- **The permissions parser mis-read what the server reports (#199).** A quoted
+  `FOR` inside a condition truncated at the quote, and a keyword inside an
+  expression ended the clause. Parsing an 80 KB clause went from 26 s to 0.02 s.
+
+### Fixed — ORM
+
+- **The gaps left by the #191 ForeignKey backport (#198).** The helpers were
+  carried over byte-identical but not what changed *around* them: the JSON
+  protocol raised on every foreign-key save, the related model instance was
+  rejected by the field validator, `merge()` assigned a `RecordId` onto a `str`
+  field *after* the write had committed, and `bulk_update()` bound its SET
+  values verbatim.
+
+- **The JSON protocol lost a record id's type (#198).** `str(RecordId)` renders
+  `t:123`, which the server reads as the *numeric* record, while CBOR wrote the
+  string one, `t:` + backtick + `123` + backtick. Two different rows, no error,
+  on the protocol the backport set out to repair. Escaping now happens in the
+  SDK, where the wire format needs it.
+
+- **`raw_query(inline_dicts=True)`** handles a record link, emitting it as an
+  unquoted thing reference rather than a JSON string, and no longer reads a
+  backslash in the inlined JSON as a regex group reference.
+
+### Changed — CLI
+
+- **`makemigrations` no longer writes irreversible removals by default
+  (#201).** A database object with no model is not necessarily obsolete: a
+  `RELATE` edge table, an analyzer, the migration history, or a module that
+  simply was not imported all look identical to a deleted model. Those
+  operations are reported and held back; `--drop-missing` opts in.
+
+  **This is a behaviour change**: since 0.21.5 removing a model produced a
+  `REMOVE TABLE`; it now needs the flag.
+
+- **`schemadiff` and `makemigrations` agree about the same database (#201).**
+
+### Known limitation
+
+Migration files generated before this release carry no `previous_value`, so
+rolling one of them back still emits an `OVERWRITE` with no `VALUE` clause and
+nothing warns. An `Encrypted` column rolled back through such a file stops
+hashing. Regenerate those migrations before relying on their rollback.
+
+### Not ported
+
+`REFERENCE` / `ON DELETE` remains absent: it is a SurrealDB 3.0 clause and
+`ReferencesField` does not exist on this branch.
+
+---
+
 ## [0.21.5] - 2026-09-05
 
 **Bug-fix maintenance release (V2 LTS).** Four correctness fixes backported from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # SurrealDB-ORM - Development Context
 
-> Context document for Claude AI - Last updated: September 2026 (0.21.5)
+> Context document for Claude AI - Last updated: September 2026 (0.21.6)
 
 <!-- -->
 
@@ -19,7 +19,31 @@
 
 ---
 
-## Current Version: 0.21.5 (Beta — V2 LTS, deprecated)
+## Current Version: 0.21.6 (Beta — V2 LTS, deprecated)
+
+### What's New in 0.21.6
+
+Three migration fixes ported from `main` (#199, #200, #201) plus the gaps left by
+0.21.5's own ForeignKey backport (#198). Every point was **reproduced against a
+live SurrealDB 2.6.5 on this branch** before porting — the divergence between the
+lines is large enough that "it mattered on main" is not evidence it matters here.
+
+- **Permissions never reached the database**, and **`FULL` was a silent deny** —
+  re-emitted as `FOR select WHERE FULL`, which 2.6.5 accepts and evaluates as a
+  field reference resolving to `NONE`. A world-readable table became unreadable.
+- **Redefinition is `AlterTable`, not a flag on `CreateTable`.** The old path
+  rolled back with `REMOVE TABLE`, so a permission change had a rollback that
+  destroyed every row while reporting `reversible = True`.
+- **One renderer per statement kind.** The three hand-written `DEFINE FIELD`
+  copies share `_render_define_field` now; `DEFAULT` was rendered three
+  different ways and `VALUE` was dropped on the rollback path.
+- **`makemigrations` holds back irreversible removals** unless `--drop-missing`
+  is passed; `split_destructive()` partitions on `Operation.reversible`.
+- **The JSON protocol lost a record id's type** — `str(RecordId)` gives `t:123`,
+  the numeric record, where CBOR wrote the string one. Escaping moved into the
+  SDK.
+- **Not ported:** `REFERENCE` / `ON DELETE` (a SurrealDB 3.0 clause;
+  `ReferencesField` does not exist here).
 
 ### What's New in 0.21.5
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,53 @@ Tested with SurrealDB: v2.6.5
 
 ---
 
+## What's New in 0.21.6
+
+**Bug-fix maintenance release (V2 LTS)** — three migration fixes ported from the 3.x `main` line,
+plus the gaps left by 0.21.5's own ForeignKey backport. Each was reproduced against a live
+SurrealDB 2.6.5 on this branch before being ported.
+
+- **Table permissions now reach the database.** The clause was emitted as a second `DEFINE TABLE`,
+  which 2.6.x rejects once the table exists.
+
+- **`FULL` is no longer written as a silent deny.** Re-emitting a table defined with
+  `FOR select FULL` produced `FOR select WHERE FULL`, which the server accepts and then evaluates
+  as a field reference — it resolves to `NONE`, and a world-readable table becomes unreadable with
+  no error anywhere.
+
+- **Rolling back a table change no longer drops the table.** The diff reused `CreateTable`, whose
+  rollback is `REMOVE TABLE`, so a migration that changed one permission had a rollback that
+  destroyed every row — and reported itself reversible.
+
+- **A rollback renders a field exactly as the statement it reverses does.** `backwards()` quoted
+  every `DEFAULT` and dropped the `VALUE` clause entirely, which stopped an `Encrypted` column
+  hashing and stored plaintext from then on.
+
+- **The JSON protocol no longer loses a record id's type.** `str(RecordId)` renders `t:123`, the
+  *numeric* record, while CBOR wrote the string one — two different rows, no error, on the very
+  protocol 0.21.5's ForeignKey backport set out to repair.
+
+### Behaviour change
+
+`makemigrations` no longer writes irreversible removals by default. A `RELATE` edge table, an
+analyzer, the migration history, or a module that simply was not imported all look identical to a
+deleted model, so those operations are reported and held back:
+
+```
+$ surreal-orm makemigrations
+Skipped 2 irreversible operation(s) with no model to justify them:
+  - Drop table has_player
+  - Remove analyzer english
+Pass --drop-missing to apply them (irreversible).
+```
+
+### Known limitation
+
+Migration files generated before this release carry no `previous_value`, so their rollback still
+drops the `VALUE` clause and nothing warns. Regenerate them before relying on it.
+
+---
+
 ## What's New in 0.21.5
 
 **Bug-fix maintenance release (V2 LTS).** Four correctness fixes backported from the 3.x

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surrealdb-orm"
-version = "0.21.5"
+version = "0.21.6"
 description = "SurrealDB ORM as 'DJango style' for Python with async support. Works with pydantic validation."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/surreal_orm/__init__.py
+++ b/src/surreal_orm/__init__.py
@@ -170,7 +170,7 @@ __all__ = [
     "retry_on_conflict",
 ]
 
-__version__ = "0.21.5"
+__version__ = "0.21.6"
 
 # ---------------------------------------------------------------------------
 # Deprecation notice (V2 LTS branch)

--- a/src/surreal_sdk/__init__.py
+++ b/src/surreal_sdk/__init__.py
@@ -74,7 +74,7 @@ from .types import (
     ResponseStatus,
 )
 
-__version__ = "0.21.5"
+__version__ = "0.21.6"
 __all__ = [
     # Connections
     "BaseSurrealConnection",

--- a/src/surreal_sdk/pyproject.toml
+++ b/src/surreal_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surreal-sdk"
-version = "0.21.5"
+version = "0.21.6"
 description = "Custom Python SDK for SurrealDB with HTTP and WebSocket support. No dependency on official surrealdb package."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1538,7 +1538,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb-orm"
-version = "0.21.5"
+version = "0.21.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release PR for **0.21.6**, the V2 LTS maintenance release covering #198, #199, #200 and #201.

## Contents

Version strings (4 declarations), `CHANGELOG` — note: no `.md` on this branch — the README "What's New" section, and `CLAUDE.md`.

**`SECURITY.md` is deliberately untouched.** This is a patch bump; the table tracks the `X.Y` line, and `0.21.x` / `0.33.x` are both still accurate.

## What ships

- Table permissions reach the database, and `FULL` is no longer written as `FOR select WHERE FULL` — which the server accepts and then evaluates as a field reference resolving to `NONE`, silently denying every read on a world-readable table.
- Redefinition is `AlterTable`: rolling back a permission change no longer drops the table and every row in it.
- One shared `DEFINE FIELD` renderer, so a rollback cannot render `DEFAULT` differently from the statement it reverses, nor drop the `VALUE` clause that keeps an `Encrypted` column hashing.
- The JSON protocol keeps a record id's type: `str(RecordId)` wrote `t:123`, the *numeric* record, where CBOR wrote the string one.
- `makemigrations` holds back irreversible removals unless `--drop-missing` is passed.

## Release mechanics

**Merge with squash, keeping the subject `chore(release): bump version to 0.21.6`.** That subject is what `tag-release.yml` gates on; it then creates `v0.21.6` with `PAT_TOKEN` and a GitHub Release. `publish.yml` verifies the tag is on `main` before touching PyPI, so **this release does not publish to PyPI** — correct for the LTS line.

Merged **before** the `main` 0.33.2 release, so `main` ends up as the newest GitHub Release.