### PR TITLE
chore(release): bump version to 0.33.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,122 @@ and adheres to [SemVer](https://semver.org/) versioning.
 
 ---
 
+## [0.33.2] - 2026-09-07
+
+**Bug fix release.** Three migration defects, all found reviewing what 0.33.1
+shipped. Two of them are the dangerous kind: they produce a *wrong answer*
+rather than an error.
+
+### Fixed — Migrations
+
+- **Table permissions never reached the database (#194).** The `PERMISSIONS`
+  clause was emitted as a *second* `DEFINE TABLE`, which SurrealDB rejects once
+  the table exists (`The table 'x' already exists`). Since 0.33.1 started
+  surfacing statement errors, the first migration of any model declaring
+  `permissions={...}` aborted; before that it failed silently and the server
+  stored `PERMISSIONS NONE`.
+
+- **`FULL` was written as a silent deny (#194).** Reading a table defined with
+  `FOR select FULL` back and re-emitting it produced
+  `FOR select WHERE FULL`. SurrealDB accepts that, evaluates `FULL` as a field
+  reference, gets `NONE`, and denies — a world-readable table became unreadable
+  with no error anywhere:
+
+  ```
+  DEFINE TABLE pw PERMISSIONS FOR select WHERE FULL;   -- status OK
+  RETURN !!FULL;                                       -- false
+  ```
+
+  `FULL` and `NONE` are rendered as keywords now.
+
+- **Redefining a table is `AlterTable`, not `CreateTable(overwrite=True)`.** The
+  diff reused `CreateTable`, whose `backwards()` is `REMOVE TABLE`: a migration
+  that changed one permission had a rollback that dropped the table and every
+  row in it, and reported `reversible = True`. An `AlterTable` carries the
+  definition it replaced and restores it; built without one it is *not*
+  reversible, because a bare `DEFINE TABLE OVERWRITE t;` resets the table to
+  `TYPE ANY SCHEMALESS PERMISSIONS NONE` rather than restoring anything.
+
+- **`TYPE USER` reached the DDL (#194).** `USER`, `STREAM` and `HASH` classify a
+  model; SurrealDB accepts only `NORMAL`, `RELATION` and `ANY`, and answered
+  ``Parse error: Unexpected token `USER` ``. Any change to a USER table was
+  unmigratable through `makemigrations`.
+
+- **A materialized view was flattened into a plain table (#194).**
+  `ModelIntrospector` never populated `view_query`, so a view model diffed on
+  every run and the redefinition it emitted carried no `AS` clause.
+
+- **A rollback rendered `DEFAULT` differently from the statement it reverses
+  (#196).** `AlterField.backwards()` single-quoted every string with no function
+  detection, no quote escaping and Python `str()` for booleans:
+
+  ```
+  DEFAULT 'time::now()'   the function became a string literal
+  DEFAULT True            not a SurrealDB boolean
+  DEFAULT 'it's'          a parse error — the rollback fails
+  ```
+
+  `AddField.forwards`, `AlterField.forwards` and `AlterField.backwards` now
+  render through one shared function, so a clause cannot be added to one
+  direction and forgotten in another.
+
+- **`AlterField.backwards()` dropped the `VALUE` clause (#195, #196).**
+  `DEFINE FIELD OVERWRITE` replaces the whole definition, so rolling back an
+  alter on an `Encrypted` column stopped it hashing and stored plaintext from
+  then on. Computed fields lost their expression the same way.
+
+- **The permissions parser mis-read what the server reports (#194).** A
+  condition containing a quoted `FOR` (`label = 'FOR sale'`) truncated at the
+  quote; a keyword inside an expression ended the clause, so
+  `FOR select WHERE meta.type != NONE` left the condition as `meta.` and the
+  table type as `!= none`. Parsing an 80 KB clause also took 26 s; it takes
+  0.02 s.
+
+- **`COMMENT` and relation lists (#194, #196).** A table or field comment was
+  dropped in both directions of an alter, and `relation_out=["a", "b"]` — the
+  documented config form — rendered as `OUT ['a', 'b']` instead of
+  `OUT a | b`.
+
+- **`define_table()` was never idempotent (#194).** A second call failed with
+  `already exists` and the error was swallowed, so a changed `PERMISSIONS`
+  clause never reached an existing table. It emits the `OVERWRITE` form and
+  checks per-statement status now.
+
+### Changed — CLI
+
+- **`makemigrations` no longer writes irreversible removals by default
+  (#197).** Diffing against the live database, which became the default in
+  0.33.1, made `diff()`'s removal branches reachable — and they fire for every
+  database object no model can declare: `RELATE` edge tables (`Relation` fields
+  are deliberately skipped by the introspector), the migration history,
+  analyzers and APIs the model introspector never produces, and the `in`/`out`
+  columns SurrealDB defines on a `TYPE RELATION` table. Those operations are
+  reported and held back; `--drop-missing` opts in.
+
+  **This is a behaviour change**: since 0.33.1 removing a model produced a
+  `REMOVE TABLE`; it now needs the flag.
+
+- **`schemadiff` and `makemigrations` agree about the same database.**
+  `schemadiff` reported `Drop table has_player` while `makemigrations` said
+  `No changes detected`, so a CI gate on `schemadiff` failed permanently on
+  every RELATE edge table.
+
+### Known limitation
+
+Migration files generated between 0.32.6 and 0.33.1 carry no `previous_value`,
+so rolling one of them back still emits an `OVERWRITE` with no `VALUE` clause
+and nothing warns. An `Encrypted` column rolled back through such a file stops
+hashing. Regenerate those migrations, or add the clause by hand, before relying
+on their rollback.
+
+### Internal
+
+- `click` is a development dependency, so the CLI tests stop skipping in CI.
+- `MIGRATIONS_TABLE` moved to `constants.py`; `state.py` is pure data and was
+  importing the executor, and through it the connection manager, for one string.
+
+---
+
 ## [0.33.1] - 2026-09-05
 
 **Bug fix release.** `makemigrations` regenerated the whole schema on every run,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # SurrealDB-ORM - Development Context
 
-> Context document for Claude AI - Last updated: September 2026 (0.33.1)
+> Context document for Claude AI - Last updated: September 2026 (0.33.2)
 
 ## Project Vision
 
@@ -10,7 +10,7 @@
 
 ---
 
-## Current Version: 0.33.1 (Beta) — SurrealDB 3.2+ required
+## Current Version: 0.33.2 (Beta) — SurrealDB 3.2+ required
 
 ### Branch Strategy
 
@@ -18,6 +18,37 @@
 | ------ | ---------- | ----------- | ------------------------------- |
 | `main` | **3.2.4**  | 0.33.x      | Active development              |
 | `v2`   | **2.6.5**  | 0.21.x      | LTS (security & bug fixes only) |
+
+### What's New in 0.33.2
+
+Three migration defects found reviewing 0.33.1 (#194, #196, #197). Two produce a
+*wrong answer* rather than an error, which is what makes them the dangerous kind.
+
+- **Permissions never reached the database** — the clause was a second
+  `DEFINE TABLE`, rejected once the table exists. **`FULL` was a silent deny**:
+  re-emitted as `FOR select WHERE FULL`, which the server accepts and evaluates
+  as a field reference resolving to `NONE`. A world-readable table became
+  unreadable. Both fixed; `FULL`/`NONE` render as keywords.
+- **Redefinition is `AlterTable`, not a flag on `CreateTable`.** The old path
+  rolled back with `REMOVE TABLE` — a permission change had a rollback that
+  destroyed every row, and reported `reversible = True`. An `AlterTable` built
+  without a previous definition is deliberately irreversible: a bare
+  `DEFINE TABLE OVERWRITE t;` resets the table to
+  `TYPE ANY SCHEMALESS PERMISSIONS NONE`.
+- **One renderer per statement kind.** `AddField.forwards`,
+  `AlterField.forwards` and `AlterField.backwards` were three hand-written
+  copies, and every clause added to one was eventually forgotten in another —
+  `REFERENCE` (#170), `VALUE` (#195) and `DEFAULT` (#196) are the same omission.
+  They share `_render_define_field` now, driven off `FIELD_DEFINITION_FIELDS`;
+  `CreateTable`/`AlterTable` likewise share `_render_define_table` off
+  `TABLE_DEFINITION_FIELDS`.
+- **`makemigrations` holds back irreversible removals** unless `--drop-missing`
+  is passed. `split_destructive()` partitions on `Operation.reversible` rather
+  than enumerating classes, so the next irreversible operation does not have to
+  be remembered there. `schemadiff` shares the partition — the two commands used
+  to disagree about the same database.
+- **Known limitation:** migrations generated between 0.32.6 and 0.33.1 carry no
+  `previous_value`, so their rollback still drops `VALUE`.
 
 ### What's New in 0.33.1
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,63 @@ Both branches receive automated daily security monitoring from `main` (GitHub Ac
 
 ---
 
+## What's New in 0.33.2
+
+**Bug fix release** — three migration defects found reviewing what 0.33.1 shipped. Two are the
+dangerous kind: they produce a *wrong answer* rather than an error.
+
+- **Table permissions now reach the database.** The `PERMISSIONS` clause was emitted as a second
+  `DEFINE TABLE`, which SurrealDB rejects once the table exists, so a model declaring
+  `permissions={...}` either failed loudly (0.33.1) or silently stored `PERMISSIONS NONE`.
+
+- **`FULL` is no longer written as a silent deny.** Re-emitting a table defined with
+  `FOR select FULL` produced `FOR select WHERE FULL`, which SurrealDB accepts and then evaluates as
+  a field reference — it resolves to `NONE`, and a world-readable table becomes unreadable with no
+  error anywhere:
+
+  ```
+  DEFINE TABLE pw PERMISSIONS FOR select WHERE FULL;   -- status OK
+  RETURN !!FULL;                                       -- false
+  ```
+
+- **Rolling back a table change no longer drops the table.** The diff reused `CreateTable`, whose
+  rollback is `REMOVE TABLE`, so a migration that changed one permission had a rollback that
+  destroyed every row — and reported itself reversible. Redefinition is now `AlterTable`, which
+  carries the definition it replaced and restores it.
+
+- **A rollback renders a field exactly as the statement it reverses does.** `backwards()` quoted
+  every `DEFAULT`, so `time::now()` came back as the string `'time::now()'`, `True` as `True`
+  rather than `true`, and an apostrophe produced a parse error. It also dropped the `VALUE` clause
+  entirely, which stopped an `Encrypted` column hashing and stored plaintext from then on.
+
+- **Materialized views, `TYPE USER` tables, `COMMENT`s and relation lists** survive a redefinition
+  instead of being flattened, rejected as a parse error, silently dropped, or rendered as
+  `OUT ['a', 'b']`.
+
+### Behaviour change
+
+`makemigrations` no longer writes irreversible removals by default. A database object with no model
+is not necessarily obsolete — a `RELATE` edge table, an analyzer, the migration history, or a module
+that simply was not imported all look identical to a deleted model. Those operations are now
+reported and held back:
+
+```
+$ surreal-orm makemigrations
+Skipped 2 irreversible operation(s) with no model to justify them:
+  - Drop table has_player
+  - Remove analyzer english
+Pass --drop-missing to apply them (irreversible).
+```
+
+Use `--drop-missing` to opt in.
+
+### Known limitation
+
+Migration files generated between 0.32.6 and 0.33.1 carry no `previous_value`, so their rollback
+still drops the `VALUE` clause and nothing warns. Regenerate them before relying on it.
+
+---
+
 ## What's New in 0.33.1
 
 **Bug fix release (#171).** `makemigrations` regenerated the whole schema on every run,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surrealdb-orm"
-version = "0.33.1"
+version = "0.33.2"
 description = "SurrealDB ORM as 'DJango style' for Python with async support. Works with pydantic validation."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/surreal_orm/__init__.py
+++ b/src/surreal_orm/__init__.py
@@ -193,4 +193,4 @@ __all__ = [
     "retry_on_conflict",
 ]
 
-__version__ = "0.33.1"
+__version__ = "0.33.2"

--- a/src/surreal_sdk/__init__.py
+++ b/src/surreal_sdk/__init__.py
@@ -75,7 +75,7 @@ from .types import (
     ResponseStatus,
 )
 
-__version__ = "0.33.1"
+__version__ = "0.33.2"
 __all__ = [
     # Connections
     "BaseSurrealConnection",

--- a/src/surreal_sdk/pyproject.toml
+++ b/src/surreal_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surreal-sdk"
-version = "0.33.1"
+version = "0.33.2"
 description = "Custom Python SDK for SurrealDB with HTTP and WebSocket support. No dependency on official surrealdb package."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1594,7 +1594,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb-orm"
-version = "0.33.1"
+version = "0.33.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release PR for **0.33.2**, covering #194, #196 and #197.

## Contents

Version strings (4 declarations), `CHANGELOG.md`, the README "What's New" section, and `CLAUDE.md`.

**`SECURITY.md` is deliberately untouched.** This is a patch bump; the table tracks the `X.Y` line, and `0.33.x` / `0.21.x` are both still accurate — the rule the release checklist added in #197 spells out.

## What ships

Three migration defects found reviewing 0.33.1. Two are the dangerous kind — they produce a *wrong answer* rather than an error:

- **Table permissions never reached the database**, and re-emitting a table defined with `FOR select FULL` produced `FOR select WHERE FULL`. SurrealDB accepts it, evaluates `FULL` as a field reference, gets `NONE`, and denies — a world-readable table becomes unreadable with no error anywhere.
- **Rolling back a table change dropped the table.** The diff reused `CreateTable`, whose rollback is `REMOVE TABLE`, so a migration that changed one permission destroyed every row while reporting itself reversible.
- **A rollback rendered a field differently from the statement it reverses**, quoting `DEFAULT time::now()` into a string literal and dropping the `VALUE` clause that keeps an `Encrypted` column hashing.
- Materialized views, `TYPE USER` tables, `COMMENT`s and relation lists survive a redefinition.

## Behaviour change

`makemigrations` no longer writes irreversible removals by default; `--drop-missing` opts in. Since 0.33.1 removing a model produced a `REMOVE TABLE`.

## Known limitation

Migration files generated between 0.32.6 and 0.33.1 carry no `previous_value`, so their rollback still drops `VALUE` and nothing warns. Both are documented in the changelog.

## Release mechanics

**Merge with squash, keeping the subject `chore(release): bump version to 0.33.2`.** `tag-release.yml` gates on that subject, creates `v0.33.2` with `PAT_TOKEN`, and the tag triggers `publish.yml` → PyPI + GitHub Release.

Merged **after** the v2 0.21.6 release, so this one ends up as the newest GitHub Release.