### PR TITLE
chore(release): bump version to 0.33.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,83 @@ and adheres to [SemVer](https://semver.org/) versioning.
 
 ---
 
+## [0.33.3] - 2026-09-08
+
+**Bug fix release.** One defect, at the boundary where a value is written into a
+query string instead of bound — and it had two call sites, one of which crashed
+on any accented text.
+
+### Fixed — Query-string substitution
+
+- **Inlined JSON was parsed as a regex replacement pattern (#193).**
+  `inline_dict_variables()` handed the serialised JSON to `re.sub` as a
+  replacement *string*, which `re.sub` reads as a mini-pattern: `\1` is a
+  backreference, `\g<0>` a group reference, and an unknown escape an error.
+  `json.dumps` emits `\uXXXX` for every non-ASCII character, so
+  `raw_query(inline_dicts=True)` raised on any accented value:
+
+  ```python
+  inline_dict_variables("UPDATE t SET a = $v;", {"v": {"meta": {"k": 1}, "p": "café"}})
+  # re.error: bad escape \u at position 28
+  ```
+
+  The backslash half failed silently instead, which is worse: every literal
+  backslash was doubled by `json.dumps` and then collapsed back by the
+  replacement parsing, so a Windows path reached the database altered. Values
+  are now inserted verbatim through a callable replacement.
+
+- **Live-query filters went through the same defective path (#193).**
+  `LiveSelectStream._inline_params_static` also passed a rendered value to
+  `re.sub` as a replacement. `_format_value` doubles backslashes on purpose and
+  the parsing undid it, so SurrealQL read `\t` as a tab and a
+  `QuerySet.live()` filter containing a backslash silently matched nothing.
+
+- **A later variable could rewrite text inside an earlier one (#193).**
+  Substituting key by key re-scanned the JSON just inserted, so a `$b` occurring
+  inside a *string value* of `$a` was replaced too — and which one won depended
+  on dict insertion order. Substitution is a single pass over the original query
+  now.
+
+- **Astral characters were rejected by the server (#193).** `json.dumps` defaults
+  to `ensure_ascii=True`, emitting a UTF-16 surrogate pair, which SurrealDB 3.x
+  refuses at parse time (`String contains invalid escape sequence`). BMP text
+  such as `café` did decode, so this was narrower than the crash above but
+  invisible to a `json.loads` round-trip assertion — surrogate pairs are valid
+  JSON. `ensure_ascii=False` sends the character raw.
+
+- **An unreferenced complex variable was silently dropped (#193).** A value whose
+  `$name` never appeared in the query was serialised, matched nothing, and then
+  vanished from both the query and the returned bindings. It stays a binding now,
+  and is not serialised at all. This also covers a key that is not an ASCII
+  identifier, such as `$my-var`.
+
+- **A lone surrogate raised the wrong error (#193).** `ensure_ascii=False` lets
+  it past `json.dumps`, after which it surfaced as a `UnicodeEncodeError` from
+  inside the CBOR encoder rather than the `ValueError` the function documents.
+
+### Performance
+
+- **Datetime markers expand in one pass (#193).** Each `d"..."` literal was a
+  full `str.replace` over the entire JSON payload. 5,000 datetimes in an 0.8 MB
+  payload took 2.80 s; the same work now takes 0.023 s.
+
+### Added — SDK
+
+- **`surreal_sdk.substitute_params()`** and **`surreal_sdk.find_param_references()`**
+  — the shared primitive both call sites use. It lives in the SDK because the
+  dependency only runs one way: `surreal_orm` imports from `surreal_sdk`, never
+  the reverse.
+
+### Known follow-ups
+
+- **#204** — `HTTPTransaction.commit()` namespaces parameters with a boundary-less
+  `str.replace`, so `$auth.id` becomes `$tx_0_auth.id` and the `WHERE` compares
+  against `NONE`. Affects every `save(tx=)` / `merge(tx=)` over HTTP.
+- **#205** — on `main`, `LIVE SELECT` binds its parameters correctly on 3.2.4, so
+  the inline renderers are a 2.x workaround the branch no longer needs.
+
+---
+
 ## [0.33.2] - 2026-09-07
 
 **Bug fix release.** Three migration defects, all found reviewing what 0.33.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # SurrealDB-ORM - Development Context
 
-> Context document for Claude AI - Last updated: September 2026 (0.33.2)
+> Context document for Claude AI - Last updated: September 2026 (0.33.3)
 
 ## Project Vision
 
@@ -10,7 +10,7 @@
 
 ---
 
-## Current Version: 0.33.2 (Beta) — SurrealDB 3.2+ required
+## Current Version: 0.33.3 (Beta) — SurrealDB 3.2+ required
 
 ### Branch Strategy
 
@@ -18,6 +18,60 @@
 | ------ | ---------- | ----------- | ------------------------------- |
 | `main` | **3.2.4**  | 0.33.x      | Active development              |
 | `v2`   | **2.6.5**  | 0.21.x      | LTS (security & bug fixes only) |
+
+### What's New in 0.33.3
+
+One defect (#193), at the boundary where a value is *written into* a query string
+instead of bound — and it had two call sites.
+
+- **`re.sub` parsed the inlined JSON as a replacement pattern.** A replacement
+  *string* is a mini-pattern: `\1` is a backreference, `\g<0>` a group
+  reference, an unknown escape an error. `json.dumps` emits `\uXXXX` for every
+  non-ASCII character, so `raw_query(inline_dicts=True)` **raised on any accented
+  value** — for most real data that is "always", not "an edge case". The
+  backslash half was the dangerous one: `json.dumps` doubles every literal
+  backslash and the parsing collapsed it back, so a Windows path reached the
+  database altered, with no error. A *callable* replacement is exempt from that
+  parsing.
+- **The same line was live in the SDK.** `LiveSelectStream._inline_params_static`
+  fed `_format_value` output — which doubles backslashes on purpose — through the
+  same `re.sub`, so a `QuerySet.live()` filter containing a backslash silently
+  matched nothing. Both sites share **`surreal_sdk.utils.substitute_params()`**;
+  it lives in the SDK because the dependency only runs one way.
+- **One pass, not one per key.** Substituting key by key re-scanned the text just
+  inserted, so a `$b` inside a *string value* of `$a` was rewritten and the winner
+  depended on dict order. The single pass also removed the `B023` / "cannot infer
+  type of lambda" workarounds the per-key shape had needed.
+- **`ensure_ascii=False`.** The default emits astral characters as UTF-16
+  surrogate pairs, which SurrealDB 3.x rejects at parse time. **A `json.loads`
+  round-trip cannot see this** — surrogate pairs are valid JSON — so the test
+  asserts on the emitted text. BMP text like `café` did decode, which is why the
+  first diagnosis ("any non-ASCII") was too broad.
+- **An unreferenced complex variable was serialized, matched nothing, and then
+  dropped from the bindings** — silently. `find_param_references()` collects the
+  names the query uses first, so it stays a binding and is never serialized. The
+  reference pattern is `re.ASCII`, matching SurrealDB's identifier lexer: `$my-var`
+  is `$my` followed by `-var` to the server, and is now left alone rather than
+  dangling.
+- **A lone surrogate** passed `json.dumps` under `ensure_ascii=False` and failed
+  later as `UnicodeEncodeError` inside the CBOR encoder; encoding inside the same
+  `try` restores the documented `ValueError`.
+- **The datetime-marker loop was quadratic** — one full `str.replace` over the
+  payload per `d"..."` literal. Same callable-regex technique, applied once:
+  5,000 datetimes in an 0.8 MB payload, 2.80 s → 0.023 s.
+- **Two follow-ups filed, deliberately out of scope.** **#204** —
+  `HTTPTransaction.commit()` namespaces parameters with a boundary-less
+  `str.replace`, so a bound key that *prefixes* `auth`/`session`/`this`/`before`/
+  `after`/`value`/`input` renames the built-in: `$auth.id` → `$tx_0_auth.id`,
+  unbound, and the `WHERE` compares against `NONE`. That is every `save(tx=)` /
+  `merge(tx=)` over HTTP, and `substitute_params` is a drop-in fix. **#205** —
+  measured on both servers, 3.2.4 evaluates bound parameters in a `LIVE SELECT`
+  WHERE and 2.6.5 does not, so on `main` the inline renderers are a 2.x workaround
+  the branch no longer needs (and they render a dict filter value as a Python
+  repr, which never fires).
+- **Not backported yet** — the `v2` line already carries the
+  `inline_dict_variables` half via #198; the `live_select` site and the
+  single-pass/`find_param_references` work are still open there.
 
 ### What's New in 0.33.2
 

--- a/README.md
+++ b/README.md
@@ -30,12 +30,63 @@
 
 | Branch | SurrealDB  | ORM Version | Status                          |
 | ------ | ---------- | ----------- | ------------------------------- |
-| `main` | **3.2.4**  | 0.32.x      | Active development              |
+| `main` | **3.2.4**  | 0.33.x      | Active development              |
 | `v2`   | **2.6.5**  | 0.21.x      | LTS (security & bug fixes only) |
 
 Both branches receive automated daily security monitoring from `main` (GitHub Actions only runs cron workflows from the default branch).
 
 ---
+
+## What's New in 0.33.3
+
+**Bug fix release** — one defect at the boundary where a value is written into a query
+string instead of being bound, with two call sites (#193).
+
+- **Inlined JSON was parsed as a regex replacement pattern.** `inline_dict_variables()`
+  handed the serialised JSON to `re.sub` as a replacement *string*, which `re.sub` reads as
+  a mini-pattern: `\1` is a backreference, `\g<0>` a group reference, an unknown escape an
+  error. `json.dumps` emits `\uXXXX` for every non-ASCII character, so
+  `raw_query(inline_dicts=True)` raised on **any accented value** — for most real data,
+  "always", not "in an edge case":
+
+  ```python
+  inline_dict_variables("UPDATE t SET a = $v;", {"v": {"meta": {"k": 1}, "p": "café"}})
+  # re.error: bad escape \u at position 28
+  ```
+
+  The backslash half failed *silently*, which is the worse one: `json.dumps` doubles every
+  literal backslash and the replacement parsing collapsed it back, so a Windows path reached
+  the database altered. Values are inserted verbatim now, through a callable replacement.
+
+- **Live-query filters shared the defect.** `LiveSelectStream._inline_params_static` passed a
+  rendered value to `re.sub` the same way. `_format_value` doubles backslashes on purpose and
+  the parsing undid it, so SurrealQL read `\t` as a tab and a `QuerySet.live()` filter
+  containing a backslash silently matched nothing.
+
+- **A later variable could rewrite text inside an earlier one.** Substituting key by key
+  re-scanned the JSON just inserted, so a `$b` inside a *string value* of `$a` was replaced
+  too, with the winner depending on dict insertion order. One pass over the original query now.
+
+- **Astral characters were rejected by the server.** The `ensure_ascii=True` default emits a
+  UTF-16 surrogate pair, which SurrealDB 3.x refuses at parse time. Invisible to a
+  `json.loads` round-trip assertion — surrogate pairs are valid JSON — so the test asserts on
+  the emitted text. `ensure_ascii=False` sends the character raw.
+
+- **An unreferenced complex variable was silently dropped**, and a lone surrogate raised a
+  `UnicodeEncodeError` from inside the CBOR encoder instead of the documented `ValueError`.
+  Both fixed.
+
+- **Datetime markers expand in one pass** — 5,000 datetimes in an 0.8 MB payload went from
+  2.80 s to 0.023 s.
+
+- **New public SDK API** — `substitute_params()` and `find_param_references()`, the shared
+  primitive both call sites use. It lives in `surreal_sdk` because the dependency only runs
+  one way.
+
+- **Known follow-ups** — #204 (`HTTPTransaction.commit()` renames `$auth` and every other
+  built-in whose name a bound key prefixes, on every `save(tx=)` over HTTP) and #205 (on
+  `main`, `LIVE SELECT` binds parameters correctly on 3.2.4, so the inline renderers are a
+  2.x workaround the branch no longer needs).
 
 ## What's New in 0.33.2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surrealdb-orm"
-version = "0.33.2"
+version = "0.33.3"
 description = "SurrealDB ORM as 'DJango style' for Python with async support. Works with pydantic validation."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/surreal_orm/__init__.py
+++ b/src/surreal_orm/__init__.py
@@ -193,4 +193,4 @@ __all__ = [
     "retry_on_conflict",
 ]
 
-__version__ = "0.33.2"
+__version__ = "0.33.3"

--- a/src/surreal_sdk/__init__.py
+++ b/src/surreal_sdk/__init__.py
@@ -76,7 +76,7 @@ from .types import (
 )
 from .utils import find_param_references, substitute_params
 
-__version__ = "0.33.2"
+__version__ = "0.33.3"
 __all__ = [
     # Connections
     "BaseSurrealConnection",

--- a/src/surreal_sdk/pyproject.toml
+++ b/src/surreal_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surreal-sdk"
-version = "0.33.2"
+version = "0.33.3"
 description = "Custom Python SDK for SurrealDB with HTTP and WebSocket support. No dependency on official surrealdb package."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1594,7 +1594,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb-orm"
-version = "0.33.2"
+version = "0.33.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release PR for **0.33.3**. Carries only version strings and documentation — the code shipped in #193, which merged as `fb6b904`.

## What is in this release

One defect, at the boundary where a value is *written into* a query string instead of bound, with two call sites.

`inline_dict_variables()` passed the serialised JSON to `re.sub` as a replacement **string**, which `re.sub` reads as a mini-pattern. Since `json.dumps` emits `\uXXXX` for every non-ASCII character, `raw_query(inline_dicts=True)` raised on any accented value; the backslash half failed silently instead, altering data on its way to the database. `LiveSelectStream._inline_params_static` had the same line. Both go through the new `surreal_sdk.substitute_params()`, which inserts verbatim and in a single pass.

Also fixed in the same function: astral characters rejected by SurrealDB 3.x (`ensure_ascii=False`), an unreferenced complex variable silently dropped from the bindings, a lone surrogate raising `UnicodeEncodeError` instead of the documented `ValueError`, and a quadratic datetime-marker loop (2.80 s → 0.023 s on 5,000 datetimes).

## Files updated

| File | Change |
| --- | --- |
| `pyproject.toml`, `src/surreal_sdk/pyproject.toml` | `version = "0.33.3"` |
| `src/surreal_orm/__init__.py`, `src/surreal_sdk/__init__.py` | `__version__` |
| `uv.lock` | the local package version |
| `CHANGELOG.md` | new `[0.33.3]` entry |
| `README.md` | "What's New in 0.33.3" — and the branch table, which still said `main` was on `0.32.x` |
| `CLAUDE.md` | header date/version, `## Current Version`, new "What's New" section |

`SECURITY.md` is deliberately **unchanged**: this is a Z bump, so the supported line stays `0.33.x` and the SurrealDB floor stays `>= 3.2`. Both rows are still accurate.

## Verification

| Gate | Result |
| --- | --- |
| `ruff format --check src/ tests/` | 161 files already formatted |
| `ruff check src/ tests/` | All checks passed |
| `mypy src/` (via `uv sync --group lint --exact`) | no issues, 68 source files |
| unit suite | **2128 passed**, 469 deselected |
| integration vs SurrealDB **3.2.4** | **467 passed**, 1 skipped, 1 xfailed (upstream #147) |

## Known follow-ups, filed while reviewing #193

- **#204** — `HTTPTransaction.commit()` namespaces parameters with a boundary-less `str.replace`, so a bound key that prefixes `auth`/`session`/`this`/`before`/`after`/`value`/`input` renames the built-in (`$auth.id` → `$tx_0_auth.id`, unbound). Affects every `save(tx=)` / `merge(tx=)` over HTTP. `substitute_params` is a drop-in fix.
- **#205** — on `main`, 3.2.4 evaluates bound parameters in a `LIVE SELECT` WHERE (2.6.5 does not), so the inline renderers are a 2.x workaround this branch no longer needs.

## v2

The `v2` line already carries the `inline_dict_variables` half via #198. The `live_select` site is **still defective there**, and it matters more on `v2` than on `main`: 2.6.5 cannot bind live-query parameters, so the renderer is load-bearing rather than a workaround. Not opened — say the word.